### PR TITLE
Instance: Updates instance_placement scriptlet function to accept both project and reason as part of `request`

### DIFF
--- a/doc/explanation/clustering.md
+++ b/doc/explanation/clustering.md
@@ -170,18 +170,17 @@ It is also possible for the scriptlet to request information about each candidat
 
 An instance placement scriptlet must implement the `instance_placement` function with the following signature:
 
-   `instance_placement(reason, request, candidate_members)`:
+   `instance_placement(request, candidate_members)`:
 
-- `reason` will be a `string` indicating the reason for the instance placement request (`new`, `evacuation`, `relocation`).
-- `request` will be a `dict` containing an expanded representation of [`api.InstancesPost`](https://pkg.go.dev/github.com/lxc/lxd/shared/api#InstancesPost).
+- `request` will be a `dict` containing an expanded representation of [`scriptlet.InstancePlacement`](https://pkg.go.dev/github.com/lxc/lxd/shared/api/scriptlet/#InstancePlacement). This request includes `project` and `reason` fields. The `reason` can be `new`, `evacuation` or `relocation`.
 - `candidate_members` will be a `list` of cluster member `dicts` representing [`api.ClusterMember`](https://pkg.go.dev/github.com/lxc/lxd/shared/api#ClusterMember) entries.
 
 For example:
 
 ```python
-def instance_placement(reason, request, candidate_members):
+def instance_placement(request, candidate_members):
     # Example of logging info, this will appear in LXD's log.
-    log_info("instance placement started: ", reason, request)
+    log_info("instance placement started: ", request)
 
     # Example of applying logic based on the instance request.
     if request["name"] == "foo":

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3014,7 +3014,8 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 		ctx := context.TODO()
 
 		for _, inst := range instances {
-			l := logger.AddContext(logger.Log, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
+			instProject := inst.Project()
+			l := logger.AddContext(logger.Log, logger.Ctx{"project": instProject.Name, "instance": inst.Name()})
 
 			// Check if migratable.
 			migrate, live := inst.CanMigrate()
@@ -3036,7 +3037,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 			// Stop the instance if needed.
 			isRunning := inst.IsRunning()
 			if isRunning && !(migrate && live) {
-				metadata["evacuation_progress"] = fmt.Sprintf("Stopping %q in project %q", inst.Name(), inst.Project().Name)
+				metadata["evacuation_progress"] = fmt.Sprintf("Stopping %q in project %q", inst.Name(), instProject.Name)
 				_ = op.UpdateMetadata(metadata)
 
 				// Get the shutdown timeout for the instance.
@@ -3054,7 +3055,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 					// Fallback to forced stop.
 					err = inst.Stop(false)
 					if err != nil && !errors.Is(err, instanceDrivers.ErrInstanceIsStopped) {
-						return fmt.Errorf("Failed to stop instance %q: %w", inst.Name(), err)
+						return fmt.Errorf("Failed to stop instance %q in project %q: %w", inst.Name(), instProject.Name, err)
 					}
 				}
 
@@ -3150,7 +3151,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 			}
 
 			// Start migrating the instance.
-			metadata["evacuation_progress"] = fmt.Sprintf("Migrating %q in project %q to %q", inst.Name(), inst.Project().Name, targetMemberInfo.Name)
+			metadata["evacuation_progress"] = fmt.Sprintf("Migrating %q in project %q to %q", inst.Name(), instProject.Name, targetMemberInfo.Name)
 			_ = op.UpdateMetadata(metadata)
 
 			// Set origin server (but skip if already set as that suggests more than one server being evacuated).
@@ -3166,7 +3167,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 
 			err = migrateInstance(d, r, inst, targetMemberInfo.Name, false, req, op)
 			if err != nil {
-				return fmt.Errorf("Failed to migrate instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
+				return fmt.Errorf("Failed to migrate instance %q in project %q: %w", inst.Name(), instProject.Name, err)
 			}
 
 			if !isRunning || live {
@@ -3176,12 +3177,12 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 			// Start it back up on target.
 			dest, err := cluster.Connect(targetMemberInfo.Address, d.endpoints.NetworkCert(), d.serverCert(), r, true)
 			if err != nil {
-				return fmt.Errorf("Failed to connect to destination %q for instance %q in project %q: %w", targetMemberInfo.Address, inst.Name(), inst.Project().Name, err)
+				return fmt.Errorf("Failed to connect to destination %q for instance %q in project %q: %w", targetMemberInfo.Address, inst.Name(), instProject.Name, err)
 			}
 
 			dest = dest.UseProject(inst.Project().Name)
 
-			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), inst.Project().Name)
+			metadata["evacuation_progress"] = fmt.Sprintf("Starting %q in project %q", inst.Name(), instProject.Name)
 			_ = op.UpdateMetadata(metadata)
 
 			startOp, err := dest.UpdateInstanceState(inst.Name(), api.InstanceStatePut{Action: "start"}, "")

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -39,6 +39,7 @@ import (
 	"github.com/lxc/lxd/lxd/warnings"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	apiScriptlet "github.com/lxc/lxd/shared/api/scriptlet"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/validate"
@@ -3100,13 +3101,17 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 				}
 
 				// Copy request so we don't modify it when expanding the config.
-				reqExpanded := api.InstancesPost{
-					Name: inst.Name(),
-					Type: api.InstanceType(inst.Type().String()),
-					InstancePut: api.InstancePut{
-						Config:  inst.ExpandedConfig(),
-						Devices: inst.ExpandedDevices().CloneNative(),
+				reqExpanded := apiScriptlet.InstancePlacement{
+					InstancesPost: api.InstancesPost{
+						Name: inst.Name(),
+						Type: api.InstanceType(inst.Type().String()),
+						InstancePut: api.InstancePut{
+							Config:  inst.ExpandedConfig(),
+							Devices: inst.ExpandedDevices().CloneNative(),
+						},
 					},
+					Project: instProject.Name,
+					Reason:  scriptlet.InstancePlacementReasonEvacuation,
 				}
 
 				reqExpanded.Architecture, err = osarch.ArchitectureName(inst.Architecture())

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3116,7 +3116,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 
 				reqExpanded.Architecture, err = osarch.ArchitectureName(inst.Architecture())
 				if err != nil {
-					return fmt.Errorf("Failed getting architecture for instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
+					return fmt.Errorf("Failed getting architecture for instance %q in project %q: %w", inst.Name(), instProject.Name, err)
 				}
 
 				for _, p := range inst.Profiles() {
@@ -3124,10 +3124,10 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 				}
 
 				ctx, cancel := context.WithTimeout(ctx, time.Second*5)
-				targetMemberInfo, err = scriptlet.InstancePlacementRun(ctx, logger.Log, s, scriptlet.InstancePlacementReasonEvacuation, &reqExpanded, candidateMembers, leaderAddress)
+				targetMemberInfo, err = scriptlet.InstancePlacementRun(ctx, logger.Log, s, &reqExpanded, candidateMembers, leaderAddress)
 				if err != nil {
 					cancel()
-					return fmt.Errorf("Failed instance placement scriptlet for instance %q in project %q: %w", inst.Name(), inst.Project().Name, err)
+					return fmt.Errorf("Failed instance placement scriptlet for instance %q in project %q: %w", inst.Name(), instProject.Name, err)
 				}
 
 				cancel()

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3111,7 +3111,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 						},
 					},
 					Project: instProject.Name,
-					Reason:  scriptlet.InstancePlacementReasonEvacuation,
+					Reason:  apiScriptlet.InstancePlacementReasonEvacuation,
 				}
 
 				reqExpanded.Architecture, err = osarch.ArchitectureName(inst.Architecture())

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -1027,16 +1027,9 @@ func internalGC(d *Daemon, r *http.Request) response.Response {
 }
 
 func internalRAFTSnapshot(d *Daemon, r *http.Request) response.Response {
-	logger.Infof("Started forced RAFT snapshot")
-	err := d.gateway.Snapshot()
-	if err != nil {
-		logger.Errorf("Failed forced RAFT snapshot: %v", err)
-		return response.InternalError(err)
-	}
+	logger.Warn("Forced RAFT snapshot not supported")
 
-	logger.Infof("Completed forced RAFT snapshot")
-
-	return response.EmptySyncResponse
+	return response.InternalError(fmt.Errorf("Not supported"))
 }
 
 func internalBGPState(d *Daemon, r *http.Request) response.Response {

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -337,15 +337,6 @@ func (g *Gateway) HandlerFuncs(heartbeatHandler HeartbeatHandler, trustedCerts f
 	}
 }
 
-// Snapshot can be used to manually trigger a RAFT snapshot.
-func (g *Gateway) Snapshot() error {
-	g.lock.RLock()
-	defer g.lock.RUnlock()
-
-	// TODO: implement support for forcing a snapshot in dqlite v1
-	return fmt.Errorf("Not supported")
-}
-
 // WaitUpgradeNotification waits for a notification from another node that all
 // nodes in the cluster should now have been upgraded and have matching schema
 // and API versions.

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1134,7 +1134,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			reqExpanded := apiScriptlet.InstancePlacement{
 				InstancesPost: req,
 				Project:       targetProjectName,
-				Reason:        scriptlet.InstancePlacementReasonNew,
+				Reason:        apiScriptlet.InstancePlacementReasonNew,
 			}
 
 			reqExpanded.Config = db.ExpandInstanceConfig(reqExpanded.Config, profiles)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -34,6 +34,7 @@ import (
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	apiScriptlet "github.com/lxc/lxd/shared/api/scriptlet"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
 )
@@ -1130,11 +1131,16 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			// Copy request so we don't modify it when expanding the config.
-			reqExpanded := req
+			reqExpanded := apiScriptlet.InstancePlacement{
+				InstancesPost: req,
+				Project:       targetProjectName,
+				Reason:        scriptlet.InstancePlacementReasonNew,
+			}
+
 			reqExpanded.Config = db.ExpandInstanceConfig(reqExpanded.Config, profiles)
 			reqExpanded.Devices = db.ExpandInstanceDevices(deviceConfig.NewDevices(reqExpanded.Devices), profiles).CloneNative()
 
-			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, scriptlet.InstancePlacementReasonNew, &reqExpanded, candidateMembers, leaderAddress)
+			targetMemberInfo, err = scriptlet.InstancePlacementRun(r.Context(), logger.Log, s, &reqExpanded, candidateMembers, leaderAddress)
 			if err != nil {
 				return response.SmartError(fmt.Errorf("Failed instance placement scriptlet: %w", err))
 			}

--- a/lxd/scriptlet/instance_placement.go
+++ b/lxd/scriptlet/instance_placement.go
@@ -353,11 +353,11 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("Failed to start: %w", err)
+		return nil, fmt.Errorf("Failed to run: %w", err)
 	}
 
 	if v.Type() != "NoneType" {
-		return nil, fmt.Errorf("Failed with return value: %v", v)
+		return nil, fmt.Errorf("Failed with unexpected return value: %v", v)
 	}
 
 	return targetMember, nil

--- a/lxd/scriptlet/instance_placement.go
+++ b/lxd/scriptlet/instance_placement.go
@@ -22,15 +22,6 @@ import (
 	"github.com/lxc/lxd/shared/units"
 )
 
-// InstancePlacementReasonNew is when a new instance request is received.
-const InstancePlacementReasonNew = "new"
-
-// InstancePlacementReasonRelocation is when an existing instance is temporarily migrated because a cluster member is down.
-const InstancePlacementReasonRelocation = "relocation"
-
-// InstancePlacementReasonEvacuation is when an existing instance is temporarily migrated because a cluster member is being evacuated.
-const InstancePlacementReasonEvacuation = "evacuation"
-
 // InstancePlacementRun runs the instance placement scriptlet and returns the chosen cluster member target.
 func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, req *apiScriptlet.InstancePlacement, candidateMembers []db.NodeInfo, leaderAddress string) (*db.NodeInfo, error) {
 	ctx, cancel := context.WithCancel(ctx)

--- a/lxd/scriptlet/instance_placement.go
+++ b/lxd/scriptlet/instance_placement.go
@@ -32,7 +32,7 @@ const InstancePlacementReasonRelocation = "relocation"
 const InstancePlacementReasonEvacuation = "evacuation"
 
 // InstancePlacementRun runs the instance placement scriptlet and returns the chosen cluster member target.
-func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, reason string, req *api.InstancesPost, candidateMembers []db.NodeInfo, leaderAddress string) (*db.NodeInfo, error) {
+func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, req *apiScriptlet.InstancePlacement, candidateMembers []db.NodeInfo, leaderAddress string) (*db.NodeInfo, error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -353,10 +353,6 @@ func InstancePlacementRun(ctx context.Context, l logger.Logger, s *state.State, 
 
 	// Call starlark function from Go.
 	v, err := starlark.Call(thread, instancePlacement, nil, []starlark.Tuple{
-		{
-			starlark.String("reason"),
-			starlark.String(reason),
-		},
 		{
 			starlark.String("request"),
 			rv,

--- a/lxd/scriptlet/starlark.go
+++ b/lxd/scriptlet/starlark.go
@@ -3,6 +3,7 @@ package scriptlet
 import (
 	"fmt"
 	"reflect"
+	"sort"
 	"strings"
 
 	"go.starlark.net/starlark"
@@ -52,6 +53,17 @@ func StarlarkMarshal(input any) (starlark.Value, error) {
 	case reflect.Map:
 		mKeys := v.MapKeys()
 		d := starlark.NewDict(len(mKeys))
+
+		for _, k := range mKeys {
+			kind := k.Kind()
+			if kind != reflect.String {
+				return nil, fmt.Errorf("Only string keys are supported, found %s", kind)
+			}
+		}
+
+		sort.Slice(mKeys, func(i, j int) bool {
+			return mKeys[i].String() < mKeys[j].String()
+		})
 
 		for _, k := range v.MapKeys() {
 			mv := v.MapIndex(k)

--- a/lxd/scriptlet/starlark.go
+++ b/lxd/scriptlet/starlark.go
@@ -11,8 +11,16 @@ import (
 // StarlarkMarshal converts input to a starlark Value.
 // It only includes exported struct fields, and uses the "json" tag for field names.
 func StarlarkMarshal(input any) (starlark.Value, error) {
+	if input == nil {
+		return starlark.None, nil
+	}
+
+	sv, ok := input.(starlark.Value)
+	if ok {
+		return sv, nil
+	}
+
 	var err error
-	var sv starlark.Value
 
 	v := reflect.ValueOf(input)
 
@@ -27,7 +35,7 @@ func StarlarkMarshal(input any) (starlark.Value, error) {
 		sv = starlark.Float(v.Float())
 	case reflect.Bool:
 		sv = starlark.Bool(v.Bool())
-	case reflect.Slice:
+	case reflect.Array, reflect.Slice:
 		vlen := v.Len()
 		listElems := make([]starlark.Value, 0, vlen)
 

--- a/lxd/scriptlet/starlark_test.go
+++ b/lxd/scriptlet/starlark_test.go
@@ -1,0 +1,173 @@
+package scriptlet_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.starlark.net/starlark"
+
+	"github.com/lxc/lxd/lxd/scriptlet"
+)
+
+type starlarkMarshalTest struct {
+	from      any
+	to        starlark.Value
+	errPrefix string
+}
+
+type DummyStringer int
+
+var _ fmt.Stringer = DummyStringer(0)
+
+func (DummyStringer) String() string { return "(DummyStringer)" }
+
+func TestStarlarkMarshal(t *testing.T) {
+	type DummyEmbeddedStruct struct {
+		A string
+	}
+
+	for i, scenario := range []starlarkMarshalTest{{
+		from: starlark.MakeInt(-1),
+		to:   starlark.MakeInt(-1),
+	}, {
+		from: nil,
+		to:   starlark.None,
+	}, {
+		from: true,
+		to:   starlark.True,
+	}, {
+		from: int(-1),
+		to:   starlark.MakeInt(-1),
+	}, {
+		from: int8(-1),
+		to:   starlark.MakeInt(-1),
+	}, {
+		from: int16(-1),
+		to:   starlark.MakeInt(-1),
+	}, {
+		from: int32(-1),
+		to:   starlark.MakeInt(-1),
+	}, {
+		from: int64(-1),
+		to:   starlark.MakeInt(-1),
+	}, {
+		from: uint(1),
+		to:   starlark.MakeInt(1),
+	}, {
+		from: uint8(1),
+		to:   starlark.MakeInt(1),
+	}, {
+		from: uint16(1),
+		to:   starlark.MakeInt(1),
+	}, {
+		from: uint32(1),
+		to:   starlark.MakeInt(1),
+	}, {
+		from: uint64(1),
+		to:   starlark.MakeInt(1),
+	}, {
+		from: float32(0.5),
+		to:   starlark.Float(0.5),
+	}, {
+		from: float64(0.5),
+		to:   starlark.Float(0.5),
+	}, {
+		from: func() any {
+			v := 1
+			return &v
+		}(),
+		to: starlark.MakeInt(1),
+	}, {
+		from: 'a',
+		to:   starlark.MakeInt(97), // runes are indistinguishable from int32s.
+	}, {
+		from: "foo",
+		to:   starlark.String("foo"),
+	}, {
+		from: []bool{true, false},
+		to:   starlark.NewList([]starlark.Value{starlark.True, starlark.False}),
+	}, {
+		from: [...]bool{true, false},
+		to:   starlark.NewList([]starlark.Value{starlark.True, starlark.False}),
+	}, {
+		from: []struct{ A, B string }{{A: "a1", B: "b1"}, {A: "a2", B: "b2"}},
+		to: func() starlark.Value {
+			s1 := starlark.NewDict(2)
+			assert.NoError(t, s1.SetKey(starlark.String("A"), starlark.String("a1")))
+			assert.NoError(t, s1.SetKey(starlark.String("B"), starlark.String("b1")))
+
+			s2 := starlark.NewDict(2)
+			assert.NoError(t, s2.SetKey(starlark.String("A"), starlark.String("a2")))
+			assert.NoError(t, s2.SetKey(starlark.String("B"), starlark.String("b2")))
+
+			return starlark.NewList([]starlark.Value{s1, s2})
+		}(),
+	}, {
+		from: map[string]string{"a": "b", "c": "d"},
+		to: func() starlark.Value {
+			ret := starlark.NewDict(1)
+			assert.NoError(t, ret.SetKey(starlark.String("a"), starlark.String("b")))
+			assert.NoError(t, ret.SetKey(starlark.String("c"), starlark.String("d")))
+			return ret
+		}(),
+	}, {
+		from:      map[int]string{1: "1", 2: "2"},
+		errPrefix: "Only string keys are supported, found int",
+	}, {
+		from:      map[*int]string{nil: "a"},
+		errPrefix: "Only string keys are supported, found ptr",
+	}, {
+		from: struct {
+			A string `json:"foo"`
+			B string `json:"bar"`
+		}{A: "a", B: "b"},
+		to: func() starlark.Value {
+			ret := starlark.NewDict(2)
+			assert.NoError(t, ret.SetKey(starlark.String("foo"), starlark.String("a")))
+			assert.NoError(t, ret.SetKey(starlark.String("bar"), starlark.String("b")))
+			return ret
+		}(),
+	}, {
+		from: struct{ DummyEmbeddedStruct }{DummyEmbeddedStruct: DummyEmbeddedStruct{A: "a"}},
+		to: func() starlark.Value {
+			ret := starlark.NewDict(1)
+			assert.NoError(t, ret.SetKey(starlark.String("A"), starlark.String("a")))
+			return ret
+		}(),
+	}, {
+		from: struct{ fmt.Stringer }{Stringer: DummyStringer(0xbaa)},
+		to: func() starlark.Value {
+			ret := starlark.NewDict(1)
+			assert.NoError(t, ret.SetKey(starlark.String("Stringer"), starlark.MakeInt(0xbaa)))
+			return ret
+		}(),
+	}, {
+		from: struct {
+			fmt.Stringer `json:"foo"`
+		}{Stringer: DummyStringer(0xbaa)},
+		to: func() starlark.Value {
+			ret := starlark.NewDict(1)
+			assert.NoError(t, ret.SetKey(starlark.String("foo"), starlark.MakeInt(0xbaa)))
+			return ret
+		}(),
+	}, {
+		from:      func() {},
+		errPrefix: "Unrecognised type func()",
+	}, {
+		from:      make(chan int),
+		errPrefix: "Unrecognised type chan int",
+	}} {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			sv, err := scriptlet.StarlarkMarshal(scenario.from)
+			if scenario.errPrefix == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.True(t, strings.HasPrefix(err.Error(), scenario.errPrefix))
+			}
+
+			assert.Equal(t, scenario.to, sv)
+		})
+	}
+}

--- a/shared/api/scriptlet/instance.go
+++ b/shared/api/scriptlet/instance.go
@@ -1,5 +1,18 @@
 package scriptlet
 
+import (
+	"github.com/lxc/lxd/shared/api"
+)
+
+// InstancePlacementReasonNew is when a new instance request is received.
+const InstancePlacementReasonNew = "new"
+
+// InstancePlacementReasonRelocation is when an existing instance is temporarily migrated because a cluster member is down.
+const InstancePlacementReasonRelocation = "relocation"
+
+// InstancePlacementReasonEvacuation is when an existing instance is temporarily migrated because a cluster member is being evacuated.
+const InstancePlacementReasonEvacuation = "evacuation"
+
 // InstanceResources represents the required resources for an instance.
 //
 // API extension: instances_placement_scriptlet.
@@ -7,4 +20,14 @@ type InstanceResources struct {
 	CPUCores     uint64 `json:"cpu_cores"`
 	MemorySize   uint64 `json:"memory_size"`
 	RootDiskSize uint64 `json:"root_disk_size"`
+}
+
+// InstancePlacement represents the instance placement request.
+//
+// API extension: instances_placement_scriptlet.
+type InstancePlacement struct {
+	api.InstancesPost `yaml:",inline"`
+
+	Reason  string `json:"reason"`
+	Project string `json:"project"`
 }

--- a/test/suites/clustering_instance_placement_scriptlet.sh
+++ b/test/suites/clustering_instance_placement_scriptlet.sh
@@ -98,7 +98,7 @@ EOF
 def instance_placement(request, candidate_members):
         log_error("instance placement not allowed") # Log placement error.
 
-        return "Instance not allowed" # Return placement error to prevent instance creation.
+        fail("Instance not allowed") # Fail to prevent instance creation.
 EOF
 
   ! LXD_DIR="${LXD_ONE_DIR}" lxc init testimage c1 || false

--- a/test/suites/clustering_instance_placement_scriptlet.sh
+++ b/test/suites/clustering_instance_placement_scriptlet.sh
@@ -53,6 +53,9 @@ def instance_placement(request, candidate_members):
         if request["project"] != "default":
                 return "Expecting project default"
 
+        if request["config"]["limits.memory"] != "512MiB":
+                return "Expecting config limits.memory of 512MiB"
+
         if instance_resources["cpu_cores"] != 1:
                 return "Expecting cpu_cores of 1"
 


### PR DESCRIPTION
- Adds new `shared/api/scriptlet.InstancePlacement` struct that embeds `api.InstancesPost` and adds `Reason` and `Project` fields. This allows the instance's project to be passed to the scriptlet.
- Updated https://discuss.linuxcontainers.org/t/lxd-scriptlet-based-instance-placement-scheduler/15728
- Integrates improvements and fixes to `StarlarkMarshal` from https://github.com/lxc/lxd/pull/11326
- Fixes multi-level embedded structs in `StarlarkMarshal`.