### PR TITLE
lxc/migrate: Make live migration error message more helpful

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -44,6 +44,7 @@ import (
 	"github.com/lxc/lxd/lxd/lifecycle"
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/metrics"
+	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
@@ -4951,7 +4952,7 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 
 	_, err := exec.LookPath("criu")
 	if err != nil {
-		return fmt.Errorf("Unable to perform container live migration. CRIU isn't installed")
+		return migration.ErrNoLiveMigration
 	}
 
 	d.logger.Info("Migrating container", ctxMap)

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -58,7 +58,7 @@ func newMigrationSource(inst instance.Instance, stateful bool, instanceOnly bool
 		if inst.Type() == instancetype.Container {
 			_, err := exec.LookPath("criu")
 			if err != nil {
-				return nil, fmt.Errorf("Unable to perform container live migration. CRIU isn't installed on the source server")
+				return nil, migration.ErrNoLiveMigrationSource
 			}
 
 			ret.criuSecret, err = shared.RandomCryptoString()
@@ -795,9 +795,9 @@ func newMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {
 	if sink.src.instance.Type() == instancetype.Container {
 		_, err = exec.LookPath("criu")
 		if sink.push && sink.dest.live && err != nil {
-			return nil, fmt.Errorf("Unable to perform container live migration. CRIU isn't installed on the destination server")
+			return nil, migration.ErrNoLiveMigrationTarget
 		} else if sink.src.live && err != nil {
-			return nil, fmt.Errorf("Unable to perform container live migration. CRIU isn't installed on the destination server")
+			return nil, migration.ErrNoLiveMigrationTarget
 		}
 	}
 

--- a/lxd/migration/utils.go
+++ b/lxd/migration/utils.go
@@ -1,5 +1,9 @@
 package migration
 
+import (
+	"fmt"
+)
+
 // IndexHeaderVersion version of the index header to be sent/recv.
 const IndexHeaderVersion uint32 = 1
 
@@ -86,3 +90,14 @@ func (m *MigrationHeader) GetBtrfsFeaturesSlice() []string {
 
 	return features
 }
+
+const (
+	unableToLiveMigrate = "Unable to perform live container migration."
+	toMigrateLive       = "To migrate the container, stop the container before migration or install CRIU"
+)
+
+var (
+	ErrNoLiveMigrationSource = fmt.Errorf("%s CRIU isn't installed on the source server. %s on the source server", unableToLiveMigrate, toMigrateLive)
+	ErrNoLiveMigrationTarget = fmt.Errorf("%s CRIU isn't installed on the target server. %s on the target server", unableToLiveMigrate, toMigrateLive)
+	ErrNoLiveMigration       = fmt.Errorf("%s CRIU isn't installed. %s", unableToLiveMigrate, toMigrateLive)
+)


### PR DESCRIPTION
Signed-off-by: kayos@tcp.direct <kayos@tcp.direct>