### PR TITLE
Device: Fix `disk` device `raw.mount.options` setting

### DIFF
--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -93,13 +93,14 @@ func IsBlockdev(path string) bool {
 }
 
 // DiskMount mounts a disk device.
-func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, propagation string, mountOptions []string, fsName string) error {
+func DiskMount(srcPath string, dstPath string, recursive bool, propagation string, mountOptions []string, fsName string) error {
 	var err error
 
-	// Prepare the mount flags
-	flags := 0
-	if readonly {
-		flags |= unix.MS_RDONLY
+	flags, mountOptionsStr := filesystem.ResolveMountOptions(mountOptions)
+
+	var readonly bool
+	if shared.StringInSlice("ro", mountOptions) {
+		readonly = true
 	}
 
 	// Detect the filesystem
@@ -135,7 +136,7 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 	}
 
 	// Mount the filesystem
-	err = unix.Mount(srcPath, dstPath, fsName, uintptr(flags), strings.Join(mountOptions, ","))
+	err = unix.Mount(srcPath, dstPath, fsName, uintptr(flags), mountOptionsStr)
 	if err != nil {
 		return fmt.Errorf("Unable to mount %q at %q with filesystem %q: %w", srcPath, dstPath, fsName, err)
 	}

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -236,7 +236,7 @@ func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath stri
 
 		_ = f.Close()
 
-		err = DiskMount(srcPath, devPath, false, false, "", nil, "none")
+		err = DiskMount(srcPath, devPath, false, "", nil, "none")
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1355,8 +1355,12 @@ func (d *disk) createDevice(srcPath string) (func(), string, bool, error) {
 		}
 	}
 
+	if isReadOnly {
+		mntOptions = append(mntOptions, "ro")
+	}
+
 	// Mount the fs.
-	err := DiskMount(srcPath, devPath, isReadOnly, isRecursive, d.config["propagation"], mntOptions, fsName)
+	err := DiskMount(srcPath, devPath, isRecursive, d.config["propagation"], mntOptions, fsName)
 	if err != nil {
 		return nil, "", false, err
 	}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1245,7 +1245,7 @@ func (d *disk) createDevice(srcPath string) (func(), string, bool, error) {
 	isReadOnly := shared.IsTrue(d.config["readonly"])
 	isRecursive := shared.IsTrue(d.config["recursive"])
 
-	mntOptions := shared.SplitNTrimSpace(d.config["raw.mount.options"], "-", -1, true)
+	mntOptions := shared.SplitNTrimSpace(d.config["raw.mount.options"], ",", -1, true)
 	fsName := "none"
 
 	var isFile bool

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1153,7 +1153,7 @@ func (d *qemu) Start(stateful bool) error {
 	// Mount the config drive device as readonly. This way it will be readonly irrespective of whether its
 	// exported via 9p for virtio-fs.
 	configSrcPath := filepath.Join(d.Path(), "config")
-	err = device.DiskMount(configSrcPath, configMntPath, true, false, "", nil, "none")
+	err = device.DiskMount(configSrcPath, configMntPath, false, "", []string{"ro"}, "none")
 	if err != nil {
 		return fmt.Errorf("Failed mounting device mount path %q for config drive: %w", configMntPath, err)
 	}

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -305,7 +305,7 @@ func (d *btrfs) Update(changedConfig map[string]string) error {
 
 	// Trigger a re-mount.
 	d.config["btrfs.mount_options"] = val
-	mntFlags, mntOptions := resolveMountOptions(d.getMountOptions())
+	mntFlags, mntOptions := filesystem.ResolveMountOptions(strings.Split(d.getMountOptions(), ","))
 	mntFlags |= unix.MS_REMOUNT
 
 	err := TryMount("", GetPoolMountPath(d.name), "none", mntFlags, mntOptions)
@@ -355,7 +355,7 @@ func (d *btrfs) Mount() (bool, error) {
 	}
 
 	// Get the custom mount flags/options.
-	mntFlags, mntOptions := resolveMountOptions(d.getMountOptions())
+	mntFlags, mntOptions := filesystem.ResolveMountOptions(strings.Split(d.getMountOptions(), ","))
 
 	// Handle bind-mounts first.
 	if mntFilesystem == "none" {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1172,7 +1172,7 @@ func (d *ceph) MountVolume(vol Volume, op *operations.Operation) error {
 				}
 			}
 
-			mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
+			mountFlags, mountOptions := filesystem.ResolveMountOptions(strings.Split(vol.ConfigBlockMountOptions(), ","))
 			err = TryMount(volDevPath, mountPath, fsType, mountFlags, mountOptions)
 			if err != nil {
 				return err
@@ -1611,7 +1611,7 @@ func (d *ceph) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) err
 		revert.Add(func() { _ = d.rbdUnmapVolume(cloneVol, true) })
 
 		RBDFilesystem := snapVol.ConfigBlockFilesystem()
-		mountFlags, mountOptions := resolveMountOptions(snapVol.ConfigBlockMountOptions())
+		mountFlags, mountOptions := filesystem.ResolveMountOptions(strings.Split(snapVol.ConfigBlockMountOptions(), ","))
 
 		if renegerateFilesystemUUIDNeeded(RBDFilesystem) {
 			if RBDFilesystem == "xfs" {

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -643,7 +643,7 @@ func (d *lvm) MountVolume(vol Volume, op *operations.Operation) error {
 				return err
 			}
 
-			mountFlags, mountOptions := resolveMountOptions(vol.ConfigBlockMountOptions())
+			mountFlags, mountOptions := filesystem.ResolveMountOptions(strings.Split(vol.ConfigBlockMountOptions(), ","))
 			err = TryMount(volDevPath, mountPath, fsType, mountFlags, mountOptions)
 			if err != nil {
 				return fmt.Errorf("Failed to mount LVM logical volume: %w", err)
@@ -936,7 +936,7 @@ func (d *lvm) MountVolumeSnapshot(snapVol Volume, op *operations.Operation) erro
 		// Default to mounting the original snapshot directly. This may be changed below if a temporary
 		// snapshot needs to be taken.
 		mountVol := snapVol
-		mountFlags, mountOptions := resolveMountOptions(mountVol.ConfigBlockMountOptions())
+		mountFlags, mountOptions := filesystem.ResolveMountOptions(strings.Split(mountVol.ConfigBlockMountOptions(), ","))
 
 		// Regenerate filesystem UUID if needed. This is because some filesystems do not allow mounting
 		// multiple volumes that share the same UUID. As snapshotting a volume will copy its UUID we need

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -412,68 +412,6 @@ func makeFSType(path string, fsType string, options *mkfsOptions) (string, error
 	return "", nil
 }
 
-// mountOption represents an individual mount option.
-type mountOption struct {
-	capture bool
-	flag    uintptr
-}
-
-// mountOptions represents a list of possible mount options.
-var mountOptions = map[string]mountOption{
-	"async":         {false, unix.MS_SYNCHRONOUS},
-	"atime":         {false, unix.MS_NOATIME},
-	"bind":          {true, unix.MS_BIND},
-	"defaults":      {true, 0},
-	"dev":           {false, unix.MS_NODEV},
-	"diratime":      {false, unix.MS_NODIRATIME},
-	"dirsync":       {true, unix.MS_DIRSYNC},
-	"exec":          {false, unix.MS_NOEXEC},
-	"lazytime":      {true, unix.MS_LAZYTIME},
-	"mand":          {true, unix.MS_MANDLOCK},
-	"noatime":       {true, unix.MS_NOATIME},
-	"nodev":         {true, unix.MS_NODEV},
-	"nodiratime":    {true, unix.MS_NODIRATIME},
-	"noexec":        {true, unix.MS_NOEXEC},
-	"nomand":        {false, unix.MS_MANDLOCK},
-	"norelatime":    {false, unix.MS_RELATIME},
-	"nostrictatime": {false, unix.MS_STRICTATIME},
-	"nosuid":        {true, unix.MS_NOSUID},
-	"rbind":         {true, unix.MS_BIND | unix.MS_REC},
-	"relatime":      {true, unix.MS_RELATIME},
-	"remount":       {true, unix.MS_REMOUNT},
-	"ro":            {true, unix.MS_RDONLY},
-	"rw":            {false, unix.MS_RDONLY},
-	"strictatime":   {true, unix.MS_STRICTATIME},
-	"suid":          {false, unix.MS_NOSUID},
-	"sync":          {true, unix.MS_SYNCHRONOUS},
-}
-
-// resolveMountOptions resolves the provided mount options.
-func resolveMountOptions(options string) (uintptr, string) {
-	mountFlags := uintptr(0)
-	tmp := strings.SplitN(options, ",", -1)
-	for i := 0; i < len(tmp); i++ {
-		opt := tmp[i]
-		do, ok := mountOptions[opt]
-		if !ok {
-			continue
-		}
-
-		if do.capture {
-			mountFlags |= do.flag
-		} else {
-			mountFlags &= ^do.flag
-		}
-
-		copy(tmp[i:], tmp[i+1:])
-		tmp[len(tmp)-1] = ""
-		tmp = tmp[:len(tmp)-1]
-		i--
-	}
-
-	return mountFlags, strings.Join(tmp, ",")
-}
-
 // filesystemTypeCanBeShrunk indicates if filesystems of fsType can be shrunk.
 func filesystemTypeCanBeShrunk(fsType string) bool {
 	if fsType == "" {


### PR DESCRIPTION
- Fixes separator character from `-` to `,` of `raw.mount.options` setting.
- Updates `DiskMount` to separate mount flags from mount options when calling the `mount` syscall.
- Removes redundant `readonly` argument to `DiskMount`, and instead expects callers to use the existing `mountOptions` argument. 

Fixes #11303 