### PR TITLE
`StarlarkMarshal` improvements

### DIFF
--- a/lxd/scriptlet/starlark.go
+++ b/lxd/scriptlet/starlark.go
@@ -26,14 +26,6 @@ func StarlarkMarshal(input any) (starlark.Value, error) {
 		}
 	}
 
-	{
-		r, ok := input.(rune)
-		if ok {
-			// NB: runes are indistinguishable from int32s.
-			return starlark.String(string(r)), nil
-		}
-	}
-
 	v, ok := input.(reflect.Value)
 	if !ok {
 		v = reflect.ValueOf(input)
@@ -42,7 +34,7 @@ func StarlarkMarshal(input any) (starlark.Value, error) {
 	switch v.Type().Kind() {
 	case reflect.String:
 		sv = starlark.String(v.String())
-	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int64:
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
 		sv = starlark.MakeInt(int(v.Int()))
 	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
 		sv = starlark.MakeUint(uint(v.Uint()))

--- a/lxd/scriptlet/starlark.go
+++ b/lxd/scriptlet/starlark.go
@@ -19,13 +19,19 @@ func StarlarkMarshal(input any) (starlark.Value, error) {
 		return starlark.None, nil
 	}
 
-	if value, ok := input.(starlark.Value); ok {
-		return value, nil
+	{
+		value, ok := input.(starlark.Value)
+		if ok {
+			return value, nil
+		}
 	}
 
-	if r, ok := input.(rune); ok {
-		// NB: runes are indistinguishable from int32s.
-		return starlark.String(string(r)), nil
+	{
+		r, ok := input.(rune)
+		if ok {
+			// NB: runes are indistinguishable from int32s.
+			return starlark.String(string(r)), nil
+		}
 	}
 
 	v, ok := input.(reflect.Value)
@@ -71,6 +77,7 @@ func StarlarkMarshal(input any) (starlark.Value, error) {
 		sort.Slice(mKeys, func(i, j int) bool {
 			return mKeys[i].String() < mKeys[j].String()
 		})
+
 		for _, k := range mKeys {
 			mv := v.MapIndex(k)
 			dv, err := StarlarkMarshal(mv)

--- a/lxd/scriptlet/starlark_test.go
+++ b/lxd/scriptlet/starlark_test.go
@@ -68,6 +68,9 @@ func TestStarlarkMarshal(t *testing.T) {
 		from: int16(-1),
 		to:   starlark.MakeInt(-1),
 	}, {
+		from: int32(-1),
+		to:   starlark.MakeInt(-1),
+	}, {
 		from: int64(-1),
 		to:   starlark.MakeInt(-1),
 	}, {
@@ -97,9 +100,6 @@ func TestStarlarkMarshal(t *testing.T) {
 			return &v
 		}(),
 		to: starlark.MakeInt(1),
-	}, {
-		from: 'a',
-		to:   starlark.String("a"),
 	}, {
 		from: "foo",
 		to:   starlark.String("foo"),

--- a/lxd/scriptlet/starlark_test.go
+++ b/lxd/scriptlet/starlark_test.go
@@ -123,6 +123,9 @@ func TestStarlarkMarshal(t *testing.T) {
 			return starlark.NewList([]starlark.Value{s1, s2})
 		}(),
 	}, {
+		from: map[string]string{},
+		to:   starlark.NewDict(0),
+	}, {
 		from: map[string]string{"a": "b", "c": "d"},
 		to: func() starlark.Value {
 			ret := starlark.NewDict(1)

--- a/lxd/scriptlet/starlark_test.go
+++ b/lxd/scriptlet/starlark_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/lxc/lxd/lxd/scriptlet"
 	"go.starlark.net/starlark"
+
+	"github.com/lxc/lxd/lxd/scriptlet"
 )
 
 type starlarkMarshalTest struct {


### PR DESCRIPTION
Improve `StarlarkMarshal` dict key handling, interface handling and embedding and conversion of values which already implement `starlark.Value`. Modified `rune` conversion to produce length-1 strings rather than integers.

Added unit tests for `StarlarkMarshal`.
