### PR TITLE
drivers: Unify allowed filesystems variable

### DIFF
--- a/lxd/storage/drivers/driver_ceph.go
+++ b/lxd/storage/drivers/driver_ceph.go
@@ -18,7 +18,6 @@ import (
 	"github.com/lxc/lxd/shared/validate"
 )
 
-var cephAllowedFilesystems = []string{"btrfs", "ext4", "xfs"}
 var cephVersion string
 var cephLoaded bool
 

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -813,7 +813,7 @@ func (d *ceph) FillVolumeConfig(vol Volume) error {
 // commonVolumeRules returns validation rules which are common for pool and volume.
 func (d *ceph) commonVolumeRules() map[string]func(value string) error {
 	return map[string]func(value string) error{
-		"block.filesystem":    validate.Optional(validate.IsOneOf(cephAllowedFilesystems...)),
+		"block.filesystem":    validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
 		"block.mount_options": validate.IsAny,
 	}
 }

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -24,8 +24,6 @@ const lvmVgPoolMarker = "lxd_pool" // Indicator tag used to mark volume groups a
 var lvmLoaded bool
 var lvmVersion string
 
-var lvmAllowedFilesystems = []string{"btrfs", "ext4", "xfs"}
-
 type lvm struct {
 	common
 }

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -293,7 +293,7 @@ func (d *lvm) FillVolumeConfig(vol Volume) error {
 func (d *lvm) commonVolumeRules() map[string]func(value string) error {
 	return map[string]func(value string) error{
 		"block.mount_options": validate.IsAny,
-		"block.filesystem":    validate.Optional(validate.IsOneOf(lvmAllowedFilesystems...)),
+		"block.filesystem":    validate.Optional(validate.IsOneOf(blockBackedAllowedFilesystems...)),
 		"lvm.stripes":         validate.Optional(validate.IsUint32),
 		"lvm.stripes.size":    validate.Optional(validate.IsSize),
 	}

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -22,6 +22,9 @@ import (
 // MinBlockBoundary minimum block boundary size to use.
 const MinBlockBoundary = 8192
 
+// blockBackedAllowedFilesystems allowed filesystems for block volumes.
+var blockBackedAllowedFilesystems = []string{"btrfs", "ext4", "xfs"}
+
 // wipeDirectory empties the contents of a directory, but leaves it in place.
 func wipeDirectory(path string) error {
 	// List all entries.


### PR DESCRIPTION
This drops the `{lvm,ceph}AllowedFilesystems` variables in favor of
`blockBackedAllowedFilesystems`.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
