### PR TITLE
Instance: Container shutdown edge case fixes

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -123,8 +123,8 @@ func (c *cmdAction) Command(action string) *cobra.Command {
 	}
 
 	if shared.StringInSlice(action, []string{"restart", "stop"}) {
-		cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force the instance to shutdown"))
-		cmd.Flags().IntVar(&c.flagTimeout, "timeout", -1, i18n.G("Time to wait for the instance before killing it")+"``")
+		cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force the instance to stop"))
+		cmd.Flags().IntVar(&c.flagTimeout, "timeout", -1, i18n.G("Time to wait for the instance to shutdown cleanly")+"``")
 	}
 
 	return cmd

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -2955,6 +2955,9 @@ func evacuateClusterSetState(d *Daemon, name string, state int) error {
 	return nil
 }
 
+// evacuateHostShutdownDefaultTimeout default timeout (in seconds) for waiting for clean shutdown to complete.
+const evacuateHostShutdownDefaultTimeout = 30
+
 func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Response {
 	s := d.State()
 
@@ -3039,7 +3042,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 				timeout := inst.ExpandedConfig()["boot.host_shutdown_timeout"]
 				val, err := strconv.Atoi(timeout)
 				if err != nil {
-					val = 30
+					val = evacuateHostShutdownDefaultTimeout
 				}
 
 				// Start with a clean shutdown.
@@ -3281,7 +3284,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 				timeout := inst.ExpandedConfig()["boot.host_shutdown_timeout"]
 				val, err := strconv.Atoi(timeout)
 				if err != nil {
-					val = 30
+					val = evacuateHostShutdownDefaultTimeout
 				}
 
 				// Attempt a clean stop.

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3246,6 +3246,8 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 
 		// Migrate back the remote instances.
 		for _, inst := range instances {
+			l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
+
 			// Check if live-migratable.
 			_, live := inst.CanMigrate()
 
@@ -3296,6 +3298,8 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 				// Wait for the stop operation to complete or timeout.
 				err = stopOp.Wait()
 				if err != nil {
+					l.Warn("Failed shutting down instance, forcing stop", logger.Ctx{"err": err})
+
 					// On failure, attempt a forceful stop.
 					stopOp, err = source.UpdateInstanceState(inst.Name(), api.InstanceStatePut{Action: "stop", Force: true}, "")
 					if err != nil {
@@ -3305,7 +3309,7 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 
 					// Wait for the forceful stop to complete.
 					err = stopOp.Wait()
-					if err != nil {
+					if err != nil && !strings.Contains(err.Error(), "The instance is already stopped") {
 						return fmt.Errorf("Failed to stop instance %q: %w", inst.Name(), err)
 					}
 				}

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -924,6 +924,8 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 		}
 
 		op.SetInstanceInitiated(true)
+	} else {
+		d.logger.Debug("Instance operation lock inherited for stop", logger.Ctx{"action": op.Action()})
 	}
 
 	return op, nil

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6721,6 +6721,22 @@ func (d *lxc) NextIdmap() (*idmap.IdmapSet, error) {
 
 // statusCode returns instance status code.
 func (d *lxc) statusCode() api.StatusCode {
+	// Shortcut to avoid spamming liblxc during ongoing operations.
+	op := operationlock.Get(d.Project().Name, d.Name())
+	if op != nil {
+		if op.Action() == operationlock.ActionStart {
+			return api.Stopped
+		}
+
+		if op.Action() == operationlock.ActionStop {
+			if shared.IsTrue(d.LocalConfig()["volatile.last_state.ready"]) {
+				return api.Ready
+			}
+
+			return api.Running
+		}
+	}
+
 	state, err := d.getLxcState()
 	if err != nil {
 		return api.Error

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5896,7 +5896,7 @@ func (d *lxc) networkState(hostInterfaces []net.Interface) map[string]api.Instan
 		nw, err := netutils.NetnsGetifaddrs(int32(pid), hostInterfaces)
 		if err != nil {
 			couldUseNetnsGetifaddrs = false
-			d.logger.Error("Failed to retrieve network information via netlink", logger.Ctx{"pid": pid})
+			d.logger.Warn("Failed to retrieve network information via netlink", logger.Ctx{"pid": pid})
 		} else {
 			result = nw
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2843,10 +2843,12 @@ func (d *lxc) onStopNS(args map[string]string) error {
 	}
 
 	// Create/pick up operation, but don't complete it as we leave operation running for the onStop hook below.
-	_, err := d.onStopOperationSetup(target)
+	op, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
+
+	_ = op.Reset()
 
 	// Clean up devices.
 	d.cleanupDevices(false, netns)
@@ -2871,6 +2873,8 @@ func (d *lxc) onStop(args map[string]string) error {
 		return err
 	}
 
+	_ = op.Reset()
+
 	// Make sure we can't call go-lxc functions by mistake
 	d.fromHook = true
 
@@ -2891,8 +2895,8 @@ func (d *lxc) onStop(args map[string]string) error {
 		// Unlock on return
 		defer op.Done(nil)
 
-		// Wait for other post-stop actions to be done and the container actually stopping.
-		d.IsRunning()
+		_ = op.ResetTimeout(operationlock.TimeoutShutdown)
+
 		d.logger.Debug("Container stopped, cleaning up")
 
 		// Wait for any file operations to complete.
@@ -2916,8 +2920,6 @@ func (d *lxc) onStop(args map[string]string) error {
 		}
 
 		// Stop the storage for this container
-		waitTimeout := operationlock.TimeoutShutdown
-		_ = op.ResetTimeout(waitTimeout)
 		err = d.unmount()
 		if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 			err = fmt.Errorf("Failed unmounting instance: %w", err)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6020,11 +6020,11 @@ func (d *qemu) statusCode() api.StatusCode {
 	// Shortcut to avoid spamming QMP during ongoing operations.
 	op := operationlock.Get(d.Project().Name, d.Name())
 	if op != nil {
-		if op.Action() == "start" {
+		if op.Action() == operationlock.ActionStart {
 			return api.Stopped
 		}
 
-		if op.Action() == "stop" {
+		if op.Action() == operationlock.ActionStop {
 			if shared.IsTrue(d.LocalConfig()["volatile.last_state.ready"]) {
 				return api.Ready
 			}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -678,18 +678,6 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 		return err
 	}
 
-	// Get the wait channel.
-	chDisconnect, err := monitor.Wait()
-	if err != nil {
-		if err == qmp.ErrMonitorDisconnect {
-			op.Done(nil)
-			return nil
-		}
-
-		op.Done(err)
-		return err
-	}
-
 	// Send the system_powerdown command.
 	err = monitor.Powerdown()
 	if err != nil {
@@ -704,32 +692,15 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 
 	d.logger.Debug("Shutdown request sent to instance")
 
-	var timeoutCh <-chan time.Time // If no timeout specified, will be nil, and a nil channel always blocks.
-	if timeout > 0 {
-		timeoutCh = time.After(timeout)
+	// Use default operation timeout if not specified (negatively or positively).
+	if timeout == 0 {
+		timeout = operationlock.TimeoutDefault
 	}
 
-	// Setup ticker that is half the timeout of operationlock.TimeoutDefault.
-	ticker := time.NewTicker(operationlock.TimeoutDefault / 2)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-chDisconnect:
-			// VM monitor disconnected, VM is on the way to stopping, now wait for onStop() to finish.
-		case <-timeoutCh:
-			// User specified timeout has elapsed without VM stopping.
-			err = fmt.Errorf("Instance was not shutdown after timeout")
-			op.Done(err)
-		case <-ticker.C:
-			// Keep the operation alive so its around for onStop() if the instance takes longer than
-			// the default operationlock.TimeoutDefault that the operation is kept alive for.
-			if op.Reset() == nil {
-				continue
-			}
-		}
-
-		break
+	// Extend operation lock for the requested timeout.
+	err = op.ResetTimeout(timeout)
+	if err != nil {
+		return err
 	}
 
 	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -2471,7 +2471,7 @@ msgstr ""
 
 #: lxc/action.go:126
 #, fuzzy
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/delete.go:35
@@ -5729,7 +5729,7 @@ msgstr ""
 
 #: lxc/action.go:127
 #, fuzzy
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
 #: lxc/image.go:949

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -2115,7 +2115,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5209,7 +5209,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2380,8 +2380,9 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
-msgstr ""
+#, fuzzy
+msgid "Force the instance to stop"
+msgstr "Creando el contenedor"
 
 #: lxc/delete.go:35
 msgid "Force the removal of running instances"
@@ -5513,7 +5514,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -2505,7 +2505,7 @@ msgstr ""
 
 #: lxc/action.go:126
 #, fuzzy
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr "Forcer le conteneur à s'arrêter"
 
 #: lxc/delete.go:35
@@ -5865,7 +5865,7 @@ msgstr ""
 
 #: lxc/action.go:127
 #, fuzzy
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
 #: lxc/image.go:949

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -2097,7 +2097,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5139,7 +5139,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2370,8 +2370,9 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
-msgstr ""
+#, fuzzy
+msgid "Force the instance to stop"
+msgstr "Creazione del container in corso"
 
 #: lxc/delete.go:35
 msgid "Force the removal of running instances"
@@ -5507,7 +5508,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -2407,7 +2407,8 @@ msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+#, fuzzy
+msgid "Force the instance to stop"
 msgstr "インスタンスを強制シャットダウンします"
 
 #: lxc/delete.go:35
@@ -5742,7 +5743,8 @@ msgid "Threads:"
 msgstr "スレッド:"
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+#, fuzzy
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr "インスタンスを強制停止するまで待つ時間"
 
 #: lxc/image.go:949

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2023-01-16 14:20+0000\n"
+        "POT-Creation-Date: 2023-01-20 15:06+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1891,7 +1891,7 @@ msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
 #: lxc/action.go:126
-msgid   "Force the instance to shutdown"
+msgid   "Force the instance to stop"
 msgstr  ""
 
 #: lxc/delete.go:35
@@ -4766,7 +4766,7 @@ msgid   "Threads:"
 msgstr  ""
 
 #: lxc/action.go:127
-msgid   "Time to wait for the instance before killing it"
+msgid   "Time to wait for the instance to shutdown cleanly"
 msgstr  ""
 
 #: lxc/image.go:949

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -2313,7 +2313,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5355,7 +5355,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2347,7 +2347,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5389,7 +5389,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -2425,8 +2425,9 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
-msgstr ""
+#, fuzzy
+msgid "Force the instance to stop"
+msgstr "Ignorar o estado do container"
 
 #: lxc/delete.go:35
 msgid "Force the removal of running instances"
@@ -5591,7 +5592,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2413,8 +2413,9 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
-msgstr ""
+#, fuzzy
+msgid "Force the instance to stop"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/delete.go:35
 msgid "Force the removal of running instances"
@@ -5577,7 +5578,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -2097,7 +2097,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5139,7 +5139,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -2097,7 +2097,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5139,7 +5139,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -2093,7 +2093,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5135,7 +5135,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -2097,7 +2097,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5139,7 +5139,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -2210,7 +2210,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5252,7 +5252,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-16 14:20+0000\n"
+"POT-Creation-Date: 2023-01-20 15:06+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -2096,7 +2096,7 @@ msgid "Force removing a member, even if degraded"
 msgstr ""
 
 #: lxc/action.go:126
-msgid "Force the instance to shutdown"
+msgid "Force the instance to stop"
 msgstr ""
 
 #: lxc/delete.go:35
@@ -5138,7 +5138,7 @@ msgid "Threads:"
 msgstr ""
 
 #: lxc/action.go:127
-msgid "Time to wait for the instance before killing it"
+msgid "Time to wait for the instance to shutdown cleanly"
 msgstr ""
 
 #: lxc/image.go:949

--- a/test/suites/container_devices_unix.sh
+++ b/test/suites/container_devices_unix.sh
@@ -96,14 +96,14 @@ test_container_devices_unix() {
   lxc start "${ctName}"
   ! ls "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev
   mknod "${testDev}" "${deviceTypeCode}" 0 0
-  sleep 0.5
+  sleep 1
   lxc exec "${ctName}" -- mount | grep "/tmp/testdev"
   lxc exec "${ctName}" -- stat -c '%F %a %t %T' /tmp/testdev | grep "${deviceTypeDesc} 660 0 0"
   stat -c '%F %a %t %T' "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev | grep "${deviceTypeDesc} 660 0 0"
 
   # Remove host side device and check it is dynamically removed from instance.
   rm "${testDev}"
-  sleep 0.5
+  sleep 1
   ! lxc exec "${ctName}" -- mount | grep "/tmp/testdev"
   ! lxc exec "${ctName}" -- ls /tmp/testdev
   ! ls "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev
@@ -112,7 +112,7 @@ test_container_devices_unix() {
   shutdown_lxd "${LXD_DIR}"
   respawn_lxd "${LXD_DIR}" true
   mknod "${testDev}" "${deviceTypeCode}" 0 0
-  sleep 0.5
+  sleep 1
   lxc exec "${ctName}" -- mount | grep "/tmp/testdev"
   lxc exec "${ctName}" -- stat -c '%F %a %t %T' /tmp/testdev | grep "${deviceTypeDesc} 660 0 0"
   stat -c '%F %a %t %T' "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev | grep "${deviceTypeDesc} 660 0 0"
@@ -128,14 +128,14 @@ test_container_devices_unix() {
 
   mkdir "${testDev}"
   mknod "${testDevSubDir}" "${deviceTypeCode}" 0 0
-  sleep 0.5
+  sleep 1
   lxc exec "${ctName}" -- mount | grep "/tmp/testdev"
   lxc exec "${ctName}" -- stat -c '%F %a %t %T' /tmp/testdev | grep "${deviceTypeDesc} 660 0 0"
   stat -c '%F %a %t %T' "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev | grep "${deviceTypeDesc} 660 0 0"
 
   # Cleanup.
   rm -rvf "${testDev}"
-  sleep 0.5
+  sleep 1
   ! lxc exec "${ctName}" -- mount | grep "/tmp/testdev"
   ! lxc exec "${ctName}" -- ls /tmp/testdev
   ! ls "${LXD_DIR}"/devices/"${ctName}"/unix.test--dev--dynamic.tmp-testdev
@@ -147,7 +147,7 @@ test_container_devices_unix() {
   lxc launch testimage "${ctName}2"
   lxc config device add "${ctName}2" test-dev-dynamic "${deviceType}" required=false source="${testDev}" path=/tmp/testdev2
   mknod "${testDev}" "${deviceTypeCode}" 0 0
-  sleep 0.5
+  sleep 1
   lxc exec "${ctName}1" -- mount | grep "/tmp/testdev1"
   lxc exec "${ctName}1" -- stat -c '%F %a %t %T' /tmp/testdev1 | grep "${deviceTypeDesc} 660 0 0"
   stat -c '%F %a %t %T' "${LXD_DIR}"/devices/"${ctName}"1/unix.test--dev--dynamic.tmp-testdev1 | grep "${deviceTypeDesc} 660 0 0"
@@ -159,7 +159,7 @@ test_container_devices_unix() {
   # instance was stopped. This checks the removal logic when multiple containers share watch path.
   lxc stop -f "${ctName}1"
   rm "${testDev}"
-  sleep 0.5
+  sleep 1
   ! lxc exec "${ctName}2" -- mount | grep "/tmp/testdev2"
   ! lxc exec "${ctName}2" -- ls /tmp/testdev2
   ! ls "${LXD_DIR}"/devices/"${ctName}"2/unix.test--dev--dynamic.tmp-testdev2


### PR DESCRIPTION
As part of diagnosing the evacuation test failures when `d.c.Stop()` seems to take much longer than it should (sometimes) I also made some additional changes to the container shutdown and stop processes in order to squash some edge case issues and spend less time in liblxc.

Adds support for non-expiring operation locks, and avoids the need for a go routine that runs and periodically extends the lock.





Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>