### PR TITLE
Cluster: Adds cluster member state API endpoint

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -397,6 +397,7 @@ type InstanceServer interface {
 	RenameClusterMember(name string, member api.ClusterMemberPost) (err error)
 	CreateClusterMember(member api.ClusterMembersPost) (op Operation, err error)
 	UpdateClusterCertificate(certs api.ClusterCertificatePut, ETag string) (err error)
+	GetClusterMemberState(name string) (*api.ClusterMemberState, string, error)
 	UpdateClusterMemberState(name string, state api.ClusterMemberStatePost) (op Operation, err error)
 	GetClusterGroups() ([]api.ClusterGroup, error)
 	GetClusterGroupNames() ([]string, error)

--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -174,6 +174,23 @@ func (r *ProtocolLXD) UpdateClusterCertificate(certs api.ClusterCertificatePut, 
 	return nil
 }
 
+// GetClusterMemberState gets state information about a cluster member.
+func (r *ProtocolLXD) GetClusterMemberState(name string) (*api.ClusterMemberState, string, error) {
+	err := r.CheckExtension("cluster_member_state")
+	if err != nil {
+		return nil, "", err
+	}
+
+	state := api.ClusterMemberState{}
+	u := api.NewURL().Path("cluster", "members", name, "state")
+	etag, err := r.queryStruct("GET", u.String(), nil, "", &state)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &state, etag, err
+}
+
 // UpdateClusterMemberState evacuates or restores a cluster member.
 func (r *ProtocolLXD) UpdateClusterMemberState(name string, state api.ClusterMemberStatePost) (Operation, error) {
 	if !r.HasExtension("clustering_evacuation") {

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2133,3 +2133,7 @@ but new projects will need to specify this explicitly.
 ## `instance_nic_txqueuelength`
 
 Adds a `txqueuelen` key to control the `txqueuelen` parameter of the NIC device.
+
+## `cluster_member_state`
+
+Adds `GET /1.0/cluster/members/<member>/state` API endpoint and associated `ClusterMemberState` API response type.

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -458,6 +458,18 @@ definitions:
                 x-go-name: Roles
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
+    ClusterMemberState:
+        properties:
+            storage_pools:
+                additionalProperties:
+                    $ref: '#/definitions/StoragePoolState'
+                type: object
+                x-go-name: StoragePools
+            sysinfo:
+                $ref: '#/definitions/ClusterMemberSysInfo'
+        title: ClusterMemberState represents the state of a cluster member.
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
     ClusterMemberStatePost:
         properties:
             action:
@@ -471,6 +483,49 @@ definitions:
                 type: string
                 x-go-name: Mode
         title: ClusterMemberStatePost represents the fields required to evacuate a cluster member.
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
+    ClusterMemberSysInfo:
+        properties:
+            buffered_ram:
+                format: uint64
+                type: integer
+                x-go-name: BufferRAM
+            free_ram:
+                format: uint64
+                type: integer
+                x-go-name: FreeRAM
+            free_swap:
+                format: uint64
+                type: integer
+                x-go-name: FreeSwap
+            load_averages:
+                items:
+                    format: double
+                    type: number
+                type: array
+                x-go-name: LoadAverages
+            processes:
+                format: uint16
+                type: integer
+                x-go-name: Processes
+            shared_ram:
+                format: uint64
+                type: integer
+                x-go-name: SharedRAM
+            total_ram:
+                format: uint64
+                type: integer
+                x-go-name: TotalRAM
+            total_swap:
+                format: uint64
+                type: integer
+                x-go-name: TotalSwap
+            uptime:
+                format: int64
+                type: integer
+                x-go-name: Uptime
+        title: ClusterMemberSysInfo represents the sysinfo of a cluster member.
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
     ClusterMembersPost:
@@ -5501,6 +5556,15 @@ definitions:
         title: StoragePoolPut represents the modifiable fields of a LXD storage pool.
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
+    StoragePoolState:
+        properties:
+            inodes:
+                $ref: '#/definitions/ResourcesStoragePoolInodes'
+            space:
+                $ref: '#/definitions/ResourcesStoragePoolSpace'
+        title: StoragePoolState represents the state of a storage pool.
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
     StoragePoolVolumeBackup:
         description: StoragePoolVolumeBackup represents a LXD volume backup
         properties:
@@ -6973,6 +7037,39 @@ paths:
             tags:
                 - cluster
     /1.0/cluster/members/{name}/state:
+        get:
+            description: Gets state of a specific cluster member.
+            operationId: cluster_member_state_get
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: Cluster member state
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                $ref: '#/definitions/ClusterMemberState'
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get state of the cluster member
+            tags:
+                - cluster
         post:
             consumes:
                 - application/json

--- a/lxd/cluster/member_state.go
+++ b/lxd/cluster/member_state.go
@@ -1,0 +1,103 @@
+package cluster
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
+	storagePools "github.com/lxc/lxd/lxd/storage"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
+)
+
+// getLoadAvgs returns the host's load averages from /proc/loadavg.
+func getLoadAvgs() ([]float64, error) {
+	loadAvgs := make([]float64, 3)
+
+	loadAvgsBuf, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		return nil, err
+	}
+
+	loadAvgFields := strings.Fields(string(loadAvgsBuf))
+
+	loadAvgs[0], err = strconv.ParseFloat(loadAvgFields[0], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	loadAvgs[1], err = strconv.ParseFloat(loadAvgFields[1], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	loadAvgs[2], err = strconv.ParseFloat(loadAvgFields[2], 64)
+	if err != nil {
+		return nil, err
+	}
+
+	return loadAvgs, nil
+}
+
+// MemberState retrieves state information about the cluster member.
+func MemberState(ctx context.Context, s *state.State, memberName string) (*api.ClusterMemberState, error) {
+	var err error
+	var memberState api.ClusterMemberState
+
+	// Get system info.
+	info := unix.Sysinfo_t{}
+	err = unix.Sysinfo(&info)
+	if err != nil {
+		logger.Warn("Failed getting sysinfo", logger.Ctx{"err": err})
+
+		return nil, err
+	}
+
+	// Account for different representations of Sysinfo_t on different architectures.
+	memberState.SysInfo.Uptime = int64(info.Uptime)
+	memberState.SysInfo.TotalRAM = uint64(info.Bufferram)
+	memberState.SysInfo.SharedRAM = uint64(info.Sharedram)
+	memberState.SysInfo.BufferRAM = uint64(info.Bufferram)
+	memberState.SysInfo.FreeRAM = uint64(info.Freeram)
+	memberState.SysInfo.TotalSwap = uint64(info.Totalswap)
+	memberState.SysInfo.FreeSwap = uint64(info.Freeswap)
+
+	memberState.SysInfo.Processes = info.Procs
+	memberState.SysInfo.LoadAverages, err = getLoadAvgs()
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting load averages: %w", err)
+	}
+
+	// Get storage pool states.
+	stateCreated := db.StoragePoolCreated
+	pools, poolMembers, err := s.DB.Cluster.GetStoragePools(ctx, &stateCreated)
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading storage pools: %w", err)
+	}
+
+	memberState.StoragePools = make(map[string]api.StoragePoolState, len(pools))
+
+	for poolID := range pools {
+		pool, err := storagePools.LoadByRecord(s, poolID, pools[poolID], poolMembers[poolID])
+		if err != nil {
+			return nil, fmt.Errorf("Failed loading storage pool %q: %w", pools[poolID].Name, err)
+		}
+
+		res, err := pool.GetResources()
+		if err != nil {
+			return nil, fmt.Errorf("Failed getting storage pool resources %q: %w", pools[poolID].Name, err)
+		}
+
+		memberState.StoragePools[pools[poolID].Name] = api.StoragePoolState{
+			ResourcesStoragePool: *res,
+		}
+	}
+
+	return &memberState, nil
+}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -881,7 +881,7 @@ func (d *Daemon) init() error {
 	}
 
 	for _, extension := range lxcExtensions {
-		d.os.LXCFeatures[extension] = liblxc.HasApiExtension(extension)
+		d.os.LXCFeatures[extension] = liblxc.HasAPIExtension(extension)
 	}
 
 	// Look for kernel features

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -1214,7 +1214,7 @@ SELECT DISTINCT nodes.address FROM nodes WHERE nodes.address NOT IN (
 	return c.getNodesByImageFingerprint(q, fingerprint, nil)
 }
 
-func (c *Cluster) getNodesByImageFingerprint(stmt, fingerprint string, autoUpdate *bool) ([]string, error) {
+func (c *Cluster) getNodesByImageFingerprint(stmt string, fingerprint string, autoUpdate *bool) ([]string, error) {
 	var addresses []string // Addresses of online nodes with the image
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
 		offlineThreshold, err := tx.GetNodeOfflineThreshold(ctx)

--- a/lxd/db/instances.go
+++ b/lxd/db/instances.go
@@ -149,12 +149,7 @@ SELECT nodes.id, nodes.address
 // string, to distinguish it from remote nodes.
 //
 // Instances whose node is down are added to the special address "0.0.0.0".
-func (c *ClusterTx) GetProjectAndInstanceNamesByNodeAddress(ctx context.Context, projects []string, instType instancetype.Type) (map[string][][2]string, error) {
-	offlineThreshold, err := c.GetNodeOfflineThreshold(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func (c *ClusterTx) GetProjectAndInstanceNamesByNodeAddress(ctx context.Context, offlineThreshold time.Duration, projects []string, instType instancetype.Type) (map[string][][2]string, error) {
 	args := make([]any, 0, 2) // Expect up to 2 filters.
 	var filters strings.Builder
 

--- a/lxd/db/instances_test.go
+++ b/lxd/db/instances_test.go
@@ -424,7 +424,7 @@ func TestGetInstanceNamesByNodeAddress(t *testing.T) {
 	addContainer(t, tx, nodeID2, "c4")
 
 	instType := instancetype.Container
-	result, err := tx.GetProjectAndInstanceNamesByNodeAddress(context.Background(), []string{"default"}, instType)
+	result, err := tx.GetProjectAndInstanceNamesByNodeAddress(context.Background(), time.Duration(db.DefaultOfflineThreshold)*time.Second, []string{"default"}, instType)
 	require.NoError(t, err)
 	assert.Equal(
 		t,

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -224,7 +224,7 @@ func importPreClusteringData(tx *sql.Tx, dump *Dump) error {
 				fallthrough
 			case "storage_pools":
 				columns = append(columns, "state")
-				row = append(row, storagePoolCreated)
+				row = append(row, StoragePoolCreated)
 			case "storage_volumes":
 				appendNodeID()
 			}

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -246,8 +246,8 @@ type StoragePoolState int
 
 // Storage pools state.
 const (
-	storagePoolPending StoragePoolState = iota // Storage pool defined but not yet created globally or on specific node.
-	storagePoolCreated                         // Storage pool created globally or on specific node.
+	StoragePoolPending StoragePoolState = iota // Storage pool defined but not yet created globally or on specific node.
+	StoragePoolCreated                         // Storage pool created globally or on specific node.
 	storagePoolErrored                         // Deprecated (should no longer occur).
 )
 

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -100,7 +100,7 @@ func (c *ClusterTx) GetNonPendingStoragePoolsNamesToIDs(ctx context.Context) (ma
 		pools = append(pools, p)
 
 		return nil
-	}, storagePoolPending)
+	}, StoragePoolPending)
 	if err != nil {
 		return nil, err
 	}
@@ -121,7 +121,7 @@ func (c *ClusterTx) GetNonPendingStoragePoolsNamesToIDs(ctx context.Context) (ma
 func (c *ClusterTx) UpdateStoragePoolAfterNodeJoin(poolID, nodeID int64) error {
 	columns := []string{"storage_pool_id", "node_id", "state"}
 	// Create storage pool node with storagePoolCreated state as we expect the pool to already be setup.
-	values := []any{poolID, nodeID, storagePoolCreated}
+	values := []any{poolID, nodeID, StoragePoolCreated}
 	_, err := query.UpsertObject(c.tx, "storage_pools_nodes", columns, values)
 	if err != nil {
 		return fmt.Errorf("failed to add storage pools node entry: %w", err)
@@ -302,7 +302,7 @@ func (c *ClusterTx) CreatePendingStoragePool(ctx context.Context, node string, n
 			return fmt.Errorf("Storage pool already exists with a different driver")
 		}
 
-		if pool.state != storagePoolPending {
+		if pool.state != StoragePoolPending {
 			return fmt.Errorf("Storage pool is not in pending state")
 		}
 	}
@@ -325,7 +325,7 @@ func (c *ClusterTx) CreatePendingStoragePool(ctx context.Context, node string, n
 
 	// Insert a node-specific entry pointing to ourselves with state storagePoolPending.
 	columns := []string{"storage_pool_id", "node_id", "state"}
-	values := []any{poolID, nodeInfo.ID, storagePoolPending}
+	values := []any{poolID, nodeInfo.ID, StoragePoolPending}
 	_, err = query.UpsertObject(c.tx, "storage_pools_nodes", columns, values)
 	if err != nil {
 		return err
@@ -341,7 +341,7 @@ func (c *ClusterTx) CreatePendingStoragePool(ctx context.Context, node string, n
 
 // StoragePoolCreated sets the state of the given pool to storagePoolCreated.
 func (c *ClusterTx) StoragePoolCreated(name string) error {
-	return c.storagePoolState(name, storagePoolCreated)
+	return c.storagePoolState(name, StoragePoolCreated)
 }
 
 // StoragePoolErrored sets the state of the given pool to storagePoolErrored.
@@ -403,7 +403,7 @@ func (c *ClusterTx) storagePoolNodes(ctx context.Context, poolID int64) (map[int
 
 // StoragePoolNodeCreated sets the state of the given storage pool for the local member to storagePoolCreated.
 func (c *ClusterTx) StoragePoolNodeCreated(poolID int64) error {
-	return c.storagePoolNodeState(poolID, storagePoolCreated)
+	return c.storagePoolNodeState(poolID, StoragePoolCreated)
 }
 
 // storagePoolNodeState updates the storage pool member state for the local member and specified network ID.
@@ -525,7 +525,7 @@ SELECT nodes.name FROM nodes
   LEFT JOIN storage_pools ON storage_pools_nodes.storage_pool_id = storage_pools.id
 WHERE storage_pools.id = ? AND storage_pools.state = ?
 `
-	defined, err := query.SelectStrings(ctx, c.tx, stmt, poolID, storagePoolPending)
+	defined, err := query.SelectStrings(ctx, c.tx, stmt, poolID, StoragePoolPending)
 	if err != nil {
 		return nil, err
 	}
@@ -562,7 +562,7 @@ func (c *Cluster) GetStoragePoolNames() ([]string, error) {
 
 // GetCreatedStoragePoolNames returns the names of all storage pools that are created.
 func (c *Cluster) GetCreatedStoragePoolNames() ([]string, error) {
-	return c.storagePools("state=?", storagePoolCreated)
+	return c.storagePools("state=?", StoragePoolCreated)
 }
 
 // Get all storage pools matching the given WHERE filter (if given).
@@ -640,7 +640,7 @@ func (c *Cluster) GetStoragePoolID(poolName string) (int64, error) {
 //
 // The pool must be in the created stated, not pending.
 func (c *Cluster) GetStoragePool(poolName string) (int64, *api.StoragePool, map[int64]StoragePoolNode, error) {
-	stateCreated := storagePoolCreated
+	stateCreated := StoragePoolCreated
 	pools, poolMembers, err := c.GetStoragePools(context.TODO(), &stateCreated, poolName)
 	if (err == nil && len(pools) <= 0) || errors.Is(err, sql.ErrNoRows) {
 		return -1, nil, nil, api.StatusErrorf(http.StatusNotFound, "Storage pool not found")
@@ -691,7 +691,7 @@ func (c *Cluster) getStoragePool(onlyCreated bool, where string, args ...any) (i
 
 	if onlyCreated {
 		q.WriteString(" AND state=?")
-		args = append(args, storagePoolCreated)
+		args = append(args, StoragePoolCreated)
 	}
 
 	poolID := int64(-1)
@@ -739,9 +739,9 @@ func (c *Cluster) getStoragePool(onlyCreated bool, where string, args ...any) (i
 // StoragePoolStateToAPIStatus converts DB StoragePoolState to API status string.
 func StoragePoolStateToAPIStatus(state StoragePoolState) string {
 	switch state {
-	case storagePoolPending:
+	case StoragePoolPending:
 		return api.StoragePoolStatusPending
-	case storagePoolCreated:
+	case StoragePoolCreated:
 		return api.StoragePoolStatusCreated
 	case storagePoolErrored:
 		return api.StoragePoolStatusErrored
@@ -779,7 +779,7 @@ func (c *Cluster) getStoragePoolConfig(ctx context.Context, tx *ClusterTx, poolI
 func (c *Cluster) CreateStoragePool(poolName string, poolDescription string, poolDriver string, poolConfig map[string]string) (int64, error) {
 	var id int64
 	err := c.Transaction(context.TODO(), func(ctx context.Context, tx *ClusterTx) error {
-		result, err := tx.tx.Exec("INSERT INTO storage_pools (name, description, driver, state) VALUES (?, ?, ?, ?)", poolName, poolDescription, poolDriver, storagePoolCreated)
+		result, err := tx.tx.Exec("INSERT INTO storage_pools (name, description, driver, state) VALUES (?, ?, ?, ?)", poolName, poolDescription, poolDriver, StoragePoolCreated)
 		if err != nil {
 			return err
 		}
@@ -791,7 +791,7 @@ func (c *Cluster) CreateStoragePool(poolName string, poolDescription string, poo
 
 		// Insert a node-specific entry pointing to ourselves with state storagePoolPending.
 		columns := []string{"storage_pool_id", "node_id", "state"}
-		values := []any{id, c.nodeID, storagePoolPending}
+		values := []any{id, c.nodeID, StoragePoolPending}
 		_, err = query.UpsertObject(tx.tx, "storage_pools_nodes", columns, values)
 		if err != nil {
 			return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6690,7 +6690,7 @@ func (d *lxc) DevptsFd() (*os.File, error) {
 
 	defer d.release()
 
-	if !liblxc.HasApiExtension("devpts_fd") {
+	if !liblxc.HasAPIExtension("devpts_fd") {
 		return nil, fmt.Errorf("Missing devpts_fd extension")
 	}
 
@@ -6777,7 +6777,7 @@ func (d *lxc) cgroup(cc *liblxc.Container) (*cgroup.CGroup, error) {
 		return nil, err
 	}
 
-	cg.UnifiedCapable = liblxc.HasApiExtension("cgroup2")
+	cg.UnifiedCapable = liblxc.HasAPIExtension("cgroup2")
 	return cg, nil
 }
 

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -283,7 +283,7 @@ func doInstancesGet(d *Daemon, r *http.Request) (any, error) {
 	var nodesProjectsInstances map[string][][2]string  // Projects & Instances by node address
 	var projectInstanceToNodeName map[[2]string]string // Node names by Project & Instance
 	filteredProjects := []string{}
-	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(r.Context(), func(ctx context.Context, tx *db.ClusterTx) error {
 		var err error
 
 		if allProjects {

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -1743,7 +1743,7 @@ func (s *Server) HandleSysinfoSyscall(c Instance, siov *Iovec) int {
 
 	instMetrics := Sysinfo{} // Architecture independent place to hold instance metrics.
 
-	cg, err := cgroup.NewFileReadWriter(int(siov.msg.init_pid), liblxc.HasApiExtension("cgroup2"))
+	cg, err := cgroup.NewFileReadWriter(int(siov.msg.init_pid), liblxc.HasAPIExtension("cgroup2"))
 	if err != nil {
 		l.Warn("Failed loading cgroup", logger.Ctx{"err": err, "pid": siov.msg.init_pid})
 		C.seccomp_notify_update_response(siov.resp, 0, C.uint32_t(seccompUserNotifFlagContinue))

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -551,7 +551,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -709,7 +709,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -893,7 +893,7 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1252,7 +1252,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1267,7 +1267,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1297,7 +1297,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1341,7 +1341,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1473,27 +1473,27 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1649,7 +1649,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1780,83 +1780,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -2008,7 +2009,7 @@ msgstr " Prozessorauslastung:"
 msgid "Display instances from all projects"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2033,7 +2034,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "ABLAUFDATUM"
@@ -2052,7 +2053,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
@@ -2151,11 +2152,11 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2188,7 +2189,7 @@ msgstr "Flüchtiger Container"
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2197,7 +2198,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2284,7 +2285,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2452,11 +2453,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2464,7 +2465,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2481,7 +2482,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2505,7 +2506,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2583,7 +2584,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -3038,7 +3039,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -3081,7 +3082,7 @@ msgstr "Aliasse:\n"
 msgid "List all active certificate add tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3091,7 +3092,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "List all the cluster groups"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3449,7 +3450,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3691,17 +3692,17 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -3758,7 +3759,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Missing cluster group name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3996,7 +3997,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -4193,7 +4194,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4369,7 +4370,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4391,7 +4392,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4577,7 +4578,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4663,7 +4664,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4746,7 +4747,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4802,7 +4803,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4826,7 +4827,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4848,7 +4849,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4872,7 +4873,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -4915,7 +4916,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Entferntes Administrator Passwort"
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4980,7 +4981,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -5225,7 +5226,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show content of instance file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5374,6 +5375,11 @@ msgstr ""
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Profil %s erstellt\n"
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
+msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/image.go:884 lxc/image.go:885
 msgid "Show useful information about images"
@@ -5537,7 +5543,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Store the instance state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5572,7 +5578,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5654,7 +5660,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -5697,11 +5703,11 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5842,7 +5848,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5911,7 +5917,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown output type %q"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6016,12 +6022,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6060,7 +6066,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6178,7 +6184,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -6198,7 +6204,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -6206,7 +6212,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -6357,7 +6363,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6644,8 +6650,8 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6663,7 +6669,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6672,7 +6678,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6680,7 +6686,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -7317,7 +7323,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -7373,7 +7379,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7699,7 +7705,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -628,7 +628,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -964,7 +964,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1009,7 +1009,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1177,27 +1177,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1337,7 +1337,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1462,83 +1462,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1680,7 +1681,7 @@ msgstr "  Χρήση CPU:"
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1705,7 +1706,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1723,7 +1724,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1814,11 +1815,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1850,11 +1851,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1933,7 +1934,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2097,11 +2098,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2109,7 +2110,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2125,7 +2126,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2149,7 +2150,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2226,7 +2227,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -2661,7 +2662,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2702,7 +2703,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2710,7 +2711,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3039,7 +3040,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3260,17 +3261,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3328,7 +3329,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3549,7 +3550,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3745,7 +3746,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3916,7 +3917,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "  Χρήση δικτύου:"
@@ -3938,7 +3939,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4115,7 +4116,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4198,7 +4199,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4275,7 +4276,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4326,7 +4327,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4349,7 +4350,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4368,7 +4369,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4391,7 +4392,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4433,7 +4434,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4496,7 +4497,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -4734,7 +4735,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4873,6 +4874,11 @@ msgstr ""
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
 msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
+msgstr "  Χρήση δικτύου:"
 
 #: lxc/image.go:884 lxc/image.go:885
 msgid "Show useful information about images"
@@ -5027,7 +5033,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5062,7 +5068,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5138,7 +5144,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "  Χρήση δικτύου:"
@@ -5178,11 +5184,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5320,7 +5326,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5388,7 +5394,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "  Χρήση δικτύου:"
@@ -5487,11 +5493,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5529,7 +5535,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5627,7 +5633,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5639,11 +5645,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5716,7 +5722,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5853,8 +5859,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5862,15 +5868,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6196,7 +6202,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6247,7 +6253,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6569,7 +6575,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -548,7 +548,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -695,7 +695,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -873,7 +873,7 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1213,7 +1213,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1228,7 +1228,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1258,7 +1258,7 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1301,7 +1301,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1430,27 +1430,27 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1594,7 +1594,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1720,83 +1720,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1939,7 +1940,7 @@ msgstr "Uso del disco:"
 msgid "Display instances from all projects"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1964,7 +1965,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "FECHA DE EXPIRACIÓN"
@@ -1983,7 +1984,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2074,11 +2075,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2110,12 +2111,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -2197,7 +2198,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2362,11 +2363,11 @@ msgstr "El filtrado no está soportado aún"
 msgid "Fingerprint: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2374,7 +2375,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2390,7 +2391,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2414,7 +2415,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2491,7 +2492,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Perfil %s creado"
@@ -2934,7 +2935,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2977,7 +2978,7 @@ msgstr "Aliases:"
 msgid "List all active certificate add tokens"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nombre del Miembro del Cluster"
@@ -2987,7 +2988,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "List all the cluster groups"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3321,7 +3322,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3543,17 +3544,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3610,7 +3611,7 @@ msgstr "Certificado de la huella digital: %s"
 msgid "Missing cluster group name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3841,7 +3842,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -4035,7 +4036,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4206,7 +4207,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nombre del Miembro del Cluster"
@@ -4228,7 +4229,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4409,7 +4410,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4493,7 +4494,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4570,7 +4571,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4622,7 +4623,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4646,7 +4647,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nombre del Miembro del Cluster"
@@ -4667,7 +4668,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nombre del Miembro del Cluster"
@@ -4690,7 +4691,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nombre del Miembro del Cluster"
@@ -4733,7 +4734,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4796,7 +4797,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -5034,7 +5035,7 @@ msgstr "Perfil %s creado"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5173,6 +5174,11 @@ msgstr ""
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
 msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
+msgstr "Nombre del Miembro del Cluster"
 
 #: lxc/image.go:884 lxc/image.go:885
 msgid "Show useful information about images"
@@ -5328,7 +5334,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5363,7 +5369,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5441,7 +5447,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nombre del Miembro del Cluster"
@@ -5481,11 +5487,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "El directorio importado no está disponible en esta plataforma"
@@ -5626,7 +5632,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5694,7 +5700,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Perfil %s creado"
@@ -5793,12 +5799,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Acepta certificado"
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5836,7 +5842,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5936,7 +5942,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5950,12 +5956,12 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6046,7 +6052,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6215,8 +6221,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6226,17 +6232,17 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<member> <group>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6637,7 +6643,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6689,7 +6695,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7011,7 +7017,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -549,7 +549,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -707,7 +707,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -900,7 +900,7 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1249,7 +1249,7 @@ msgstr "Profils %s appliqués à %s"
 msgid "Cluster group %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1294,7 +1294,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1346,7 +1346,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target instance"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1479,27 +1479,27 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Impossible d'assainir le chemin %s"
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1671,7 +1671,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1807,83 +1807,84 @@ msgstr "Récupération de l'image : %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -2029,7 +2030,7 @@ msgstr "  Disque utilisé :"
 msgid "Display instances from all projects"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2055,7 +2056,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATE D'EXPIRATION"
@@ -2074,7 +2075,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Clé de configuration invalide"
@@ -2174,11 +2175,11 @@ msgstr "Clé de configuration invalide"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2211,7 +2212,7 @@ msgstr "Conteneur éphémère"
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2223,7 +2224,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2317,7 +2318,7 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2485,11 +2486,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 #, fuzzy
 msgid "Force evacuation without user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -2498,7 +2499,7 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2516,7 +2517,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2540,7 +2541,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2617,7 +2618,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3080,7 +3081,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -3123,7 +3124,7 @@ msgstr "Alias :"
 msgid "List all active certificate add tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -3133,7 +3134,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "List all the cluster groups"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3532,7 +3533,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3772,17 +3773,17 @@ msgstr "Profil %s ajouté à %s"
 msgid "Member %q does not have role %q"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, fuzzy, c-format
 msgid "Member %s join token:"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -3841,7 +3842,7 @@ msgstr "Empreinte du certificat : %s"
 msgid "Missing cluster group name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -4083,7 +4084,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -4282,7 +4283,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4469,7 +4470,7 @@ msgstr "Chemin vers un dossier de configuration serveur alternatif"
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4491,7 +4492,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4678,7 +4679,7 @@ msgstr "SOURCE"
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4766,7 +4767,7 @@ msgstr "Supprimer %s (oui/non) : "
 msgid "Remove a cluster member from a cluster group"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4850,7 +4851,7 @@ msgstr "Ajouter de nouveaux clients de confiance"
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4905,7 +4906,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4930,7 +4931,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4968,7 +4969,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -4992,7 +4993,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Revoke certificate add token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5035,7 +5036,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr "Mot de passe de l'administrateur distant"
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr "ÉTAT"
@@ -5103,7 +5104,7 @@ msgstr "Protocole du serveur (lxd ou simplestreams)"
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -5350,7 +5351,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show content of instance file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5505,6 +5506,11 @@ msgstr ""
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Afficher la configuration étendue"
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
+msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/image.go:884 lxc/image.go:885
 msgid "Show useful information about images"
@@ -5669,7 +5675,7 @@ msgstr "Image copiée avec succès !"
 msgid "Store the instance state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5706,7 +5712,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5791,7 +5797,7 @@ msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -5832,11 +5838,11 @@ msgstr "le périphérique indiqué ne correspond pas au réseau"
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "L'importation de répertoire n'est pas disponible sur cette plateforme"
@@ -5981,7 +5987,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr "URL"
 
@@ -6050,7 +6056,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6158,12 +6164,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6202,7 +6208,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -6317,7 +6323,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -6334,7 +6340,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -6342,7 +6348,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -6508,7 +6514,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6846,8 +6852,8 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6871,7 +6877,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6883,7 +6889,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6891,7 +6897,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -7561,7 +7567,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -7621,7 +7627,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7966,7 +7972,7 @@ msgstr "utilisé par"
 msgid "y"
 msgstr "o"
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr "oui"

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -312,7 +312,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -453,7 +453,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1175,27 +1175,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1453,83 +1453,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1667,7 +1668,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1692,7 +1693,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1710,7 +1711,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1796,11 +1797,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1832,11 +1833,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1915,7 +1916,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2079,11 +2080,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2107,7 +2108,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2131,7 +2132,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2208,7 +2209,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2677,7 +2678,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3012,7 +3013,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3223,17 +3224,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3287,7 +3288,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3505,7 +3506,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3699,7 +3700,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3870,7 +3871,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3891,7 +3892,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4068,7 +4069,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4151,7 +4152,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4223,7 +4224,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4274,7 +4275,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4297,7 +4298,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4316,7 +4317,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4338,7 +4339,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4380,7 +4381,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4443,7 +4444,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4673,7 +4674,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4803,6 +4804,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4958,7 +4963,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4993,7 +4998,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5069,7 +5074,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5109,11 +5114,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5251,7 +5256,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5319,7 +5324,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5408,11 +5413,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5450,7 +5455,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5548,7 +5553,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5560,11 +5565,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5637,7 +5642,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5774,8 +5779,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5783,15 +5788,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6168,7 +6173,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6490,7 +6495,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -545,7 +545,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -689,7 +689,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -867,7 +867,7 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1205,7 +1205,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1220,7 +1220,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1250,7 +1250,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1291,7 +1291,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1418,27 +1418,27 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1585,7 +1585,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1711,83 +1711,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1930,7 +1931,7 @@ msgstr "Utilizzo disco:"
 msgid "Display instances from all projects"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1955,7 +1956,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DI SCADENZA"
@@ -1974,7 +1975,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2065,11 +2066,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2101,12 +2102,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -2187,7 +2188,7 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2352,11 +2353,11 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2364,7 +2365,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2380,7 +2381,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2404,7 +2405,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2481,7 +2482,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Il nome del container è: %s"
@@ -2922,7 +2923,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2965,7 +2966,7 @@ msgstr "Alias:"
 msgid "List all active certificate add tokens"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Il nome del container è: %s"
@@ -2975,7 +2976,7 @@ msgstr "Il nome del container è: %s"
 msgid "List all the cluster groups"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3311,7 +3312,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3537,17 +3538,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3603,7 +3604,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3833,7 +3834,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -4027,7 +4028,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4200,7 +4201,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Il nome del container è: %s"
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4402,7 +4403,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4486,7 +4487,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4564,7 +4565,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4616,7 +4617,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4640,7 +4641,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Il nome del container è: %s"
@@ -4661,7 +4662,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Il nome del container è: %s"
@@ -4684,7 +4685,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Il nome del container è: %s"
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Il nome del container è: %s"
@@ -4727,7 +4728,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4790,7 +4791,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -5026,7 +5027,7 @@ msgstr "Il nome del container è: %s"
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5165,6 +5166,11 @@ msgstr ""
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
 msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
+msgstr "Il nome del container è: %s"
 
 #: lxc/image.go:884 lxc/image.go:885
 msgid "Show useful information about images"
@@ -5322,7 +5328,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5357,7 +5363,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5434,7 +5440,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Il nome del container è: %s"
@@ -5475,11 +5481,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "Import da directory non disponibile su questa piattaforma"
@@ -5619,7 +5625,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5688,7 +5694,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Il nome del container è: %s"
@@ -5785,12 +5791,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Accetta certificato"
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5829,7 +5835,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5931,7 +5937,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5945,12 +5951,12 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr "Creazione del container in corso"
@@ -6041,7 +6047,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr "Creazione del container in corso"
@@ -6210,8 +6216,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr "Creazione del container in corso"
@@ -6221,17 +6227,17 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<member> <group>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr "Creazione del container in corso"
@@ -6632,7 +6638,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Creazione del container in corso"
@@ -6684,7 +6690,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7007,7 +7013,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr "si"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -535,7 +535,7 @@ msgstr ""
 "###\n"
 "### Note that the name is shown but cannot be changed"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -680,7 +680,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -872,7 +872,7 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1215,7 +1215,7 @@ msgstr "クラスターグループ %s は現在 %s に適用されていませ�
 msgid "Cluster group %s renamed to %s"
 msgstr "クラスタグループ名 %s を %s に変更しました"
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr "%s:%s のクラスターに join するためのトークンが削除されました"
@@ -1230,7 +1230,7 @@ msgstr "クラスターメンバー %s がクラスターグループ %s に追�
 msgid "Cluster member %s removed from group %s"
 msgstr "クラスターメンバー %s がグループ %s から削除されました"
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1260,7 +1260,7 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
@@ -1305,7 +1305,7 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target instance"
 msgstr "移動先のインスタンスに適用するキー/値の設定"
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1447,27 +1447,27 @@ msgstr "サーバ証明書ファイル %q をクローズできません: %w"
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "証明書のファイルパスが見つかりません: %s"
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "証明書の鍵のパスが見つかりません: %s"
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "証明書ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "秘密鍵ファイル %s をエラーで読み込めません: %v"
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr "リモート '%s' に対する新しいリモート証明書がエラーで書き込めません: %v"
@@ -1608,7 +1608,7 @@ msgstr "現在の VF 数: %d"
 msgid "DEFAULT TARGET ADDRESS"
 msgstr "DEFAULT TARGET ADDRESS"
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1729,83 +1729,84 @@ msgstr "警告を削除します"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1949,7 +1950,7 @@ msgstr "ディスク:"
 msgid "Display instances from all projects"
 msgstr "すべてのプロジェクトのインスタンスを表示します"
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -1974,7 +1975,7 @@ msgstr "ENTRIES"
 msgid "EPHEMERAL"
 msgstr "EPHEMERAL"
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr "EXPIRES AT"
 
@@ -1994,7 +1995,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr "クラスタグループを編集します"
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr "クラスターメンバーの設定をYAMLファイルで編集します"
 
@@ -2081,12 +2082,12 @@ msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 "クラスタリングで動作していないLXDサーバ上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2127,11 +2128,11 @@ msgstr "Ephemeral インスタンス"
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr "クラスターのメンバーを待避させます"
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "クラスターメンバーを待避させています: %s"
@@ -2225,7 +2226,7 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr "FAILURE DOMAIN"
 
@@ -2389,11 +2390,11 @@ msgstr "情報表示のフィルタリングはまだサポートされていま
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr "特定の待避アクションを強制します"
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr "ユーザーの確認なしで強制的に待避させます"
 
@@ -2401,7 +2402,7 @@ msgstr "ユーザーの確認なしで強制的に待避させます"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
@@ -2417,7 +2418,7 @@ msgstr "稼働中のインスタンスを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2456,7 +2457,7 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no): "
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2533,7 +2534,7 @@ msgstr "イメージのプロパティを取得します"
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr "クラスターメンバーの設定値を取得します"
 
@@ -2980,7 +2981,7 @@ msgstr ""
 "LXD は spicy か remote-viewer がインストールされている場合は自動的にどちらか"
 "を使います。"
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
@@ -3021,7 +3022,7 @@ msgstr "エイリアスを一覧表示します"
 msgid "List all active certificate add tokens"
 msgstr "有効な証明書追加トークンをすべて一覧表示します"
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr "有効なクラスターへの join トークンをすべて一覧表示します"
 
@@ -3029,7 +3030,7 @@ msgstr "有効なクラスターへの join トークンをすべて一覧表示
 msgid "List all the cluster groups"
 msgstr "クラスタグループをすべて一覧表示します"
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
@@ -3493,7 +3494,7 @@ msgstr "MEMORY USAGE"
 msgid "MEMORY USAGE%"
 msgstr "MEMORY USAGE%"
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr "MESSAGE"
 
@@ -3721,17 +3722,17 @@ msgstr "メンバー %q はすでにロール %q を持っています"
 msgid "Member %q does not have role %q"
 msgstr "メンバー %q はロール %q を持っていません"
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr "メンバ %s の join トークン:"
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -3785,7 +3786,7 @@ msgstr "証明書のフィンガープリントがありません"
 msgid "Missing cluster group name"
 msgstr "クラスターグループ名がありません"
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr "クラスターメンバー名がありません"
@@ -4021,7 +4022,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply instance name for: "
 msgstr "インスタンス名を指定する必要があります: "
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -4218,7 +4219,7 @@ msgstr "指定するデバイスに適用する新しいキー/値"
 msgid "No certificate add token for member %s on remote: %s"
 msgstr "メンバー %s に対する証明書追加トークンがリモートにありません: %s"
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4390,7 +4391,7 @@ msgstr "別のサーバアドレスを指定してください（空の場合は
 msgid "Please provide client name: "
 msgstr "クライアント名を入力してください: "
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr "クラスターメンバー名を入力してください: "
 
@@ -4411,7 +4412,7 @@ msgstr "ポート:"
 msgid "Press ctrl+c to finish"
 msgstr "終了するには ctrl+c を押してください"
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4590,7 +4591,7 @@ msgstr "RESOURCE"
 msgid "ROLE"
 msgstr "ROLE"
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr "ROLES"
 
@@ -4673,7 +4674,7 @@ msgstr "%s を消去しますか (yes/no): "
 msgid "Remove a cluster member from a cluster group"
 msgstr "クラスタグループからメンバを削除します"
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
@@ -4745,7 +4746,7 @@ msgstr "信頼済みクライアントを削除します"
 msgid "Rename a cluster group"
 msgstr "クラスタグループの名前を変更します"
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -4797,7 +4798,7 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Render: %s (%s)"
 msgstr "レンダー: %s (%s)"
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr "クラスターメンバーに join するためのトークンを要求します"
 
@@ -4823,7 +4824,7 @@ msgstr ""
 "\n"
 "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr "クラスターメンバーをリストアします"
 
@@ -4845,7 +4846,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr "クラスターメンバーをリストアしています: %s"
@@ -4867,7 +4868,7 @@ msgstr "イメージの取得中: %s"
 msgid "Revoke certificate add token"
 msgstr "証明書追加トークンを失効（Revoke）させます"
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr "クラスターメンバーに join するためのトークンを失効（Revoke）させます"
 
@@ -4909,7 +4910,7 @@ msgstr "SSH クライアントが %q に接続されました"
 msgid "SSH client disconnected %q"
 msgstr "SSH クライアントが切断されました %q"
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr "STATE"
@@ -4972,7 +4973,7 @@ msgstr "サーバのプロトコル (lxd or simplestreams)"
 msgid "Server version: %s\n"
 msgstr "サーバのバージョン: %s\n"
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を行います"
 
@@ -5259,7 +5260,7 @@ msgstr "クラスタグループの設定を表示します"
 msgid "Show content of instance file templates"
 msgstr "インスタンスのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -5390,6 +5391,11 @@ msgstr "使用量と空き容量を byte で表示します"
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
 msgstr "信頼済みクライアントの設定を表示します"
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
+msgstr "イメージについての情報を表示します"
 
 #: lxc/image.go:884 lxc/image.go:885
 msgid "Show useful information about images"
@@ -5544,7 +5550,7 @@ msgstr "ストレージボリュームの移動が成功しました!"
 msgid "Store the instance state"
 msgstr "インスタンスの状態を保存します"
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr "リモート %s に対するクラスター証明書の更新に成功しました"
@@ -5579,7 +5585,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr "TARGET"
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr "TOKEN"
 
@@ -5657,7 +5663,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたインスタンスに接続されているネットワークがありません。"
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "設定 %q はクラスタメンバー %q には存在しません"
@@ -5702,11 +5708,11 @@ msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
 "さい。"
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr "LXD サーバはすでにクラスターに属しています"
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr "この LXD サーバはネットワークから利用できません"
 
@@ -5863,7 +5869,7 @@ msgstr "UNLIMITED"
 msgid "UPLOAD DATE"
 msgstr "UPLOAD DATE"
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr "URL"
 
@@ -5931,7 +5937,7 @@ msgstr "未知の設定: %s"
 msgid "Unknown output type %q"
 msgstr "未知の出力タイプ: %q"
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr "クラスターメンバーの設定を削除します"
 
@@ -6020,11 +6026,11 @@ msgstr "サポートされていないインスタンスタイプです: %s"
 msgid "Up delay"
 msgstr "Up delay"
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr "クラスター証明書を更新します"
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -6065,7 +6071,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -6168,7 +6174,7 @@ msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -6180,11 +6186,11 @@ msgstr "[<remote>:]"
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "[<remote>:] <backup file> [<instance name>]"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "[<remote>:] <cert.crt> <cert.key>"
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr "[<remote>:] <name>"
 
@@ -6257,7 +6263,7 @@ msgstr "[<remote>:]<alias> <fingerprint>"
 msgid "[<remote>:]<alias> <new-name>"
 msgstr "[<remote>:]<alias> <new-name>"
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr "[<remote>:]<cluster member>"
 
@@ -6397,8 +6403,8 @@ msgid ""
 msgstr ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr "[<remote>:]<member>"
 
@@ -6406,15 +6412,15 @@ msgstr "[<remote>:]<member>"
 msgid "[<remote>:]<member> <group>"
 msgstr "[<remote>:]<member> <group>"
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr "[<remote>:]<member> <key>"
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "[<remote>:]<member> <key>=<value>..."
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr "[<remote>:]<member> <new-name>"
 
@@ -6750,7 +6756,7 @@ msgstr "[<remote>:][<instance>] <key>=<value>..."
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "[<remote>] <IP|FQDN|URL|token>"
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr "[[<remote>:]<member>]"
 
@@ -6807,7 +6813,7 @@ msgstr ""
 "lxc alias rename list my-list\n"
 "    エイリアス名 \"list\" を \"my-list\" に変更します。"
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7273,7 +7279,7 @@ msgstr "ストレージを使用中の"
 msgid "y"
 msgstr "y"
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr "yes"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2023-01-12 16:28-0500\n"
+        "POT-Creation-Date: 2023-01-16 14:20+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -287,7 +287,7 @@ msgid   "### This is a YAML representation of the project.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid   "### This is a yaml representation of the cluster member.\n"
         "### Any line starting with a '# will be ignored."
 msgstr  ""
@@ -425,7 +425,7 @@ msgstr  ""
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -592,7 +592,7 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid   "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr  ""
@@ -921,7 +921,7 @@ msgstr  ""
 msgid   "Cluster group %s renamed to %s"
 msgstr  ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid   "Cluster join token for %s:%s deleted"
 msgstr  ""
@@ -936,11 +936,11 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713 lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178 lxc/network.go:1240 lxc/network_forward.go:171 lxc/network_forward.go:235 lxc/network_forward.go:390 lxc/network_forward.go:491 lxc/network_forward.go:633 lxc/network_forward.go:710 lxc/network_forward.go:776 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636 lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939 lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:642 lxc/storage.go:714 lxc/storage.go:797 lxc/storage_bucket.go:86 lxc/storage_bucket.go:186 lxc/storage_bucket.go:249 lxc/storage_bucket.go:378 lxc/storage_bucket.go:523 lxc/storage_bucket.go:599 lxc/storage_bucket.go:663 lxc/storage_bucket.go:814 lxc/storage_bucket.go:892 lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093 lxc/storage_volume.go:334 lxc/storage_volume.go:524 lxc/storage_volume.go:603 lxc/storage_volume.go:844 lxc/storage_volume.go:1045 lxc/storage_volume.go:1133 lxc/storage_volume.go:1564 lxc/storage_volume.go:1596 lxc/storage_volume.go:1712 lxc/storage_volume.go:1803 lxc/storage_volume.go:1896 lxc/storage_volume.go:1933 lxc/storage_volume.go:2026 lxc/storage_volume.go:2098 lxc/storage_volume.go:2240
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713 lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178 lxc/network.go:1240 lxc/network_forward.go:171 lxc/network_forward.go:235 lxc/network_forward.go:390 lxc/network_forward.go:491 lxc/network_forward.go:633 lxc/network_forward.go:710 lxc/network_forward.go:776 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636 lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939 lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:642 lxc/storage.go:714 lxc/storage.go:797 lxc/storage_bucket.go:86 lxc/storage_bucket.go:186 lxc/storage_bucket.go:249 lxc/storage_bucket.go:378 lxc/storage_bucket.go:523 lxc/storage_bucket.go:599 lxc/storage_bucket.go:663 lxc/storage_bucket.go:814 lxc/storage_bucket.go:892 lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093 lxc/storage_volume.go:334 lxc/storage_volume.go:524 lxc/storage_volume.go:603 lxc/storage_volume.go:844 lxc/storage_volume.go:1045 lxc/storage_volume.go:1133 lxc/storage_volume.go:1564 lxc/storage_volume.go:1596 lxc/storage_volume.go:1712 lxc/storage_volume.go:1803 lxc/storage_volume.go:1896 lxc/storage_volume.go:1933 lxc/storage_volume.go:2026 lxc/storage_volume.go:2098 lxc/storage_volume.go:2240
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid   "Clustering enabled"
 msgstr  ""
 
@@ -979,7 +979,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308 lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056 lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308 lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056 lxc/storage_volume.go:977 lxc/storage_volume.go:1009
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -1092,27 +1092,27 @@ msgstr  ""
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid   "Could not find certificate file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid   "Could not find certificate key file path: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid   "Could not read certificate file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid   "Could not read certificate key file: %s with error: %v"
 msgstr  ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid   "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr  ""
@@ -1248,7 +1248,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059 lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964 lxc/network_acl.go:149 lxc/network_forward.go:146 lxc/network_load_balancer.go:149 lxc/network_peer.go:141 lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164 lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619 lxc/storage_bucket.go:496 lxc/storage_bucket.go:791 lxc/storage_volume.go:1459
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059 lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964 lxc/network_acl.go:149 lxc/network_forward.go:146 lxc/network_load_balancer.go:149 lxc/network_peer.go:141 lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164 lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619 lxc/storage_bucket.go:496 lxc/storage_bucket.go:791 lxc/storage_volume.go:1459
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1360,7 +1360,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203 lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380 lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713 lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072 lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1270 lxc/storage_volume.go:1354 lxc/storage_volume.go:1560 lxc/storage_volume.go:1593 lxc/storage_volume.go:1706 lxc/storage_volume.go:1794 lxc/storage_volume.go:1893 lxc/storage_volume.go:1927 lxc/storage_volume.go:2024 lxc/storage_volume.go:2091 lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207 lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404 lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651 lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018 lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1270 lxc/storage_volume.go:1354 lxc/storage_volume.go:1560 lxc/storage_volume.go:1593 lxc/storage_volume.go:1706 lxc/storage_volume.go:1794 lxc/storage_volume.go:1893 lxc/storage_volume.go:1927 lxc/storage_volume.go:2024 lxc/storage_volume.go:2091 lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1475,7 +1475,7 @@ msgstr  ""
 msgid   "Display instances from all projects"
 msgstr  ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -1500,7 +1500,7 @@ msgstr  ""
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid   "EXPIRES AT"
 msgstr  ""
 
@@ -1516,7 +1516,7 @@ msgstr  ""
 msgid   "Edit a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid   "Edit cluster member configurations as YAML"
 msgstr  ""
 
@@ -1601,11 +1601,11 @@ msgstr  ""
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid   "Enable clustering on a single non-clustered LXD server"
 msgstr  ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid   "Enable clustering on a single non-clustered LXD server\n"
         "\n"
         "  This command turns a non-clustered LXD server into the first member of a new\n"
@@ -1633,11 +1633,11 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid   "Evacuate cluster member"
 msgstr  ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid   "Evacuating cluster member: %s"
 msgstr  ""
@@ -1712,7 +1712,7 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid   "FAILURE DOMAIN"
 msgstr  ""
 
@@ -1874,11 +1874,11 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid   "Force a particular evacuation action"
 msgstr  ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid   "Force evacuation without user confirmation"
 msgstr  ""
 
@@ -1886,7 +1886,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
@@ -1902,7 +1902,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -1921,7 +1921,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561 lxc/storage_bucket.go:443 lxc/storage_bucket.go:734 lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561 lxc/storage_bucket.go:443 lxc/storage_bucket.go:734 lxc/storage_volume.go:1370 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -1989,7 +1989,7 @@ msgstr  ""
 msgid   "Get runtime information on networks"
 msgstr  ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid   "Get values for cluster member configuration keys"
 msgstr  ""
 
@@ -2409,7 +2409,7 @@ msgstr  ""
 msgid   "LXD automatically uses either spicy or remote-viewer when present."
 msgstr  ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004 lxc/cluster_group.go:404
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057 lxc/cluster_group.go:404
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -2449,7 +2449,7 @@ msgstr  ""
 msgid   "List all active certificate add tokens"
 msgstr  ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid   "List all active cluster member join tokens"
 msgstr  ""
 
@@ -2457,7 +2457,7 @@ msgstr  ""
 msgid   "List all the cluster groups"
 msgstr  ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid   "List all the cluster members"
 msgstr  ""
 
@@ -2772,7 +2772,7 @@ msgstr  ""
 msgid   "MEMORY USAGE%"
 msgstr  ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid   "MESSAGE"
 msgstr  ""
 
@@ -2980,17 +2980,17 @@ msgstr  ""
 msgid   "Member %q does not have role %q"
 msgstr  ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid   "Member %s join token:"
 msgstr  ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -3037,7 +3037,7 @@ msgstr  ""
 msgid   "Missing cluster group name"
 msgstr  ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110 lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110 lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid   "Missing cluster member name"
 msgstr  ""
 
@@ -3193,7 +3193,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566 lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1458
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566 lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1458
 msgid   "NAME"
 msgstr  ""
 
@@ -3377,7 +3377,7 @@ msgstr  ""
 msgid   "No certificate add token for member %s on remote: %s"
 msgstr  ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid   "No cluster join token for member %s on remote: %s"
 msgstr  ""
@@ -3548,7 +3548,7 @@ msgstr  ""
 msgid   "Please provide client name: "
 msgstr  ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid   "Please provide cluster member name: "
 msgstr  ""
 
@@ -3569,7 +3569,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207 lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679 lxc/network_acl.go:583 lxc/network_forward.go:598 lxc/network_load_balancer.go:601 lxc/network_peer.go:574 lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509 lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345 lxc/storage_bucket.go:1057 lxc/storage_volume.go:978 lxc/storage_volume.go:1010
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207 lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679 lxc/network_acl.go:583 lxc/network_forward.go:598 lxc/network_load_balancer.go:601 lxc/network_peer.go:574 lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509 lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345 lxc/storage_bucket.go:1057 lxc/storage_volume.go:978 lxc/storage_volume.go:1010
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3738,7 +3738,7 @@ msgstr  ""
 msgid   "ROLE"
 msgstr  ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid   "ROLES"
 msgstr  ""
 
@@ -3820,7 +3820,7 @@ msgstr  ""
 msgid   "Remove a cluster member from a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
@@ -3892,7 +3892,7 @@ msgstr  ""
 msgid   "Rename a cluster group"
 msgstr  ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -3942,7 +3942,7 @@ msgstr  ""
 msgid   "Render: %s (%s)"
 msgstr  ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid   "Request a join token for adding a cluster member"
 msgstr  ""
 
@@ -3964,7 +3964,7 @@ msgid   "Restart instances\n"
         "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid   "Restore cluster member"
 msgstr  ""
 
@@ -3982,7 +3982,7 @@ msgstr  ""
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid   "Restoring cluster member: %s"
 msgstr  ""
@@ -4004,7 +4004,7 @@ msgstr  ""
 msgid   "Revoke certificate add token"
 msgstr  ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid   "Revoke cluster member join token"
 msgstr  ""
 
@@ -4046,7 +4046,7 @@ msgstr  ""
 msgid   "SSH client disconnected %q"
 msgstr  ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966 lxc/network_peer.go:143 lxc/storage.go:621
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966 lxc/network_peer.go:143 lxc/storage.go:621
 msgid   "STATE"
 msgstr  ""
 
@@ -4108,7 +4108,7 @@ msgstr  ""
 msgid   "Server version: %s\n"
 msgstr  ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid   "Set a cluster member's configuration keys"
 msgstr  ""
 
@@ -4310,7 +4310,7 @@ msgstr  ""
 msgid   "Show content of instance file templates"
 msgstr  ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -4440,6 +4440,10 @@ msgstr  ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid   "Show trust configurations"
+msgstr  ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid   "Show useful information about a cluster member"
 msgstr  ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4595,7 +4599,7 @@ msgstr  ""
 msgid   "Store the instance state"
 msgstr  ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid   "Successfully updated cluster certificates for remote %s"
 msgstr  ""
@@ -4630,7 +4634,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid   "TOKEN"
 msgstr  ""
 
@@ -4702,7 +4706,7 @@ msgstr  ""
 msgid   "The instance you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid   "The key %q does not exist on cluster member %q"
 msgstr  ""
@@ -4741,11 +4745,11 @@ msgstr  ""
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid   "This LXD server is already clustered"
 msgstr  ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid   "This LXD server is not available on the network"
 msgstr  ""
 
@@ -4874,7 +4878,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid   "URL"
 msgstr  ""
 
@@ -4939,7 +4943,7 @@ msgstr  ""
 msgid   "Unknown output type %q"
 msgstr  ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid   "Unset a cluster member's configuration keys"
 msgstr  ""
 
@@ -5028,11 +5032,11 @@ msgstr  ""
 msgid   "Up delay"
 msgstr  ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid   "Update cluster certificate"
 msgstr  ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid   "Update cluster certificate with PEM certificate and key read from input files."
 msgstr  ""
 
@@ -5067,7 +5071,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -5160,7 +5164,7 @@ msgstr  ""
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365 lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31 lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391 lxc/storage.go:556 lxc/version.go:20 lxc/warning.go:69
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365 lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31 lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83 lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391 lxc/storage.go:556 lxc/version.go:20 lxc/warning.go:69
 msgid   "[<remote>:]"
 msgstr  ""
 
@@ -5168,11 +5172,11 @@ msgstr  ""
 msgid   "[<remote>:] <backup file> [<instance name>]"
 msgstr  ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid   "[<remote>:] <cert.crt> <cert.key>"
 msgstr  ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid   "[<remote>:] <name>"
 msgstr  ""
 
@@ -5244,7 +5248,7 @@ msgstr  ""
 msgid   "[<remote>:]<alias> <new-name>"
 msgstr  ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid   "[<remote>:]<cluster member>"
 msgstr  ""
 
@@ -5376,7 +5380,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr  ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070 lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937 lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid   "[<remote>:]<member>"
 msgstr  ""
 
@@ -5384,15 +5388,15 @@ msgstr  ""
 msgid   "[<remote>:]<member> <group>"
 msgstr  ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid   "[<remote>:]<member> <key>"
 msgstr  ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid   "[<remote>:]<member> <key>=<value>..."
 msgstr  ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid   "[<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -5696,7 +5700,7 @@ msgstr  ""
 msgid   "[<remote>] <IP|FQDN|URL|token>"
 msgstr  ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid   "[[<remote>:]<member>]"
 msgstr  ""
 
@@ -5744,7 +5748,7 @@ msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid   "lxc cluster edit <cluster member> < member.yaml\n"
         "    Update a cluster member using the content of member.yaml"
 msgstr  ""
@@ -6019,7 +6023,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931 lxc/image.go:1116
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931 lxc/image.go:1116
 msgid   "yes"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -528,7 +528,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -669,7 +669,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
@@ -843,7 +843,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1178,7 +1178,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1193,7 +1193,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1223,7 +1223,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1264,7 +1264,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1391,27 +1391,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1548,7 +1548,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1669,83 +1669,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1883,7 +1884,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1908,7 +1909,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1926,7 +1927,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2012,11 +2013,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2048,11 +2049,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2131,7 +2132,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2295,11 +2296,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2307,7 +2308,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2323,7 +2324,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2347,7 +2348,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2424,7 +2425,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2852,7 +2853,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2893,7 +2894,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2901,7 +2902,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3228,7 +3229,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3439,17 +3440,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3503,7 +3504,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3721,7 +3722,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3915,7 +3916,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4086,7 +4087,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4107,7 +4108,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4284,7 +4285,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4367,7 +4368,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4439,7 +4440,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4490,7 +4491,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4513,7 +4514,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4532,7 +4533,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4554,7 +4555,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4596,7 +4597,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4659,7 +4660,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4889,7 +4890,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5019,6 +5020,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -5174,7 +5179,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5209,7 +5214,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5285,7 +5290,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5325,11 +5330,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5467,7 +5472,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5535,7 +5540,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5624,11 +5629,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5666,7 +5671,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5764,7 +5769,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5776,11 +5781,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5853,7 +5858,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5990,8 +5995,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5999,15 +6004,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6333,7 +6338,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6384,7 +6389,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6706,7 +6711,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -562,7 +562,7 @@ msgstr ""
 "###\n"
 "### Nazwa jest widoczna, ale nie może zostać zmieniona"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -703,7 +703,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -877,7 +877,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1212,7 +1212,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1257,7 +1257,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1298,7 +1298,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1425,27 +1425,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1582,7 +1582,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1703,83 +1703,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1917,7 +1918,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1942,7 +1943,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1960,7 +1961,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2046,11 +2047,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2082,11 +2083,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2165,7 +2166,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2329,11 +2330,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2341,7 +2342,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2357,7 +2358,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2381,7 +2382,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2458,7 +2459,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2886,7 +2887,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2927,7 +2928,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2935,7 +2936,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3262,7 +3263,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3473,17 +3474,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3537,7 +3538,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3755,7 +3756,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3949,7 +3950,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4120,7 +4121,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4141,7 +4142,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4318,7 +4319,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4401,7 +4402,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4473,7 +4474,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4524,7 +4525,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4547,7 +4548,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4566,7 +4567,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4588,7 +4589,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4630,7 +4631,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4693,7 +4694,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4923,7 +4924,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5053,6 +5054,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -5208,7 +5213,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5243,7 +5248,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5319,7 +5324,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5359,11 +5364,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5501,7 +5506,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5569,7 +5574,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5658,11 +5663,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5700,7 +5705,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5798,7 +5803,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5810,11 +5815,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5887,7 +5892,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -6024,8 +6029,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6033,15 +6038,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6367,7 +6372,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6418,7 +6423,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6740,7 +6745,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -550,7 +550,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -702,7 +702,7 @@ msgstr "ALIAS"
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
@@ -885,7 +885,7 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1230,7 +1230,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1245,7 +1245,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1275,7 +1275,7 @@ msgstr "Dispositivo %s removido de %s"
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
@@ -1325,7 +1325,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1454,27 +1454,27 @@ msgstr "Impossível criar diretório para certificado do servidor"
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1626,7 +1626,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1759,83 +1759,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1979,7 +1980,7 @@ msgstr "Uso de disco:"
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -2004,7 +2005,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 #, fuzzy
 msgid "EXPIRES AT"
 msgstr "DATA DE VALIDADE"
@@ -2023,7 +2024,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 #, fuzzy
 msgid "Edit cluster member configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -2123,11 +2124,11 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2159,12 +2160,12 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -2243,7 +2244,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2407,11 +2408,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2419,7 +2420,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2435,7 +2436,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2459,7 +2460,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2537,7 +2538,7 @@ msgstr "Editar propriedades da imagem"
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Editar configurações de perfil como YAML"
@@ -2980,7 +2981,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -3022,7 +3023,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Nome de membro do cluster"
@@ -3032,7 +3033,7 @@ msgstr "Nome de membro do cluster"
 msgid "List all the cluster groups"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3364,7 +3365,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3596,17 +3597,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3663,7 +3664,7 @@ msgstr "Certificado fingerprint: %s"
 msgid "Missing cluster group name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3891,7 +3892,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -4085,7 +4086,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4256,7 +4257,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Nome de membro do cluster"
@@ -4278,7 +4279,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4461,7 +4462,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4545,7 +4546,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4627,7 +4628,7 @@ msgstr "Adicionar novos clientes confiáveis"
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4679,7 +4680,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4703,7 +4704,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Nome de membro do cluster"
@@ -4728,7 +4729,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Nome de membro do cluster"
@@ -4751,7 +4752,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Nome de membro do cluster"
@@ -4794,7 +4795,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4857,7 +4858,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5101,7 +5102,7 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show content of instance file templates"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5248,6 +5249,11 @@ msgstr ""
 #, fuzzy
 msgid "Show trust configurations"
 msgstr "Editar configurações do container ou do servidor como YAML"
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
+msgstr "Nome de membro do cluster"
 
 #: lxc/image.go:884 lxc/image.go:885
 msgid "Show useful information about images"
@@ -5403,7 +5409,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Ignorar o estado do container"
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5438,7 +5444,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5519,7 +5525,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Nome de membro do cluster"
@@ -5559,11 +5565,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 #, fuzzy
 msgid "This LXD server is not available on the network"
 msgstr "A importação de diretório não está disponível nessa plataforma"
@@ -5703,7 +5709,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5772,7 +5778,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5877,12 +5883,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5921,7 +5927,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6020,7 +6026,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -6033,12 +6039,12 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -6122,7 +6128,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -6267,8 +6273,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -6277,17 +6283,17 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr "Editar templates de arquivo do container"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6647,7 +6653,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr "Criar perfis"
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr "Editar templates de arquivo do container"
@@ -6699,7 +6705,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7021,7 +7027,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -561,7 +561,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -708,7 +708,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -888,7 +888,7 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %v"
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1229,7 +1229,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1244,7 +1244,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1274,7 +1274,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1315,7 +1315,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1444,27 +1444,27 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, fuzzy, c-format
 msgid "Could not find certificate file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, fuzzy, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, fuzzy, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, fuzzy, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr "Не удалось очистить путь %s"
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1617,7 +1617,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1747,83 +1747,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1967,7 +1968,7 @@ msgstr " Использование диска:"
 msgid "Display instances from all projects"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1992,7 +1993,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -2010,7 +2011,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -2103,11 +2104,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -2139,7 +2140,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 #, fuzzy
 msgid "Evacuate cluster member"
 msgstr ""
@@ -2147,7 +2148,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, fuzzy, c-format
 msgid "Evacuating cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -2231,7 +2232,7 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2395,11 +2396,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2407,7 +2408,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2423,7 +2424,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2447,7 +2448,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2524,7 +2525,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 #, fuzzy
 msgid "Get values for cluster member configuration keys"
 msgstr "Копирование образа: %s"
@@ -2968,7 +2969,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -3011,7 +3012,7 @@ msgstr "Псевдонимы:"
 msgid "List all active certificate add tokens"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 #, fuzzy
 msgid "List all active cluster member join tokens"
 msgstr "Копирование образа: %s"
@@ -3021,7 +3022,7 @@ msgstr "Копирование образа: %s"
 msgid "List all the cluster groups"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3360,7 +3361,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3593,17 +3594,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3661,7 +3662,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 #, fuzzy
 msgid "Missing cluster member name"
@@ -3893,7 +3894,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -4089,7 +4090,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -4262,7 +4263,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 #, fuzzy
 msgid "Please provide cluster member name: "
 msgstr "Копирование образа: %s"
@@ -4284,7 +4285,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4461,7 +4462,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4547,7 +4548,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4625,7 +4626,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4679,7 +4680,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4703,7 +4704,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 #, fuzzy
 msgid "Restore cluster member"
 msgstr "Копирование образа: %s"
@@ -4725,7 +4726,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, fuzzy, c-format
 msgid "Restoring cluster member: %s"
 msgstr "Копирование образа: %s"
@@ -4748,7 +4749,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr "Копирование образа: %s"
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 #, fuzzy
 msgid "Revoke cluster member join token"
 msgstr "Копирование образа: %s"
@@ -4791,7 +4792,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4854,7 +4855,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 #, fuzzy
 msgid "Set a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -5093,7 +5094,7 @@ msgstr "Копирование образа: %s"
 msgid "Show content of instance file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -5235,6 +5236,11 @@ msgstr ""
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 #, fuzzy
 msgid "Show trust configurations"
+msgstr "Копирование образа: %s"
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+#, fuzzy
+msgid "Show useful information about a cluster member"
 msgstr "Копирование образа: %s"
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -5395,7 +5401,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5430,7 +5436,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5506,7 +5512,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, fuzzy, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr "Копирование образа: %s"
@@ -5546,11 +5552,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5689,7 +5695,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5757,7 +5763,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 #, fuzzy
 msgid "Unset a cluster member's configuration keys"
 msgstr "Копирование образа: %s"
@@ -5856,12 +5862,12 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 #, fuzzy
 msgid "Update cluster certificate"
 msgstr "Принять сертификат"
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5900,7 +5906,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -6006,7 +6012,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -6026,7 +6032,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 #, fuzzy
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
@@ -6034,7 +6040,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 #, fuzzy
 msgid "[<remote>:] <name>"
 msgstr ""
@@ -6179,7 +6185,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 #, fuzzy
 msgid "[<remote>:]<cluster member>"
 msgstr ""
@@ -6448,8 +6454,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 #, fuzzy
 msgid "[<remote>:]<member>"
 msgstr ""
@@ -6465,7 +6471,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 #, fuzzy
 msgid "[<remote>:]<member> <key>"
 msgstr ""
@@ -6473,7 +6479,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 #, fuzzy
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
@@ -6481,7 +6487,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 #, fuzzy
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
@@ -7107,7 +7113,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 #, fuzzy
 msgid "[[<remote>:]<member>]"
 msgstr ""
@@ -7162,7 +7168,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -7484,7 +7490,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr "да"

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -312,7 +312,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -453,7 +453,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1175,27 +1175,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1453,83 +1453,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1667,7 +1668,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1692,7 +1693,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1710,7 +1711,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1796,11 +1797,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1832,11 +1833,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1915,7 +1916,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2079,11 +2080,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2107,7 +2108,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2131,7 +2132,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2208,7 +2209,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2677,7 +2678,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3012,7 +3013,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3223,17 +3224,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3287,7 +3288,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3505,7 +3506,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3699,7 +3700,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3870,7 +3871,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3891,7 +3892,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4068,7 +4069,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4151,7 +4152,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4223,7 +4224,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4274,7 +4275,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4297,7 +4298,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4316,7 +4317,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4338,7 +4339,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4380,7 +4381,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4443,7 +4444,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4673,7 +4674,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4803,6 +4804,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4958,7 +4963,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4993,7 +4998,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5069,7 +5074,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5109,11 +5114,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5251,7 +5256,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5319,7 +5324,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5408,11 +5413,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5450,7 +5455,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5548,7 +5553,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5560,11 +5565,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5637,7 +5642,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5774,8 +5779,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5783,15 +5788,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6168,7 +6173,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6490,7 +6495,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -312,7 +312,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -453,7 +453,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1175,27 +1175,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1453,83 +1453,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1667,7 +1668,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1692,7 +1693,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1710,7 +1711,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1796,11 +1797,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1832,11 +1833,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1915,7 +1916,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2079,11 +2080,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2107,7 +2108,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2131,7 +2132,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2208,7 +2209,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2677,7 +2678,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3012,7 +3013,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3223,17 +3224,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3287,7 +3288,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3505,7 +3506,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3699,7 +3700,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3870,7 +3871,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3891,7 +3892,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4068,7 +4069,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4151,7 +4152,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4223,7 +4224,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4274,7 +4275,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4297,7 +4298,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4316,7 +4317,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4338,7 +4339,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4380,7 +4381,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4443,7 +4444,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4673,7 +4674,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4803,6 +4804,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4958,7 +4963,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4993,7 +4998,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5069,7 +5074,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5109,11 +5114,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5251,7 +5256,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5319,7 +5324,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5408,11 +5413,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5450,7 +5455,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5548,7 +5553,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5560,11 +5565,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5637,7 +5642,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5774,8 +5779,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5783,15 +5788,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6168,7 +6173,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6490,7 +6495,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -308,7 +308,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -449,7 +449,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -958,7 +958,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -973,7 +973,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1003,7 +1003,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1044,7 +1044,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1171,27 +1171,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1328,7 +1328,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1449,83 +1449,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1663,7 +1664,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1688,7 +1689,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1706,7 +1707,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1792,11 +1793,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1828,11 +1829,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1911,7 +1912,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2075,11 +2076,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2087,7 +2088,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2103,7 +2104,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2127,7 +2128,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2204,7 +2205,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2632,7 +2633,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2673,7 +2674,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2681,7 +2682,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3008,7 +3009,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3219,17 +3220,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3283,7 +3284,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3501,7 +3502,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3695,7 +3696,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3866,7 +3867,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3887,7 +3888,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4064,7 +4065,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4147,7 +4148,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4219,7 +4220,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4270,7 +4271,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4293,7 +4294,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4312,7 +4313,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4334,7 +4335,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4376,7 +4377,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4439,7 +4440,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4669,7 +4670,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4799,6 +4800,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4954,7 +4959,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4989,7 +4994,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5065,7 +5070,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5105,11 +5110,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5247,7 +5252,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5315,7 +5320,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5404,11 +5409,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5446,7 +5451,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5544,7 +5549,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5556,11 +5561,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5633,7 +5638,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5770,8 +5775,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5779,15 +5784,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6113,7 +6118,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6164,7 +6169,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6486,7 +6491,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -312,7 +312,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -453,7 +453,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -977,7 +977,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1007,7 +1007,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1175,27 +1175,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1332,7 +1332,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1453,83 +1453,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1667,7 +1668,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1692,7 +1693,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1710,7 +1711,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1796,11 +1797,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1832,11 +1833,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1915,7 +1916,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2079,11 +2080,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2091,7 +2092,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2107,7 +2108,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2131,7 +2132,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2208,7 +2209,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2636,7 +2637,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2677,7 +2678,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2685,7 +2686,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3012,7 +3013,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3223,17 +3224,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3287,7 +3288,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3505,7 +3506,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3699,7 +3700,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3870,7 +3871,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3891,7 +3892,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4068,7 +4069,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4151,7 +4152,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4223,7 +4224,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4274,7 +4275,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4297,7 +4298,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4316,7 +4317,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4338,7 +4339,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4380,7 +4381,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4443,7 +4444,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4673,7 +4674,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4803,6 +4804,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4958,7 +4963,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4993,7 +4998,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5069,7 +5074,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5109,11 +5114,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5251,7 +5256,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5319,7 +5324,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5408,11 +5413,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5450,7 +5455,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5548,7 +5553,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5560,11 +5565,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5637,7 +5642,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5774,8 +5779,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5783,15 +5788,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6117,7 +6122,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6168,7 +6173,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6490,7 +6495,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -425,7 +425,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -566,7 +566,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -1090,7 +1090,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1120,7 +1120,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1161,7 +1161,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1288,27 +1288,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1445,7 +1445,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1566,83 +1566,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1780,7 +1781,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1805,7 +1806,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1823,7 +1824,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1909,11 +1910,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1945,11 +1946,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -2028,7 +2029,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2192,11 +2193,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2204,7 +2205,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2220,7 +2221,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2244,7 +2245,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2321,7 +2322,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2749,7 +2750,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2790,7 +2791,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2798,7 +2799,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3125,7 +3126,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3336,17 +3337,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3400,7 +3401,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3618,7 +3619,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3812,7 +3813,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3983,7 +3984,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -4004,7 +4005,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4181,7 +4182,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4264,7 +4265,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4336,7 +4337,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4387,7 +4388,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4410,7 +4411,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4429,7 +4430,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4451,7 +4452,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4493,7 +4494,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4556,7 +4557,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4786,7 +4787,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4916,6 +4917,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -5071,7 +5076,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -5106,7 +5111,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5182,7 +5187,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5222,11 +5227,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5364,7 +5369,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5432,7 +5437,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5521,11 +5526,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5563,7 +5568,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5661,7 +5666,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5673,11 +5678,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5750,7 +5755,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5887,8 +5892,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5896,15 +5901,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6230,7 +6235,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6281,7 +6286,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6603,7 +6608,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-12 16:28-0500\n"
+"POT-Creation-Date: 2023-01-16 14:20+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -311,7 +311,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/cluster.go:610
+#: lxc/cluster.go:663
 msgid ""
 "### This is a yaml representation of the cluster member.\n"
 "### Any line starting with a '# will be ignored."
@@ -452,7 +452,7 @@ msgstr ""
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/cluster.go:183 lxc/image.go:1060 lxc/list.go:555
+#: lxc/cluster.go:187 lxc/image.go:1060 lxc/list.go:555
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/cluster.go:1126
+#: lxc/cluster.go:1179
 #, c-format
 msgid "Are you sure you want to %s cluster member %q? (yes/no) [default=no]: "
 msgstr ""
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Cluster group %s renamed to %s"
 msgstr ""
 
-#: lxc/cluster.go:944
+#: lxc/cluster.go:997
 #, c-format
 msgid "Cluster join token for %s:%s deleted"
 msgstr ""
@@ -976,7 +976,7 @@ msgstr ""
 msgid "Cluster member %s removed from group %s"
 msgstr ""
 
-#: lxc/cluster.go:714 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479
 #: lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46
 #: lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713
 #: lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178
@@ -1006,7 +1006,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:584
+#: lxc/cluster.go:637
 msgid "Clustering enabled"
 msgstr ""
 
@@ -1047,7 +1047,7 @@ msgstr ""
 msgid "Config key/value to apply to the target instance"
 msgstr ""
 
-#: lxc/cluster.go:679 lxc/cluster_group.go:327 lxc/config.go:263
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263
 #: lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308
 #: lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582
 #: lxc/network_forward.go:597 lxc/network_load_balancer.go:600
@@ -1174,27 +1174,27 @@ msgstr ""
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/cluster.go:1008
+#: lxc/cluster.go:1061
 #, c-format
 msgid "Could not find certificate file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1012
+#: lxc/cluster.go:1065
 #, c-format
 msgid "Could not find certificate key file path: %s"
 msgstr ""
 
-#: lxc/cluster.go:1017
+#: lxc/cluster.go:1070
 #, c-format
 msgid "Could not read certificate file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1022
+#: lxc/cluster.go:1075
 #, c-format
 msgid "Could not read certificate key file: %s with error: %v"
 msgstr ""
 
-#: lxc/cluster.go:1039
+#: lxc/cluster.go:1092
 #, c-format
 msgid "Could not write new remote certificate for remote '%s' with error: %v"
 msgstr ""
@@ -1331,7 +1331,7 @@ msgstr ""
 msgid "DEFAULT TARGET ADDRESS"
 msgstr ""
 
-#: lxc/cluster.go:185 lxc/cluster_group.go:423 lxc/image.go:1059
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059
 #: lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964
 #: lxc/network_acl.go:149 lxc/network_forward.go:146
 #: lxc/network_load_balancer.go:149 lxc/network_peer.go:141
@@ -1452,83 +1452,84 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148
-#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:119 lxc/cluster.go:203
-#: lxc/cluster.go:252 lxc/cluster.go:299 lxc/cluster.go:351 lxc/cluster.go:380
-#: lxc/cluster.go:430 lxc/cluster.go:513 lxc/cluster.go:598 lxc/cluster.go:713
-#: lxc/cluster.go:784 lxc/cluster.go:886 lxc/cluster.go:965 lxc/cluster.go:1072
-#: lxc/cluster.go:1093 lxc/cluster_group.go:30 lxc/cluster_group.go:79
-#: lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255
-#: lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511
-#: lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48
-#: lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372
-#: lxc/config.go:464 lxc/config.go:622 lxc/config.go:742
-#: lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204
-#: lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446
-#: lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664
-#: lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55
-#: lxc/config_metadata.go:180 lxc/config_template.go:28
-#: lxc/config_template.go:68 lxc/config_template.go:111
-#: lxc/config_template.go:153 lxc/config_template.go:241
-#: lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88
-#: lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426
-#: lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645
-#: lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41
-#: lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168
-#: lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38
-#: lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491
-#: lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339
-#: lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586
-#: lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108
-#: lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29
-#: lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79
-#: lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33
-#: lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364
-#: lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710
-#: lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055
-#: lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237
-#: lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166
-#: lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314
-#: lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484
-#: lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713
-#: lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30
-#: lxc/network_forward.go:87 lxc/network_forward.go:168
-#: lxc/network_forward.go:232 lxc/network_forward.go:328
-#: lxc/network_forward.go:383 lxc/network_forward.go:461
-#: lxc/network_forward.go:488 lxc/network_forward.go:630
-#: lxc/network_forward.go:692 lxc/network_forward.go:707
-#: lxc/network_forward.go:772 lxc/network_load_balancer.go:30
-#: lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170
-#: lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330
-#: lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463
-#: lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633
-#: lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709
-#: lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859
-#: lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935
-#: lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159
-#: lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385
-#: lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606
-#: lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157
-#: lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340
-#: lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546
-#: lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721
-#: lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899
-#: lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100
-#: lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210
-#: lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105
-#: lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167
-#: lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414
-#: lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726
-#: lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30
-#: lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344
-#: lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622
-#: lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32
-#: lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625
-#: lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875
-#: lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28
-#: lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221
-#: lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636
-#: lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30
-#: lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
+#: lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207
+#: lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404
+#: lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651
+#: lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018
+#: lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30
+#: lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205
+#: lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440
+#: lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22
+#: lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30
+#: lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622
+#: lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78
+#: lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352
+#: lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551
+#: lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27
+#: lxc/config_metadata.go:55 lxc/config_metadata.go:180
+#: lxc/config_template.go:28 lxc/config_template.go:68
+#: lxc/config_template.go:111 lxc/config_template.go:153
+#: lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35
+#: lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344
+#: lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574
+#: lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31
+#: lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119
+#: lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968
+#: lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364
+#: lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020
+#: lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530
+#: lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61
+#: lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256
+#: lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25
+#: lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33
+#: lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217
+#: lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499
+#: lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891
+#: lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105
+#: lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30
+#: lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219
+#: lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397
+#: lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615
+#: lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728
+#: lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87
+#: lxc/network_forward.go:168 lxc/network_forward.go:232
+#: lxc/network_forward.go:328 lxc/network_forward.go:383
+#: lxc/network_forward.go:461 lxc/network_forward.go:488
+#: lxc/network_forward.go:630 lxc/network_forward.go:692
+#: lxc/network_forward.go:707 lxc/network_forward.go:772
+#: lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91
+#: lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234
+#: lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385
+#: lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490
+#: lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694
+#: lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773
+#: lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874
+#: lxc/network_load_balancer.go:935 lxc/network_peer.go:29
+#: lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216
+#: lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454
+#: lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29
+#: lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210
+#: lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400
+#: lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594
+#: lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771
+#: lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955
+#: lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149
+#: lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24
+#: lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185
+#: lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249
+#: lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540
+#: lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776
+#: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
+#: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
+#: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33
+#: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661
+#: lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
+#: lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343
+#: lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710
+#: lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84
+#: lxc/storage_bucket.go:184 lxc/storage_bucket.go:245
 #: lxc/storage_bucket.go:376 lxc/storage_bucket.go:442
 #: lxc/storage_bucket.go:517 lxc/storage_bucket.go:594
 #: lxc/storage_bucket.go:661 lxc/storage_bucket.go:692
@@ -1666,7 +1667,7 @@ msgstr ""
 msgid "Display instances from all projects"
 msgstr ""
 
-#: lxc/cluster.go:435
+#: lxc/cluster.go:488
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1691,7 +1692,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/cluster.go:870 lxc/config_trust.go:510
+#: lxc/cluster.go:923 lxc/config_trust.go:510
 msgid "EXPIRES AT"
 msgstr ""
 
@@ -1709,7 +1710,7 @@ msgstr ""
 msgid "Edit a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:597 lxc/cluster.go:598
+#: lxc/cluster.go:650 lxc/cluster.go:651
 msgid "Edit cluster member configurations as YAML"
 msgstr ""
 
@@ -1795,11 +1796,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:512
+#: lxc/cluster.go:565
 msgid "Enable clustering on a single non-clustered LXD server"
 msgstr ""
 
-#: lxc/cluster.go:513
+#: lxc/cluster.go:566
 msgid ""
 "Enable clustering on a single non-clustered LXD server\n"
 "\n"
@@ -1831,11 +1832,11 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/cluster.go:1071 lxc/cluster.go:1072
+#: lxc/cluster.go:1124 lxc/cluster.go:1125
 msgid "Evacuate cluster member"
 msgstr ""
 
-#: lxc/cluster.go:1151
+#: lxc/cluster.go:1204
 #, c-format
 msgid "Evacuating cluster member: %s"
 msgstr ""
@@ -1914,7 +1915,7 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/cluster.go:184
+#: lxc/cluster.go:188
 msgid "FAILURE DOMAIN"
 msgstr ""
 
@@ -2078,11 +2079,11 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/cluster.go:1074
+#: lxc/cluster.go:1127
 msgid "Force a particular evacuation action"
 msgstr ""
 
-#: lxc/cluster.go:1101
+#: lxc/cluster.go:1154
 msgid "Force evacuation without user confirmation"
 msgstr ""
 
@@ -2090,7 +2091,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:434
+#: lxc/cluster.go:487
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -2106,7 +2107,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:442
+#: lxc/cluster.go:495
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -2130,7 +2131,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:105 lxc/cluster.go:121 lxc/cluster.go:785
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838
 #: lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346
 #: lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158
 #: lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98
@@ -2207,7 +2208,7 @@ msgstr ""
 msgid "Get runtime information on networks"
 msgstr ""
 
-#: lxc/cluster.go:251
+#: lxc/cluster.go:304
 msgid "Get values for cluster member configuration keys"
 msgstr ""
 
@@ -2635,7 +2636,7 @@ msgstr ""
 msgid "LXD automatically uses either spicy or remote-viewer when present."
 msgstr ""
 
-#: lxc/cluster.go:155 lxc/cluster.go:819 lxc/cluster.go:913 lxc/cluster.go:1004
+#: lxc/cluster.go:159 lxc/cluster.go:872 lxc/cluster.go:966 lxc/cluster.go:1057
 #: lxc/cluster_group.go:404
 msgid "LXD server isn't part of a cluster"
 msgstr ""
@@ -2676,7 +2677,7 @@ msgstr ""
 msgid "List all active certificate add tokens"
 msgstr ""
 
-#: lxc/cluster.go:783 lxc/cluster.go:784
+#: lxc/cluster.go:836 lxc/cluster.go:837
 msgid "List all active cluster member join tokens"
 msgstr ""
 
@@ -2684,7 +2685,7 @@ msgstr ""
 msgid "List all the cluster groups"
 msgstr ""
 
-#: lxc/cluster.go:118 lxc/cluster.go:119
+#: lxc/cluster.go:122 lxc/cluster.go:123
 msgid "List all the cluster members"
 msgstr ""
 
@@ -3011,7 +3012,7 @@ msgstr ""
 msgid "MEMORY USAGE%"
 msgstr ""
 
-#: lxc/cluster.go:187
+#: lxc/cluster.go:191
 msgid "MESSAGE"
 msgstr ""
 
@@ -3222,17 +3223,17 @@ msgstr ""
 msgid "Member %q does not have role %q"
 msgstr ""
 
-#: lxc/cluster.go:764
+#: lxc/cluster.go:817
 #, c-format
 msgid "Member %s join token:"
 msgstr ""
 
-#: lxc/cluster.go:497
+#: lxc/cluster.go:550
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:410
+#: lxc/cluster.go:463
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -3286,7 +3287,7 @@ msgstr ""
 msgid "Missing cluster group name"
 msgstr ""
 
-#: lxc/cluster.go:631 lxc/cluster.go:1122 lxc/cluster_group.go:110
+#: lxc/cluster.go:684 lxc/cluster.go:1175 lxc/cluster_group.go:110
 #: lxc/cluster_group.go:464 lxc/cluster_role.go:70 lxc/cluster_role.go:124
 msgid "Missing cluster member name"
 msgstr ""
@@ -3504,7 +3505,7 @@ msgstr ""
 msgid "Must supply instance name for: "
 msgstr ""
 
-#: lxc/cluster.go:180 lxc/cluster.go:868 lxc/cluster_group.go:422
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422
 #: lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566
 #: lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
@@ -3698,7 +3699,7 @@ msgstr ""
 msgid "No certificate add token for member %s on remote: %s"
 msgstr ""
 
-#: lxc/cluster.go:951
+#: lxc/cluster.go:1004
 #, c-format
 msgid "No cluster join token for member %s on remote: %s"
 msgstr ""
@@ -3869,7 +3870,7 @@ msgstr ""
 msgid "Please provide client name: "
 msgstr ""
 
-#: lxc/cluster.go:738
+#: lxc/cluster.go:791
 msgid "Please provide cluster member name: "
 msgstr ""
 
@@ -3890,7 +3891,7 @@ msgstr ""
 msgid "Press ctrl+c to finish"
 msgstr ""
 
-#: lxc/cluster.go:680 lxc/cluster_group.go:328 lxc/config.go:264
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264
 #: lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207
 #: lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679
 #: lxc/network_acl.go:583 lxc/network_forward.go:598
@@ -4067,7 +4068,7 @@ msgstr ""
 msgid "ROLE"
 msgstr ""
 
-#: lxc/cluster.go:182
+#: lxc/cluster.go:186
 msgid "ROLES"
 msgstr ""
 
@@ -4150,7 +4151,7 @@ msgstr ""
 msgid "Remove a cluster member from a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:429 lxc/cluster.go:430
+#: lxc/cluster.go:482 lxc/cluster.go:483
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -4222,7 +4223,7 @@ msgstr ""
 msgid "Rename a cluster group"
 msgstr ""
 
-#: lxc/cluster.go:379 lxc/cluster.go:380
+#: lxc/cluster.go:432 lxc/cluster.go:433
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -4273,7 +4274,7 @@ msgstr ""
 msgid "Render: %s (%s)"
 msgstr ""
 
-#: lxc/cluster.go:712 lxc/cluster.go:713
+#: lxc/cluster.go:765 lxc/cluster.go:766
 msgid "Request a join token for adding a cluster member"
 msgstr ""
 
@@ -4296,7 +4297,7 @@ msgid ""
 "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/cluster.go:1092 lxc/cluster.go:1093
+#: lxc/cluster.go:1145 lxc/cluster.go:1146
 msgid "Restore cluster member"
 msgstr ""
 
@@ -4315,7 +4316,7 @@ msgstr ""
 msgid "Restore storage volume snapshots"
 msgstr ""
 
-#: lxc/cluster.go:1149
+#: lxc/cluster.go:1202
 #, c-format
 msgid "Restoring cluster member: %s"
 msgstr ""
@@ -4337,7 +4338,7 @@ msgstr ""
 msgid "Revoke certificate add token"
 msgstr ""
 
-#: lxc/cluster.go:885
+#: lxc/cluster.go:938
 msgid "Revoke cluster member join token"
 msgstr ""
 
@@ -4379,7 +4380,7 @@ msgstr ""
 msgid "SSH client disconnected %q"
 msgstr ""
 
-#: lxc/cluster.go:186 lxc/list.go:571 lxc/network.go:966
+#: lxc/cluster.go:190 lxc/list.go:571 lxc/network.go:966
 #: lxc/network_peer.go:143 lxc/storage.go:621
 msgid "STATE"
 msgstr ""
@@ -4442,7 +4443,7 @@ msgstr ""
 msgid "Server version: %s\n"
 msgstr ""
 
-#: lxc/cluster.go:298
+#: lxc/cluster.go:351
 msgid "Set a cluster member's configuration keys"
 msgstr ""
 
@@ -4672,7 +4673,7 @@ msgstr ""
 msgid "Show content of instance file templates"
 msgstr ""
 
-#: lxc/cluster.go:202 lxc/cluster.go:203
+#: lxc/cluster.go:206 lxc/cluster.go:207
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -4802,6 +4803,10 @@ msgstr ""
 
 #: lxc/config_trust.go:644 lxc/config_trust.go:645
 msgid "Show trust configurations"
+msgstr ""
+
+#: lxc/cluster.go:255 lxc/cluster.go:256
+msgid "Show useful information about a cluster member"
 msgstr ""
 
 #: lxc/image.go:884 lxc/image.go:885
@@ -4957,7 +4962,7 @@ msgstr ""
 msgid "Store the instance state"
 msgstr ""
 
-#: lxc/cluster.go:1044
+#: lxc/cluster.go:1097
 #, c-format
 msgid "Successfully updated cluster certificates for remote %s"
 msgstr ""
@@ -4992,7 +4997,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/cluster.go:869 lxc/config_trust.go:509
+#: lxc/cluster.go:922 lxc/config_trust.go:509
 msgid "TOKEN"
 msgstr ""
 
@@ -5068,7 +5073,7 @@ msgstr ""
 msgid "The instance you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/cluster.go:282
+#: lxc/cluster.go:335
 #, c-format
 msgid "The key %q does not exist on cluster member %q"
 msgstr ""
@@ -5108,11 +5113,11 @@ msgstr ""
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
-#: lxc/cluster.go:567
+#: lxc/cluster.go:620
 msgid "This LXD server is already clustered"
 msgstr ""
 
-#: lxc/cluster.go:557
+#: lxc/cluster.go:610
 msgid "This LXD server is not available on the network"
 msgstr ""
 
@@ -5250,7 +5255,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:181 lxc/remote.go:727
+#: lxc/cluster.go:185 lxc/remote.go:727
 msgid "URL"
 msgstr ""
 
@@ -5318,7 +5323,7 @@ msgstr ""
 msgid "Unknown output type %q"
 msgstr ""
 
-#: lxc/cluster.go:350
+#: lxc/cluster.go:403
 msgid "Unset a cluster member's configuration keys"
 msgstr ""
 
@@ -5407,11 +5412,11 @@ msgstr ""
 msgid "Up delay"
 msgstr ""
 
-#: lxc/cluster.go:964
+#: lxc/cluster.go:1017
 msgid "Update cluster certificate"
 msgstr ""
 
-#: lxc/cluster.go:966
+#: lxc/cluster.go:1019
 msgid ""
 "Update cluster certificate with PEM certificate and key read from input "
 "files."
@@ -5449,7 +5454,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:461 lxc/delete.go:48
+#: lxc/cluster.go:514 lxc/delete.go:48
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -5547,7 +5552,7 @@ msgstr ""
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/cluster.go:116 lxc/cluster.go:782 lxc/cluster_group.go:365
+#: lxc/cluster.go:120 lxc/cluster.go:835 lxc/cluster_group.go:365
 #: lxc/config_trust.go:341 lxc/config_trust.go:424 lxc/monitor.go:31
 #: lxc/network.go:888 lxc/network_acl.go:92 lxc/network_zone.go:83
 #: lxc/operation.go:102 lxc/profile.go:586 lxc/project.go:391
@@ -5559,11 +5564,11 @@ msgstr ""
 msgid "[<remote>:] <backup file> [<instance name>]"
 msgstr ""
 
-#: lxc/cluster.go:962
+#: lxc/cluster.go:1015
 msgid "[<remote>:] <cert.crt> <cert.key>"
 msgstr ""
 
-#: lxc/cluster.go:511 lxc/config_trust.go:572
+#: lxc/cluster.go:564 lxc/config_trust.go:572
 msgid "[<remote>:] <name>"
 msgstr ""
 
@@ -5636,7 +5641,7 @@ msgstr ""
 msgid "[<remote>:]<alias> <new-name>"
 msgstr ""
 
-#: lxc/cluster.go:596
+#: lxc/cluster.go:649
 msgid "[<remote>:]<cluster member>"
 msgstr ""
 
@@ -5773,8 +5778,8 @@ msgid ""
 "[<remote>:]<instance>[/<snapshot>] [[<remote>:]<instance>[/<snapshot>]...]"
 msgstr ""
 
-#: lxc/cluster.go:201 lxc/cluster.go:427 lxc/cluster.go:884 lxc/cluster.go:1070
-#: lxc/cluster.go:1091
+#: lxc/cluster.go:205 lxc/cluster.go:254 lxc/cluster.go:480 lxc/cluster.go:937
+#: lxc/cluster.go:1123 lxc/cluster.go:1144
 msgid "[<remote>:]<member>"
 msgstr ""
 
@@ -5782,15 +5787,15 @@ msgstr ""
 msgid "[<remote>:]<member> <group>"
 msgstr ""
 
-#: lxc/cluster.go:250 lxc/cluster.go:349
+#: lxc/cluster.go:303 lxc/cluster.go:402
 msgid "[<remote>:]<member> <key>"
 msgstr ""
 
-#: lxc/cluster.go:297
+#: lxc/cluster.go:350
 msgid "[<remote>:]<member> <key>=<value>..."
 msgstr ""
 
-#: lxc/cluster.go:377
+#: lxc/cluster.go:430
 msgid "[<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -6116,7 +6121,7 @@ msgstr ""
 msgid "[<remote>] <IP|FQDN|URL|token>"
 msgstr ""
 
-#: lxc/cluster.go:711
+#: lxc/cluster.go:764
 msgid "[[<remote>:]<member>]"
 msgstr ""
 
@@ -6167,7 +6172,7 @@ msgid ""
 "    Rename existing alias \"list\" to \"my-list\"."
 msgstr ""
 
-#: lxc/cluster.go:600
+#: lxc/cluster.go:653
 msgid ""
 "lxc cluster edit <cluster member> < member.yaml\n"
 "    Update a cluster member using the content of member.yaml"
@@ -6489,7 +6494,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:460 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
+#: lxc/cluster.go:513 lxc/delete.go:47 lxc/image.go:926 lxc/image.go:931
 #: lxc/image.go:1116
 msgid "yes"
 msgstr ""

--- a/shared/api/cluster_state.go
+++ b/shared/api/cluster_state.go
@@ -1,0 +1,28 @@
+package api
+
+// ClusterMemberSysInfo represents the sysinfo of a cluster member.
+//
+// swagger:model
+//
+// API extension: cluster_member_state.
+type ClusterMemberSysInfo struct {
+	Uptime       int64     `json:"uptime" yaml:"uptime"`
+	LoadAverages []float64 `json:"load_averages" yaml:"load_averages"`
+	TotalRAM     uint64    `json:"total_ram" yaml:"total_ram"`
+	FreeRAM      uint64    `json:"free_ram" yaml:"free_ram"`
+	SharedRAM    uint64    `json:"shared_ram" yaml:"shared_ram"`
+	BufferRAM    uint64    `json:"buffered_ram" yaml:"buffered_ram"`
+	TotalSwap    uint64    `json:"total_swap" yaml:"total_swap"`
+	FreeSwap     uint64    `json:"free_swap" yaml:"free_swap"`
+	Processes    uint16    `json:"processes" yaml:"processes"`
+}
+
+// ClusterMemberState represents the state of a cluster member.
+//
+// swagger:model
+//
+// API extension: cluster_member_state.
+type ClusterMemberState struct {
+	SysInfo      ClusterMemberSysInfo        `json:"sysinfo" yaml:"sysinfo"`
+	StoragePools map[string]StoragePoolState `json:"storage_pools" yaml:"storage_pools"`
+}

--- a/shared/api/storage_pool.go
+++ b/shared/api/storage_pool.go
@@ -89,3 +89,12 @@ type StoragePoolPut struct {
 func (storagePool *StoragePool) Writable() StoragePoolPut {
 	return storagePool.StoragePoolPut
 }
+
+// StoragePoolState represents the state of a storage pool.
+//
+// swagger:model
+//
+// API extension: cluster_member_state.
+type StoragePoolState struct {
+	ResourcesStoragePool `yaml:",inline"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -357,6 +357,7 @@ var APIExtensions = []string{
 	"cpu_hotplug",
 	"projects_networks_zones",
 	"network_txqueuelen",
+	"cluster_member_state",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -256,6 +256,10 @@ test_clustering_membership() {
   lxc network list cluster: | grep -q "${bridge}"
   lxc remote remove cluster
 
+  # Check info for single node (from local and remote node).
+  LXD_DIR="${LXD_FIVE_DIR}" lxc cluster info node5
+  LXD_DIR="${LXD_ONE_DIR}" lxc cluster info node5
+
   # Disable image replication
   LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.images_minimal_replica 1
 


### PR DESCRIPTION
Part of my work on https://github.com/lxc/lxd/pull/11180

Adds `GET /1.0/cluster/members/<member>/state` API endpoint for returning state info about the cluster member and its local storage pools.