### PR TITLE
Add mipsle and mips64le architecture aliases

### DIFF
--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -49,8 +49,8 @@ var architectureAliases = map[int][]string{
 	ARCH_32BIT_POWERPC_BIG_ENDIAN:    {"powerpc"},
 	ARCH_64BIT_POWERPC_BIG_ENDIAN:    {"powerpc64", "ppc64"},
 	ARCH_64BIT_POWERPC_LITTLE_ENDIAN: {"ppc64el"},
-	ARCH_32BIT_MIPS:                  {"mipsel"},
-	ARCH_64BIT_MIPS:                  {"mips64el"},
+	ARCH_32BIT_MIPS:                  {"mipsel", "mipsle"},
+	ARCH_64BIT_MIPS:                  {"mips64el", "mips64le"},
 	ARCH_32BIT_RISCV_LITTLE_ENDIAN:   {},
 	ARCH_64BIT_RISCV_LITTLE_ENDIAN:   {},
 }


### PR DESCRIPTION
Debian's mips architectures are reported as "mipsle" and "mips64le". Add them to the list of architecture aliases, otherwise we get an error like:

```
panic: Architecture isn't supported: mips64le

goroutine 1 [running]:
github.com/lxc/lxd/shared/version.getUserAgent()
	github.com/lxc/lxd/shared/version/useragent.go:22 +0x72c
github.com/lxc/lxd/shared/version.init()
	github.com/lxc/lxd/shared/version/useragent.go:15 +0x38
```