### PR TITLE
Device: Allow all multicast to fix IPv6 NDP for `macvlan` NICs in VMs

### DIFF
--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 	"net/http"
+	"os"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
@@ -11,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/network"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -201,6 +203,19 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 		err = macvtap.Add()
 		if err != nil {
 			return nil, err
+		}
+
+		// Enable all multicast processing which is required for IPv6 NDP functionality.
+		link := &ip.Link{Name: saveData["host_name"]}
+		err = link.SetAllMulticast(true)
+		if err != nil {
+			return nil, fmt.Errorf("Failed setting all multicast on %q: %w", link.Name, err)
+		}
+
+		// Disable IPv6 on host interface to avoid getting IPv6 link-local addresses unnecessarily.
+		err = util.SysctlSet(fmt.Sprintf("net/ipv6/conf/%s/disable_ipv6", link.Name), "1")
+		if err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("Failed to disable IPv6 on host interface %q: %w", link.Name, err)
 		}
 	}
 

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -97,6 +97,18 @@ func (l *Link) SetAddress(address string) error {
 	return nil
 }
 
+// SetAllMulticast when enabled instructs network driver to retrieve all multicast packets from the network to the
+// kernel for further processing.
+func (l *Link) SetAllMulticast(enabled bool) error {
+	mode := "off"
+	if enabled {
+		mode = "on"
+	}
+
+	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "allmulticast", mode)
+	return err
+}
+
 // SetMaster sets the master of the link device.
 func (l *Link) SetMaster(master string) error {
 	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "master", master)


### PR DESCRIPTION
Previously IPv6 for `macvlan` NICs on VMs only (coincidentally) worked for SLAAC addresses.

This is because the host interface still had IPv6 enabled and so was generating its own link-local address which was in the
same multicast group required for SLAAC address NDP operation.

However if the guest used a non-SLAAC address (static or DHCPv6 stateful) because the host interface did not know about this the NDP solication didn't work and the address was unreachable.

This disables IPv6 on the host-side to ensure there are no IPv6 addresses at all on the host interface, and instead enables all multicast processing to allow the guest to configure any IP it wants.

This aligns with the macvlan behaviour for containers, where because we pass the host interface directly into the container, any addresses added to the guest interface are known about by the host and the correct multicast groups are joined for NDP to work.

Reported from https://discuss.linuxcontainers.org/t/macvlan-and-multicast-between-host-and-guest/16158/2 (and I also encountered it coincidentally a few days earlier as well).