### PR TITLE
Storage: Only check for minimum number of columns in `btrfs qgroup show` command

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_utils.go
+++ b/lxd/storage/drivers/driver_btrfs_utils.go
@@ -253,7 +253,9 @@ func (d *btrfs) getQGroup(path string) (string, int64, error) {
 		}
 
 		fields := strings.Fields(line)
-		if len(fields) != 4 {
+
+		// The BTRFS tooling changed the number of columns between versions so we only check for minimum.
+		if len(fields) < 3 {
 			continue
 		}
 


### PR DESCRIPTION
In addition to https://github.com/lxc/lxd/pull/11252 BTRFS tooling has also changed the number of columns in `btrfs qgroup show` output:

Previously we expected 4 columns, but in btrfs-progs >= 6.0 this has changed to 5 columns.

E.g. in Jammy btrfs-progs v5.16.2:

```
sudo btrfs qgroup show /var/lib/lxd/storage-pools/btrfs
qgroupid         rfer         excl
--------         ----         ----
0/5          16.00KiB     16.00KiB
0/256         9.66MiB    400.00KiB
0/257         9.66MiB    392.00KiB
```

And in Lunar btrfs-progs v6.1.3:

```
btrfs qgroup show /var/lib/lxd/storage-pools/btrfs
Qgroupid    Referenced    Exclusive   Path
--------    ----------    ---------   ----
0/5           16.00KiB     16.00KiB   <toplevel>
0/256          9.63MiB    400.00KiB   images/1f81470478d136f0008c856e3a47369e0ac863f0402ce0e31c56dd29e9fdd4d7
0/257          9.64MiB    404.00KiB   containers/c1
```


Fixes #11210

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>