### PR TITLE
client: fix cast to http.Transport when using TransportWrapper

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -49,7 +49,7 @@ type ConnectionArgs struct {
 	HTTPClient *http.Client
 
 	// TransportWrapper wraps the *http.Transport set by lxd
-	TransportWrapper func(*http.Transport) http.RoundTripper
+	TransportWrapper func(*http.Transport) HTTPTransporter
 
 	// Controls whether a client verifies the server's certificate chain and host name.
 	InsecureSkipVerify bool

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1356,7 +1356,10 @@ func (r *ProtocolLXD) DeleteInstanceFile(instanceName string, filePath string) e
 // rawSFTPConn connects to the apiURL, upgrades to an SFTP raw connection and returns it.
 func (r *ProtocolLXD) rawSFTPConn(apiURL *url.URL) (net.Conn, error) {
 	// Get the HTTP transport.
-	httpTransport := r.http.Transport.(*http.Transport)
+	httpTransport, err := r.getUnderlyingHTTPTransport()
+	if err != nil {
+		return nil, err
+	}
 
 	req := &http.Request{
 		Method:     http.MethodGet,
@@ -1375,7 +1378,6 @@ func (r *ProtocolLXD) rawSFTPConn(apiURL *url.URL) (net.Conn, error) {
 
 	// Establish the connection.
 	var conn net.Conn
-	var err error
 
 	if httpTransport.TLSClientConfig != nil {
 		conn, err = httpTransport.DialTLSContext(context.Background(), "tcp", apiURL.Host)

--- a/client/util.go
+++ b/client/util.go
@@ -13,7 +13,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, proxy func(req *http.Request) (*url.URL, error), transportWrapper func(t *http.Transport) http.RoundTripper) (*http.Client, error) {
+func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, proxy func(req *http.Request) (*url.URL, error), transportWrapper func(t *http.Transport) HTTPTransporter) (*http.Client, error) {
 	// Get the TLS configuration
 	tlsConfig, err := shared.GetTLSConfigMem(tlsClientCert, tlsClientKey, tlsCA, tlsServerCert, insecureSkipVerify)
 	if err != nil {
@@ -231,4 +231,13 @@ func parseFilters(filters []string) string {
 		}
 	}
 	return strings.Join(result, " and ")
+}
+
+// HTTPTransporter represents a wrapper around *http.Transport.
+// It is used to add some pre and postprocessing logic to http requests / responses.
+type HTTPTransporter interface {
+	http.RoundTripper
+
+	// Transport what this struct wraps
+	Transport() *http.Transport
 }


### PR DESCRIPTION
On this [PR](https://github.com/lxc/lxd/pull/11318) I added a way to wrap the http transport of the http client.
I only noticed later that there were 2 places where the http client transport was cast to `*http.Transport`.

This PR adds a func to get the http transport, with or without the wrapper.

Signed-off-by: Sebastiao Pamplona <sebastiaodsrp@gmail.com>