### PR TITLE
doc: Images section

### DIFF
--- a/doc/howto/images_copy.md
+++ b/doc/howto/images_copy.md
@@ -1,3 +1,7 @@
+---
+discourse: 9310
+---
+
 (images-copy)=
 # How to copy and import images
 
@@ -6,3 +10,91 @@
 
   - local file
   - file on web server
+
+
+### Direct pushing of the image files
+
+This is mostly useful for air-gapped environments where images cannot be
+directly retrieved from an external server.
+
+In such a scenario, image files can be downloaded on another system using:
+
+    lxc image export ubuntu:22.04
+
+Then transferred to the target system and manually imported into the
+local image store with:
+
+    lxc image import META ROOTFS --alias ubuntu-22.04
+
+`lxc image import` supports both unified images (single file) and split
+images (two files) with the example above using the latter.
+
+### File on a remote web server
+
+As an alternative to running a full image server only to distribute a
+single image to users, LXD also supports importing images by URL.
+
+There are a few limitations to that method though:
+
+- Only unified (single file) images are supported
+- Additional HTTP headers must be returned by the remote server
+
+LXD will set the following headers when querying the server:
+
+- `LXD-Server-Architectures` to a comma-separated list of architectures the client supports
+- `LXD-Server-Version` to the version of LXD in use
+
+And expects `LXD-Image-Hash` and `LXD-Image-URL` to be set by the remote server.
+The former being the SHA256 of the image being downloaded and the latter
+the URL to download the image from.
+
+This allows for reasonably complex image servers to be implemented using
+only a basic web server with support for custom headers.
+
+On the client side, this is used with:
+
+    lxc image import URL --alias some-name
+
+
+## Import images
+You can import images, that you:
+
+- built yourself (see [Build Images](#build-images)),
+- downloaded manually (see [Manual Download](#manual-download))
+- exported from images or containers (see [Export Images](#export-images) and [Create Image from Containers](#create-image-from-containers))
+
+#### Import container image
+
+Components:
+
+- lxd.tar.xz
+- rootfs.squashfs
+
+Use:
+
+	lxc image import lxd.tar.xz rootfs.squashfs --alias custom-imagename
+
+
+#### Import virtual-machine image
+
+Components:
+
+- lxd.tar.xz
+- disk.qcow2
+
+Use:
+
+	lxc image import lxd.tar.xz disk.qcow2 --alias custom-imagename
+
+
+### Manual download
+You can also download images manually. For that you need to download the components described [above](#import-images).
+
+#### From official LXD image server
+
+!!! note
+    It is easier to use the usual method with `lxc launch`. Use manual download only if you have a specific reason, like modification of the files before use for example.
+
+**Link to official image server:**
+
+[https://images.linuxcontainers.org/images/](https://images.linuxcontainers.org/images/)

--- a/doc/howto/images_copy.md
+++ b/doc/howto/images_copy.md
@@ -1,0 +1,8 @@
+(images-copy)=
+# How to copy and import images
+
+- Copy images from a remote (can also copy to another server)
+- Import an image from a file
+
+  - local file
+  - file on web server

--- a/doc/howto/images_create.md
+++ b/doc/howto/images_create.md
@@ -3,3 +3,102 @@
 
 - Publish from an instance or snapshot
 - Use distrobuilder
+
+
+
+### Publishing an instance or snapshot as a new image
+
+An instance or one of its snapshots can be turned into a new image.
+This is done on the CLI with `lxc publish`.
+
+When doing this, you will most likely first want to cleanup metadata and
+templates on the instance you're publishing using the `lxc config metadata`
+and `lxc config template` commands. You will also want to remove any
+instance-specific state like host SSH keys, `dbus/systemd machine-id`, ...
+
+The publishing process can take quite a while as a tarball must be
+generated from the instance and then be compressed. As this can be
+particularly I/O and CPU intensive, publish operations are serialized by LXD.
+
+
+
+### Create image from containers
+See command:
+
+	lxc publish
+
+## Build images
+For building your own images, you can use [`distrobuilder`](https://github.com/lxc/distrobuilder) (a tool developed by us).
+
+### Install distrobuilder
+You can install distrobuilder via snap or compile it manually:
+
+#### Install via Snap
+See [https://snapcraft.io/distrobuilder](https://snapcraft.io/distrobuilder).
+
+#### Compile
+See [Instructions on distrobuilder GitHub repo](https://github.com/lxc/distrobuilder/#installing-from-source).
+
+### Write or edit a template
+You need an image template (e.g. `ubuntu.yaml`) to give instructions to distrobuilder.
+
+You can start by using one of the example templates below. Modify those templates so they fit your needs.
+
+See [Template details](#template-details) below for an overview of configuration keys.
+
+#### Example templates
+Standard template (includes all available options): [https://github.com/lxc/distrobuilder/blob/master/doc/examples/scheme.yaml](https://github.com/lxc/distrobuilder/blob/master/doc/examples/scheme.yaml)
+
+Official LXD templates for various distributions: [https://github.com/lxc/lxc-ci/tree/master/images](https://github.com/lxc/lxc-ci/tree/master/images)
+
+#### Template details
+You can define multiple keys in templates:
+
+
+| Section: | Description: | Documentation: |
+| ---      | ---          | ---            |
+| `image`  | defines distribution, architecture, release etc.| see [image.md](https://github.com/lxc/distrobuilder/blob/master/doc/image.md) |
+| `source` | defines main package source, keys etc. | see [source.md](https://github.com/lxc/distrobuilder/blob/master/doc/source.md) |
+| `targets` | defines configs for specific targets (e.g. LXD-client, instances etc.) |  see [targets.md](https://github.com/lxc/distrobuilder/blob/master/doc/targets.md) |
+| `files` | defines generators to modify files | see [generators.md](https://github.com/lxc/distrobuilder/blob/master/doc/generators.md) |
+| `packages` | defines packages for install or removal; add repositories |   see [packages.md](https://github.com/lxc/distrobuilder/blob/master/doc/packages.md) |
+| `actions` | defines scripts to be run after specific steps during image building |  see [actions.md](https://github.com/lxc/distrobuilder/blob/master/doc/actions.md) |
+| `mappings` | maps different terms for architectures for specific distributions (e.g. x86_64: amd64) | see [mappings.md](https://github.com/lxc/distrobuilder/blob/master/doc/mappings.md) |
+
+
+!!! note "Note for VMs"
+	You should either build an image with cloud-init support (provides automatic size growth) or set a higher size in the template, because the standard size is relatively small (~4 GB). Alternatively you can also grow it manually.
+
+### Build an image
+
+#### Container image
+Build a container image with:
+
+	distrobuilder build-lxd filename [target folder]
+
+Replace:
+
+* `filename` - with a template file (e.g. `ubuntu.yaml`).
+* (optional)`[target folder]` - with the path to a folder of your choice; if not set, distrobuilder will use the current folder
+
+After the image is built, see [Import images](#import-images) for how to import your image to LXD.
+
+See [Building.md on distrobuilder's GitHub repo](https://github.com/lxc/distrobuilder/blob/master/doc/building.md#lxd-image) for details.
+
+#### Virtual machine image
+Build a virtual machine image with:
+
+	distrobuilder build-lxd filename --vm [target folder]
+
+Replace:
+
+* `filename` - with a template file (e.g. `ubuntu.yaml`).
+* (optional)`[target folder]` - with the path to a folder of your choice; if not set, distrobuilder will use the current folder
+
+
+After the image is built, see [Import images](#import-images) for how to import your image to LXD.
+
+### More information
+[Distrobuilder GitHub repo](https://github.com/lxc/distrobuilder)
+
+[Distrobuilder documentation](https://github.com/lxc/distrobuilder/tree/master/doc)

--- a/doc/howto/images_create.md
+++ b/doc/howto/images_create.md
@@ -1,104 +1,40 @@
 (images-create)=
 # How to create images
 
-- Publish from an instance or snapshot
-- Use distrobuilder
+If you want to create and share your own images, you can do this either based on an existing instance or snapshot or by building your own image from scratch.
 
+(images-create-publish)=
+## Publish an image from an instance or snapshot
 
+If you want to be able to use an instance or an instance snapshot as the base for new instances, you should create and publish an image from it.
 
-### Publishing an instance or snapshot as a new image
+To publish an image from an instance, make sure that the instance is stopped.
+Then enter the following command:
 
-An instance or one of its snapshots can be turned into a new image.
-This is done on the CLI with `lxc publish`.
+    lxc publish <instance_name> [<remote>:]
 
-When doing this, you will most likely first want to cleanup metadata and
-templates on the instance you're publishing using the `lxc config metadata`
-and `lxc config template` commands. You will also want to remove any
-instance-specific state like host SSH keys, `dbus/systemd machine-id`, ...
+To publish an image from a snapshot, enter the following command:
 
-The publishing process can take quite a while as a tarball must be
-generated from the instance and then be compressed. As this can be
-particularly I/O and CPU intensive, publish operations are serialized by LXD.
+    lxc publish <instance_name>/<snapshot_name> [<remote>:]
 
+In both cases, you can specify an alias for the new image with the `--alias` flag, set an expiration date with `--expire` and make the image publicly available with `--public`.
+See `lxc publish --help` for a full list of available flags.
 
+The publishing process can take quite a while because it generates a tarball from the instance or snapshot and then compresses it.
+As this can be particularly I/O and CPU intensive, publish operations are serialized by LXD.
 
-### Create image from containers
-See command:
+### Prepare the instance for publishing
 
-	lxc publish
+Before you publish an image from an instance, clean up all data that should not be included in the image.
+Usually, this includes the following data:
 
-## Build images
-For building your own images, you can use [`distrobuilder`](https://github.com/lxc/distrobuilder) (a tool developed by us).
+- Instance metadata (use `lxc config metadata` to edit)
+- File templates (use `lxc config template` to edit)
+- Instance-specific data inside the instance itself (for example, host SSH keys and `dbus/systemd machine-id`)
 
-### Install distrobuilder
-You can install distrobuilder via snap or compile it manually:
+(images-create-build)=
+## Build an image
 
-#### Install via Snap
-See [https://snapcraft.io/distrobuilder](https://snapcraft.io/distrobuilder).
+For building your own images, you can use [`distrobuilder`](https://github.com/lxc/distrobuilder).
 
-#### Compile
-See [Instructions on distrobuilder GitHub repo](https://github.com/lxc/distrobuilder/#installing-from-source).
-
-### Write or edit a template
-You need an image template (e.g. `ubuntu.yaml`) to give instructions to distrobuilder.
-
-You can start by using one of the example templates below. Modify those templates so they fit your needs.
-
-See [Template details](#template-details) below for an overview of configuration keys.
-
-#### Example templates
-Standard template (includes all available options): [https://github.com/lxc/distrobuilder/blob/master/doc/examples/scheme.yaml](https://github.com/lxc/distrobuilder/blob/master/doc/examples/scheme.yaml)
-
-Official LXD templates for various distributions: [https://github.com/lxc/lxc-ci/tree/master/images](https://github.com/lxc/lxc-ci/tree/master/images)
-
-#### Template details
-You can define multiple keys in templates:
-
-
-| Section: | Description: | Documentation: |
-| ---      | ---          | ---            |
-| `image`  | defines distribution, architecture, release etc.| see [image.md](https://github.com/lxc/distrobuilder/blob/master/doc/image.md) |
-| `source` | defines main package source, keys etc. | see [source.md](https://github.com/lxc/distrobuilder/blob/master/doc/source.md) |
-| `targets` | defines configs for specific targets (e.g. LXD-client, instances etc.) |  see [targets.md](https://github.com/lxc/distrobuilder/blob/master/doc/targets.md) |
-| `files` | defines generators to modify files | see [generators.md](https://github.com/lxc/distrobuilder/blob/master/doc/generators.md) |
-| `packages` | defines packages for install or removal; add repositories |   see [packages.md](https://github.com/lxc/distrobuilder/blob/master/doc/packages.md) |
-| `actions` | defines scripts to be run after specific steps during image building |  see [actions.md](https://github.com/lxc/distrobuilder/blob/master/doc/actions.md) |
-| `mappings` | maps different terms for architectures for specific distributions (e.g. x86_64: amd64) | see [mappings.md](https://github.com/lxc/distrobuilder/blob/master/doc/mappings.md) |
-
-
-!!! note "Note for VMs"
-	You should either build an image with cloud-init support (provides automatic size growth) or set a higher size in the template, because the standard size is relatively small (~4 GB). Alternatively you can also grow it manually.
-
-### Build an image
-
-#### Container image
-Build a container image with:
-
-	distrobuilder build-lxd filename [target folder]
-
-Replace:
-
-* `filename` - with a template file (e.g. `ubuntu.yaml`).
-* (optional)`[target folder]` - with the path to a folder of your choice; if not set, distrobuilder will use the current folder
-
-After the image is built, see [Import images](#import-images) for how to import your image to LXD.
-
-See [Building.md on distrobuilder's GitHub repo](https://github.com/lxc/distrobuilder/blob/master/doc/building.md#lxd-image) for details.
-
-#### Virtual machine image
-Build a virtual machine image with:
-
-	distrobuilder build-lxd filename --vm [target folder]
-
-Replace:
-
-* `filename` - with a template file (e.g. `ubuntu.yaml`).
-* (optional)`[target folder]` - with the path to a folder of your choice; if not set, distrobuilder will use the current folder
-
-
-After the image is built, see [Import images](#import-images) for how to import your image to LXD.
-
-### More information
-[Distrobuilder GitHub repo](https://github.com/lxc/distrobuilder)
-
-[Distrobuilder documentation](https://github.com/lxc/distrobuilder/tree/master/doc)
+See the [`distrobuilder` documentation](https://distrobuilder.readthedocs.io/en/latest/) for instructions for installing and using the tool.

--- a/doc/howto/images_create.md
+++ b/doc/howto/images_create.md
@@ -1,0 +1,5 @@
+(images-create)=
+# How to create images
+
+- Publish from an instance or snapshot
+- Use distrobuilder

--- a/doc/howto/images_manage.md
+++ b/doc/howto/images_manage.md
@@ -1,20 +1,110 @@
 (images-manage)=
 # How to manage images
 
-- List images
-- Show image info (info and show)
-- Get and set property
-- Edit
-- Use aliases
-- Export an image as a file
+When working with images, you can inspect various information about the available images, view and edit their properties and configure aliases to refer to specific images.
+You can also export an image to a file, which can be useful to {ref}`copy or import it <images-copy>` on another machine.
 
+## List available images
 
+To list all images on a server, enter the following command:
 
-## Export images
-Use:
+    lxc image list [<remote>:]
 
-	lxc image export imagename [target folder] [flags]
+If you do not specify a remote, the {ref}`default remote <images-remote-default>` is used.
 
-Flags:
+(images-manage-filter)=
+### Filter available images
 
-`--vm` - Query virtual machine images
+To filter the results that are displayed, specify a part of the alias or fingerprint after the command.
+For example, to show all Debian images, enter the following command:
+
+    lxc image list images: debian
+
+You can specify several filters as well.
+For example, to show all 64-bit Debian images, enter the following command:
+
+    lxc image list images: debian amd64
+
+To filter for properties other than alias or fingerprint, specify the filter in `<key>=<value>` format.
+For example:
+
+    lxc image list images: debian architecture=x86_64
+
+## View image information
+
+To view information about an image, enter the following command:
+
+    lxc image info <image_ID>
+
+As the image ID, you can specify either the image's alias or its fingerprint.
+For a remote image, remember to include the remote server (for example, `images:ubuntu/22.04`).
+
+To display only the image properties, enter the following command:
+
+    lxc image show <image_ID>
+
+You can also display a specific image property (located under the `properties` key) with the following command:
+
+    lxc image get-property <image_ID> <key>
+
+For example, to show the release name of the official Ubuntu 22.04 image, enter the following command:
+
+    lxc image get-property ubuntu:22.04 release
+
+(images-manage-edit)=
+## Edit image properties
+
+To set a specific image property that is located under the `properties` key, enter the following command:
+
+    lxc image set-property <image_ID> <key>
+
+```{note}
+These properties can be used to convey information about the image.
+They do not configure LXD's behavior in any way.
+```
+
+To edit the full image properties, including the top-level properties, enter the following command:
+
+    lxc image edit <image_ID>
+
+## Configure image aliases
+
+Configuring an alias for an image can be useful to make it easier to refer to an image, since remembering an alias is usually easier than remembering a fingerprint.
+Most importantly, however, you can change an alias to point to a different image, which allows creating an alias that always provides a current image (for example, the latest version of a release).
+
+You can see some of the existing aliases in the image list.
+To see the full list, enter the following command:
+
+    lxc image alias list
+
+You can directly assign an alias to an image when you {ref}`copy or import <images-copy>` or {ref}`publish <images-create-publish>` it.
+Alternatively, enter the following command:
+
+    lxc image alias create <alias_name> <image_fingerprint>
+
+You can also delete an alias:
+
+    lxc image alias delete <alias_name>
+
+To rename an alias, enter the following command:
+
+    lxc image alias rename <alias_name> <new_alias_name>
+
+If you want to keep the alias name, but point the alias to a different image (for example, a newer version), you must delete the existing alias and then create a new one.
+
+(images-manage-export)=
+## Export an image to a file
+
+Images are located in the image store of your local server or a remote LXD server.
+You can export them to a file though.
+This method can be useful to back up image files or to transfer them to an air-gapped environment.
+
+To export a container image to a file, enter the following command:
+
+    lxc image export [<remote>:]<image> [<output_directory_path>]
+
+To export a virtual machine image to a file, add the `--vm` flag:
+
+    lxc image export [<remote>:]<image> [<output_directory_path>] --vm
+
+See {ref}`image-format` for a description of the file structure used for the image.

--- a/doc/howto/images_manage.md
+++ b/doc/howto/images_manage.md
@@ -1,0 +1,9 @@
+(images-manage)=
+# How to manage images
+
+- List images
+- Show image info (info and show)
+- Get and set property
+- Edit
+- Use aliases
+- Export an image as a file

--- a/doc/howto/images_manage.md
+++ b/doc/howto/images_manage.md
@@ -7,3 +7,14 @@
 - Edit
 - Use aliases
 - Export an image as a file
+
+
+
+## Export images
+Use:
+
+	lxc image export imagename [target folder] [flags]
+
+Flags:
+
+`--vm` - Query virtual machine images

--- a/doc/howto/images_profiles.md
+++ b/doc/howto/images_profiles.md
@@ -1,13 +1,22 @@
 (images-profiles)=
 # How to associate profiles with an image
 
-## Profiles
+You can associate one or more profiles with a specific image.
+Instances that are created from the image will then automatically use the associated profiles in the order they were specified.
 
-A list of profiles can be associated with an image using the `lxc image edit`
-command. After associating profiles with an image, an instance launched
-using the image will have the profiles applied in order. If `nil` is passed
-as the list of profiles, only the `default` profile will be associated with
-the image. If an empty list is passed, then no profile will be associated
-with the image, not even the `default` profile. An image's associated
-profiles can be overridden when launching an instance by using the
-`--profile` and the `--no-profiles` flags to `lxc launch`.
+To associate a list of profiles with an image, use the `lxc image edit` command and edit the `profiles:` section:
+
+```yaml
+profiles:
+- default
+```
+
+Most provided images come with a profile list that includes only the `default` profile.
+To prevent any profile (including the `default` profile) from being associated with an image, pass an empty list.
+
+```{note}
+Passing an empty list is different than passing `nil`.
+If you pass `nil` as the profile list, only the `default` profile is associated with the image.
+```
+
+You can override the associated profiles for an image when creating an instance by adding the `--profile` or the `--no-profiles` flag to the launch or init command.

--- a/doc/howto/images_profiles.md
+++ b/doc/howto/images_profiles.md
@@ -1,0 +1,2 @@
+(images-profiles)=
+# How to associate profiles with an image

--- a/doc/howto/images_profiles.md
+++ b/doc/howto/images_profiles.md
@@ -1,2 +1,13 @@
 (images-profiles)=
 # How to associate profiles with an image
+
+## Profiles
+
+A list of profiles can be associated with an image using the `lxc image edit`
+command. After associating profiles with an image, an instance launched
+using the image will have the profiles applied in order. If `nil` is passed
+as the list of profiles, only the `default` profile will be associated with
+the image. If an empty list is passed, then no profile will be associated
+with the image, not even the `default` profile. An image's associated
+profiles can be overridden when launching an instance by using the
+`--profile` and the `--no-profiles` flags to `lxc launch`.

--- a/doc/howto/images_remote.md
+++ b/doc/howto/images_remote.md
@@ -1,125 +1,73 @@
 (images-remote)=
 # How to use remote images
 
-- Link to {ref}`remote-image-servers`
-- List remotes
-- Add remotes
-- Set a default remote
-- Reference an image (`<remote>:<image>`)
-- Search for images
-- Configure caching
+The `lxc` CLI command is pre-configured with several remote image servers.
+See {ref}`remote-image-servers` for an overview.
 
+## List configured remotes
 
+To see all configured remote servers, enter the following command:
 
-### Remote image server (LXD or simplestreams)
+    lxc remote list
 
-This is the most common source of images and the only one of the three
-options which is supported directly at instance creation time.
+Remote servers that use the [simple streams format](https://git.launchpad.net/simplestreams/tree/) are pure image servers.
+Servers that use the `lxd` format are LXD servers, which either serve solely as image servers or might provide some images in addition to serving as regular LXD servers.
+See {ref}`remote-image-server-types` for more information.
 
-With this option, an image server is provided to the target LXD server
-along with any needed certificate to validate it (only HTTPS is supported).
+## List available images on a remote
 
-The image itself is then selected either by its fingerprint (SHA256) or
-one of its aliases.
+To list all remote images on a server, enter the following command:
 
-From a CLI point of view, this is what's done behind those common actions:
+    lxc image list <remote>:
 
-    lxc launch ubuntu:22.04 u1
-    lxc launch images:centos/8 c1
-    lxc launch my-server:SHA256 a1
-    lxc image copy images:gentoo local: --copy-aliases --auto-update
+You can filter the results.
+See {ref}`images-manage-filter` for instructions.
 
-In the cases of `ubuntu` and `images` above, those remotes use
-simplestreams as a read-only image server protocol and select images by
-one of their aliases.
+## Add a remote server
 
-The `my-server` remote there is another LXD server and in that example
-selects an image based on its fingerprint.
+How to add a remote depends on the protocol that the server uses.
 
-## Use remote image servers
-The easiest way is to use a built-in remote image server.
+### Add a simple streams server
 
-You can get a list of built-in image servers with:
+To add a simple streams server as a remote, enter the following command:
 
-	lxc remote list
+    lxc remote add <remote_name> <URL> --protocol=simplestreams
 
-LXD comes with 3 default servers:
+The URL must use HTTPS.
 
- 1. `ubuntu:` (for stable Ubuntu images)
- 2. `ubuntu-daily:` (for daily Ubuntu images)
- 3. `images:` (for a [bunch of other distros](https://images.linuxcontainers.org))
+### Add a remote LXD server
 
-### List images on server
+To add a LXD server as a remote, enter the following command:
 
-To get a list of remote images on server `images`, type:
+    lxc remote add <remote_name> <IP|FQDN|URL> [flags]
 
-	lxc image list images:
+Some authentication methods require specific flags (for example, use `lxc remote add <remote_name> <IP|FQDN|URL> --auth-type=candid` for Candid authentication).
+See {ref}`authentication` for more information.
 
-**Details:**
+For example, enter the following command to add a remote through an IP address:
 
-_Most details in the list should be self-explanatory._
+    lxc remote add my-remote 192.0.2.10
 
-- Alias with `cloud`: refers to images with built-in cloud-init support (see [Advanced Guide - Cloud-Init](/lxd/advanced-guide#cloud-init) and [official cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/))
+You are prompted to confirm the remote server fingerprint and then asked for the password or token, depending on the authentication method used by the remote.
 
-### Search for images
-You can search for images, by applying specific elements (e.g. the name of a distribution).
+## Reference an image
 
-Show all Debian images:
+To reference an image, specify its remote and its alias or fingerprint, separated with a colon.
+For example:
 
-	lxc image list images: debian
+    images:ubuntu/22.04
+    ubuntu:22.04
+    local:ed7509d7e83f
 
-Show all 64-bit Debian images:
+(images-remote-default)=
+## Select a default remote
 
-	lxc image list images: debian amd64
+If you specify an image name without the name of the remote, the default image server is used.
 
-## Images for virtual machines
-It is recommended to use the `cloud` variants of images (visible by the `cloud`-tag in their `ALIAS`). They include cloud-init and the LXD-agent. They also increase their size automatically and are tested daily.
+To see which server is configured as the default image server, enter the following command:
 
+    lxc remote get-default
 
-## Remote servers
-See [Image handling](/lxd/docs/master/image-handling/) for detailed information.
+To select a different remote as the default image server, enter the following command:
 
-LXD supports different kinds of remote servers:
-
-* `Simple streams servers`: Pure image servers that use the [simple streams format](https://git.launchpad.net/simplestreams/tree/).
-* `Public LXD servers`: Empty LXD servers with no storage pools and no networks that serve solely as image servers. Set the `core.https_address` configuration option (see [Server configuration](/lxd/docs/master/server/#server-configuration)) to `:8443` and do not configure any authentication methods to make the LXD server publicly available over the network on port 8443. Then set the images that you want to share to `public`.
-* `LXD servers`: Regular LXD servers that you can manage over a network, and that can also be used as image servers. For security reasons, you should restrict the access to the remote API and configure an authentication method to control access. See [Access to the remote API](/lxd/docs/master/security/#access-to-the-remote-api) and [Remote API authentication](/lxd/docs/master/authentication/) for more information.
-
-### Use a remote simple streams server
-
-To add a simple streams server as a remote, use the following command:
-
-	lxc remote add some-name https://example.com/some/path --protocol=simplestreams
-
-### Use a remote LXD server
-
-To add a LXD server as a remote, use the following command:
-
-	lxc remote add some-name <IP|FQDN|URL> [flags]
-
-Some authentication methods require specific flags (for example, use `lxc remote add some-name <IP|FQDN|URL> --auth-type=candid` for Candid authentication). See [Remote API authentication](/lxd/docs/master/authentication/) for more information.
-
-An example using an IP address:
-
-    lxc remote add remoteserver2 1.2.3.4
-
-This will prompt you to confirm the remote server fingerprint and then ask you for the password or token, depending on the authentication method used by the remote.
-
-### Use remote servers
-
-#### Image list on a remote server
-A list of images on that server can be obtained with:
-
-    lxc image list my-images:
-
-#### Launch an instance
-Launch an instance based on an image of that server:
-
-    lxc launch some-name:image-name your-instance [--vm]
-
-#### Manage instances on a remote server
-You can use the same commands but prefixing the server and instance name like:
-
-    lxc exec remoteserver-name:instancename -- apt-get update
-
-You can replace `apt-get update` with any command the instance supports.
+    lxc remote switch <remote_name>

--- a/doc/howto/images_remote.md
+++ b/doc/howto/images_remote.md
@@ -8,3 +8,118 @@
 - Reference an image (`<remote>:<image>`)
 - Search for images
 - Configure caching
+
+
+
+### Remote image server (LXD or simplestreams)
+
+This is the most common source of images and the only one of the three
+options which is supported directly at instance creation time.
+
+With this option, an image server is provided to the target LXD server
+along with any needed certificate to validate it (only HTTPS is supported).
+
+The image itself is then selected either by its fingerprint (SHA256) or
+one of its aliases.
+
+From a CLI point of view, this is what's done behind those common actions:
+
+    lxc launch ubuntu:22.04 u1
+    lxc launch images:centos/8 c1
+    lxc launch my-server:SHA256 a1
+    lxc image copy images:gentoo local: --copy-aliases --auto-update
+
+In the cases of `ubuntu` and `images` above, those remotes use
+simplestreams as a read-only image server protocol and select images by
+one of their aliases.
+
+The `my-server` remote there is another LXD server and in that example
+selects an image based on its fingerprint.
+
+## Use remote image servers
+The easiest way is to use a built-in remote image server.
+
+You can get a list of built-in image servers with:
+
+	lxc remote list
+
+LXD comes with 3 default servers:
+
+ 1. `ubuntu:` (for stable Ubuntu images)
+ 2. `ubuntu-daily:` (for daily Ubuntu images)
+ 3. `images:` (for a [bunch of other distros](https://images.linuxcontainers.org))
+
+### List images on server
+
+To get a list of remote images on server `images`, type:
+
+	lxc image list images:
+
+**Details:**
+
+_Most details in the list should be self-explanatory._
+
+- Alias with `cloud`: refers to images with built-in cloud-init support (see [Advanced Guide - Cloud-Init](/lxd/advanced-guide#cloud-init) and [official cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/))
+
+### Search for images
+You can search for images, by applying specific elements (e.g. the name of a distribution).
+
+Show all Debian images:
+
+	lxc image list images: debian
+
+Show all 64-bit Debian images:
+
+	lxc image list images: debian amd64
+
+## Images for virtual machines
+It is recommended to use the `cloud` variants of images (visible by the `cloud`-tag in their `ALIAS`). They include cloud-init and the LXD-agent. They also increase their size automatically and are tested daily.
+
+
+## Remote servers
+See [Image handling](/lxd/docs/master/image-handling/) for detailed information.
+
+LXD supports different kinds of remote servers:
+
+* `Simple streams servers`: Pure image servers that use the [simple streams format](https://git.launchpad.net/simplestreams/tree/).
+* `Public LXD servers`: Empty LXD servers with no storage pools and no networks that serve solely as image servers. Set the `core.https_address` configuration option (see [Server configuration](/lxd/docs/master/server/#server-configuration)) to `:8443` and do not configure any authentication methods to make the LXD server publicly available over the network on port 8443. Then set the images that you want to share to `public`.
+* `LXD servers`: Regular LXD servers that you can manage over a network, and that can also be used as image servers. For security reasons, you should restrict the access to the remote API and configure an authentication method to control access. See [Access to the remote API](/lxd/docs/master/security/#access-to-the-remote-api) and [Remote API authentication](/lxd/docs/master/authentication/) for more information.
+
+### Use a remote simple streams server
+
+To add a simple streams server as a remote, use the following command:
+
+	lxc remote add some-name https://example.com/some/path --protocol=simplestreams
+
+### Use a remote LXD server
+
+To add a LXD server as a remote, use the following command:
+
+	lxc remote add some-name <IP|FQDN|URL> [flags]
+
+Some authentication methods require specific flags (for example, use `lxc remote add some-name <IP|FQDN|URL> --auth-type=candid` for Candid authentication). See [Remote API authentication](/lxd/docs/master/authentication/) for more information.
+
+An example using an IP address:
+
+    lxc remote add remoteserver2 1.2.3.4
+
+This will prompt you to confirm the remote server fingerprint and then ask you for the password or token, depending on the authentication method used by the remote.
+
+### Use remote servers
+
+#### Image list on a remote server
+A list of images on that server can be obtained with:
+
+    lxc image list my-images:
+
+#### Launch an instance
+Launch an instance based on an image of that server:
+
+    lxc launch some-name:image-name your-instance [--vm]
+
+#### Manage instances on a remote server
+You can use the same commands but prefixing the server and instance name like:
+
+    lxc exec remoteserver-name:instancename -- apt-get update
+
+You can replace `apt-get update` with any command the instance supports.

--- a/doc/howto/images_remote.md
+++ b/doc/howto/images_remote.md
@@ -1,0 +1,10 @@
+(images-remote)=
+# How to use remote images
+
+- Link to {ref}`remote-image-servers`
+- List remotes
+- Add remotes
+- Set a default remote
+- Reference an image (`<remote>:<image>`)
+- Search for images
+- Configure caching

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -57,7 +57,7 @@ Remote access (see {ref}`security_remote_access` and {ref}`authentication`)
 
   You can choose to add client certificates to the server (manually or through tokens, the recommended way) or set a trust password.
 
-Automatic image update (see {ref}`image-handling`)
+Automatic image update (see {ref}`about-images`)
 : You can download images from image servers.
   In this case, images can be updated automatically.
 

--- a/doc/howto/storage_volumes.md
+++ b/doc/howto/storage_volumes.md
@@ -86,7 +86,7 @@ Access to cached data is not affected by the limit.
 (storage-volume-special)=
 ### Use the volume for backups or images
 
-Instead of attaching a custom volume to an instance as a disk device, you can also use it as a special kind of volume to store {ref}`backups <backups>` or {ref}`images <image-handling>`.
+Instead of attaching a custom volume to an instance as a disk device, you can also use it as a special kind of volume to store {ref}`backups <backups>` or {ref}`images <about-images>`.
 
 To do so, you must set the corresponding {ref}`server configuration <server-options-misc>`:
 

--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -8,6 +8,8 @@ discourse: 9310
 ```{youtube} https://www.youtube.com/watch?v=wT7IDjo0Wgg
 ```
 
+Instances are based on images, which contain a basic operating system (for example a Linux distribution) and some other LXD-related information.
+
 ## Introduction
 
 LXD uses an image based workflow. It comes with a built-in image store
@@ -26,88 +28,6 @@ LXD supports importing images from three different sources:
 - Remote image server (LXD or simplestreams)
 - Direct pushing of the image files
 - File on a remote web server
-
-### Remote image server (LXD or simplestreams)
-
-This is the most common source of images and the only one of the three
-options which is supported directly at instance creation time.
-
-With this option, an image server is provided to the target LXD server
-along with any needed certificate to validate it (only HTTPS is supported).
-
-The image itself is then selected either by its fingerprint (SHA256) or
-one of its aliases.
-
-From a CLI point of view, this is what's done behind those common actions:
-
-    lxc launch ubuntu:22.04 u1
-    lxc launch images:centos/8 c1
-    lxc launch my-server:SHA256 a1
-    lxc image copy images:gentoo local: --copy-aliases --auto-update
-
-In the cases of `ubuntu` and `images` above, those remotes use
-simplestreams as a read-only image server protocol and select images by
-one of their aliases.
-
-The `my-server` remote there is another LXD server and in that example
-selects an image based on its fingerprint.
-
-### Direct pushing of the image files
-
-This is mostly useful for air-gapped environments where images cannot be
-directly retrieved from an external server.
-
-In such a scenario, image files can be downloaded on another system using:
-
-    lxc image export ubuntu:22.04
-
-Then transferred to the target system and manually imported into the
-local image store with:
-
-    lxc image import META ROOTFS --alias ubuntu-22.04
-
-`lxc image import` supports both unified images (single file) and split
-images (two files) with the example above using the latter.
-
-### File on a remote web server
-
-As an alternative to running a full image server only to distribute a
-single image to users, LXD also supports importing images by URL.
-
-There are a few limitations to that method though:
-
-- Only unified (single file) images are supported
-- Additional HTTP headers must be returned by the remote server
-
-LXD will set the following headers when querying the server:
-
-- `LXD-Server-Architectures` to a comma-separated list of architectures the client supports
-- `LXD-Server-Version` to the version of LXD in use
-
-And expects `LXD-Image-Hash` and `LXD-Image-URL` to be set by the remote server.
-The former being the SHA256 of the image being downloaded and the latter
-the URL to download the image from.
-
-This allows for reasonably complex image servers to be implemented using
-only a basic web server with support for custom headers.
-
-On the client side, this is used with:
-
-    lxc image import URL --alias some-name
-
-### Publishing an instance or snapshot as a new image
-
-An instance or one of its snapshots can be turned into a new image.
-This is done on the CLI with `lxc publish`.
-
-When doing this, you will most likely first want to cleanup metadata and
-templates on the instance you're publishing using the `lxc config metadata`
-and `lxc config template` commands. You will also want to remove any
-instance-specific state like host SSH keys, `dbus/systemd machine-id`, ...
-
-The publishing process can take quite a while as a tarball must be
-generated from the instance and then be compressed. As this can be
-particularly I/O and CPU intensive, publish operations are serialized by LXD.
 
 ## Caching
 
@@ -147,17 +67,6 @@ than delay the instance creation.
 This behavior only happens if the current image is scheduled to be
 auto-updated and can be disabled by setting `images.auto_update_interval` to 0.
 
-## Profiles
-
-A list of profiles can be associated with an image using the `lxc image edit`
-command. After associating profiles with an image, an instance launched
-using the image will have the profiles applied in order. If `nil` is passed
-as the list of profiles, only the `default` profile will be associated with
-the image. If an empty list is passed, then no profile will be associated
-with the image, not even the `default` profile. An image's associated
-profiles can be overridden when launching an instance by using the
-`--profile` and the `--no-profiles` flags to `lxc launch`.
-
 ## Special image properties
 
 Image properties beginning with the prefix ***requirements*** (e.g. `requirements.XYZ`)
@@ -171,119 +80,3 @@ Key                                         | Type      | Default      | Descrip
 :--                                         | :---      | :------      | :----------
 `requirements.secureboot`                   | string    | -            | If set to `false`, indicates the image will not boot under secure boot
 `requirements.cgroup`                       | string    | -            | If set to `v1`, indicates the image requires the host to run `CGroupV1`
-
-## Image format
-
-LXD currently supports two LXD-specific image formats.
-
-The first is a unified tarball, where a single tarball
-contains both the instance root and the needed metadata.
-
-The second is a split model, using two files instead, one containing
-the root, the other containing the metadata.
-
-The former is what's produced by LXD itself and what people should be
-using for LXD-specific images.
-
-The latter is designed to allow for easy image building from existing
-non-LXD rootfs tarballs already available today.
-
-### Unified tarball
-
-Tarball, can be compressed and contains:
-
-- `rootfs/`
-- `metadata.yaml`
-- `templates/` (optional)
-
-In this mode, the image identifier is the SHA-256 of the tarball.
-
-### Split tarballs
-
-Two (possibly compressed) tarballs. One for metadata, one for the rootfs.
-
-`metadata.tar` contains:
-
-- `metadata.yaml`
-- `templates/` (optional)
-
-`rootfs.tar` contains a Linux root file system at its root.
-
-In this mode the image identifier is the SHA-256 of the concatenation of
-the metadata and rootfs tarball (in that order).
-
-### Supported compression
-
-LXD supports a wide variety of compression algorithms for tarballs
-though for compatibility purposes, `gzip` or `xz` should be preferred.
-
-For split images, the rootfs file can also be SquashFS-formatted in the
-container case. For virtual machines, the `rootfs.img` file is always
-`qcow2` and can optionally be compressed using `qcow2`'s native compression.
-
-### Content
-
-For containers, the rootfs directory (or tarball) contains a full file system tree of what will become the `/`.
-For VMs, this is instead a `rootfs.img` file which becomes the main disk device.
-
-The templates directory contains Pongo2-formatted templates of files inside the instance.
-
-`metadata.yaml` contains information relevant to running the image under
-LXD, at the moment, this contains:
-
-```yaml
-architecture: x86_64
-creation_date: 1424284563
-properties:
-  description: Ubuntu 22.04 LTS Intel 64bit
-  os: Ubuntu
-  release: jammy 22.04
-templates:
-  /etc/hosts:
-    when:
-      - create
-      - rename
-    template: hosts.tpl
-    properties:
-      foo: bar
-  /etc/hostname:
-    when:
-      - start
-    template: hostname.tpl
-  /etc/network/interfaces:
-    when:
-      - create
-    template: interfaces.tpl
-    create_only: true
-```
-
-The `architecture` and `creation_date` fields are mandatory, the properties
-are just a set of default properties for the image. The `os`, `release`,
-`name` and `description` fields while not mandatory in any way, should be
-pretty common.
-
-For templates, the `when` key can be one or more of:
-
-- `create` (run at the time a new instance is created from the image)
-- `copy` (run when an instance is created from an existing one)
-- `start` (run every time the instance is started)
-
-The templates will always receive the following context:
-
-- `trigger`: name of the event which triggered the template (string)
-- `path`: path of the file that uses the template (string)
-- `container`: key/value map of instance properties (name, architecture, privileged and ephemeral) (map[string]string) (deprecated in favor of `instance`)
-- `instance`: key/value map of instance properties (name, architecture, privileged and ephemeral) (map[string]string)
-- `config`: key/value map of the instance's configuration (map[string]string)
-- `devices`: key/value map of the devices assigned to this instance (map[string]map[string]string)
-- `properties`: key/value map of the template properties specified in `metadata.yaml` (map[string]string)
-
-The `create_only` key can be set to have LXD only only create missing files but not overwrite an existing file.
-
-As a general rule, you should never template a file which is owned by a
-package or is otherwise expected to be overwritten by normal operation
-of the instance.
-
-For convenience the following functions are exported to Pongo2 templates:
-
-- `config_get("user.foo", "bar")` => Returns the value of `user.foo` or `"bar"` if unset.

--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -2,8 +2,8 @@
 discourse: 9310
 ---
 
-(image-handling)=
-# Image handling
+(about-images)=
+# About images
 
 ```{youtube} https://www.youtube.com/watch?v=wT7IDjo0Wgg
 ```

--- a/doc/images.md
+++ b/doc/images.md
@@ -4,7 +4,5 @@
 ```{toctree}
 :maxdepth: 1
 
-architectures
-Cloud-init <cloud-init>
-Handling <image-handling>
+image-handling
 ```

--- a/doc/images.md
+++ b/doc/images.md
@@ -5,4 +5,11 @@
 :maxdepth: 1
 
 image-handling
+Use remote images <howto/images_remote>
+Manage images <howto/images_manage>
+Copy and import images <howto/images_copy>
+Create images <howto/images_create>
+Associate profiles <howto/images_profiles>
+reference/remote_image_servers
+reference/image_format
 ```

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -10,6 +10,7 @@ Manage instances <howto/instances_manage.md>
 Configure instances <howto/instances_configure.md>
 Create snapshots <howto/instances_snapshots.md>
 Use profiles <profiles.md>
+Use cloud-init <cloud-init>
 Run commands <instance-exec.md>
 Access the console <howto/instances_console.md>
 Access files <howto/instances_access_files.md>

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -9,4 +9,5 @@ remotes
 explanation/performance_tuning
 Backups <backup>
 migration
+architectures
 ```

--- a/doc/reference/image_format.md
+++ b/doc/reference/image_format.md
@@ -1,2 +1,118 @@
 (image-format)=
 # Image format
+
+## Image format
+
+LXD currently supports two LXD-specific image formats.
+
+The first is a unified tarball, where a single tarball
+contains both the instance root and the needed metadata.
+
+The second is a split model, using two files instead, one containing
+the root, the other containing the metadata.
+
+The former is what's produced by LXD itself and what people should be
+using for LXD-specific images.
+
+The latter is designed to allow for easy image building from existing
+non-LXD rootfs tarballs already available today.
+
+### Unified tarball
+
+Tarball, can be compressed and contains:
+
+- `rootfs/`
+- `metadata.yaml`
+- `templates/` (optional)
+
+In this mode, the image identifier is the SHA-256 of the tarball.
+
+### Split tarballs
+
+Two (possibly compressed) tarballs. One for metadata, one for the rootfs.
+
+`metadata.tar` contains:
+
+- `metadata.yaml`
+- `templates/` (optional)
+
+`rootfs.tar` contains a Linux root file system at its root.
+
+In this mode the image identifier is the SHA-256 of the concatenation of
+the metadata and rootfs tarball (in that order).
+
+### Supported compression
+
+LXD supports a wide variety of compression algorithms for tarballs
+though for compatibility purposes, `gzip` or `xz` should be preferred.
+
+For split images, the rootfs file can also be SquashFS-formatted in the
+container case. For virtual machines, the `rootfs.img` file is always
+`qcow2` and can optionally be compressed using `qcow2`'s native compression.
+
+### Content
+
+For containers, the rootfs directory (or tarball) contains a full file system tree of what will become the `/`.
+For VMs, this is instead a `rootfs.img` file which becomes the main disk device.
+
+The templates directory contains Pongo2-formatted templates of files inside the instance.
+
+`metadata.yaml` contains information relevant to running the image under
+LXD, at the moment, this contains:
+
+```yaml
+architecture: x86_64
+creation_date: 1424284563
+properties:
+  description: Ubuntu 22.04 LTS Intel 64bit
+  os: Ubuntu
+  release: jammy 22.04
+templates:
+  /etc/hosts:
+    when:
+      - create
+      - rename
+    template: hosts.tpl
+    properties:
+      foo: bar
+  /etc/hostname:
+    when:
+      - start
+    template: hostname.tpl
+  /etc/network/interfaces:
+    when:
+      - create
+    template: interfaces.tpl
+    create_only: true
+```
+
+The `architecture` and `creation_date` fields are mandatory, the properties
+are just a set of default properties for the image. The `os`, `release`,
+`name` and `description` fields while not mandatory in any way, should be
+pretty common.
+
+For templates, the `when` key can be one or more of:
+
+- `create` (run at the time a new instance is created from the image)
+- `copy` (run when an instance is created from an existing one)
+- `start` (run every time the instance is started)
+
+The templates will always receive the following context:
+
+- `trigger`: name of the event which triggered the template (string)
+- `path`: path of the file that uses the template (string)
+- `container`: key/value map of instance properties (name, architecture, privileged and ephemeral) (map[string]string) (deprecated in favor of `instance`)
+- `instance`: key/value map of instance properties (name, architecture, privileged and ephemeral) (map[string]string)
+- `config`: key/value map of the instance's configuration (map[string]string)
+- `devices`: key/value map of the devices assigned to this instance (map[string]map[string]string)
+- `properties`: key/value map of the template properties specified in `metadata.yaml` (map[string]string)
+
+The `create_only` key can be set to have LXD only only create missing files but not overwrite an existing file.
+
+As a general rule, you should never template a file which is owned by a
+package or is otherwise expected to be overwritten by normal operation
+of the instance.
+
+For convenience the following functions are exported to Pongo2 templates:
+
+- `config_get("user.foo", "bar")` => Returns the value of `user.foo` or `"bar"` if unset.

--- a/doc/reference/image_format.md
+++ b/doc/reference/image_format.md
@@ -1,0 +1,2 @@
+(image-format)=
+# Image format

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,2 +1,8 @@
 (remote-image-servers)=
 # Remote image servers
+
+LXD comes with 3 default servers:
+
+ 1. `ubuntu:` (for stable Ubuntu images)
+ 2. `ubuntu-daily:` (for daily Ubuntu images)
+ 3. `images:` (for a [bunch of other distros](https://images.linuxcontainers.org))

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,0 +1,2 @@
+(remote-image-servers)=
+# Remote image servers

--- a/doc/reference/remote_image_servers.md
+++ b/doc/reference/remote_image_servers.md
@@ -1,8 +1,43 @@
 (remote-image-servers)=
 # Remote image servers
 
-LXD comes with 3 default servers:
+The `lxc` CLI command comes pre-configured with the following default remote image servers:
 
- 1. `ubuntu:` (for stable Ubuntu images)
- 2. `ubuntu-daily:` (for daily Ubuntu images)
- 3. `images:` (for a [bunch of other distros](https://images.linuxcontainers.org))
+`images:`
+: This server provides unofficial images for a variety of Linux distributions.
+  The images are maintained by the LXD team and are built to be compact and minimal.
+
+  See [`images.linuxcontainers.org`](https://images.linuxcontainers.org) for an overview of available images.
+
+`ubuntu:`
+: This server provides official stable Ubuntu images.
+  All images are cloud images, which means that they include both `cloud-init` and the `lxd-agent`.
+
+  See [`cloud-images.ubuntu.com/releases`](https://cloud-images.ubuntu.com/releases/) for an overview of available images.
+
+`ubuntu-daily:`
+: This server provides official daily Ubuntu images.
+  All images are cloud images, which means that they include both `cloud-init` and the `lxd-agent`.
+
+  See [`cloud-images.ubuntu.com/daily`](https://cloud-images.ubuntu.com/daily/) for an overview of available images.
+
+(remote-image-server-types)=
+## Remote server types
+
+LXD supports the following types of remote image servers:
+
+Simple streams servers
+: Pure image servers that use the [simple streams format](https://git.launchpad.net/simplestreams/tree/).
+  The default image servers are simple streams servers.
+
+Public LXD servers
+: LXD servers that are used solely to serve images and do not run instances themselves.
+
+  To make a LXD server publicly available over the network on port 8443, set the [`core.https_address`](server-options-core) configuration option to `:8443` and do not configure any authentication methods (see {ref}`server-expose` for more information).
+  Then set the images that you want to share to `public`.
+
+LXD servers
+: Regular LXD servers that you can manage over a network, and that can also be used as image servers.
+
+  For security reasons, you should restrict the access to the remote API and configure an authentication method to control access.
+  See {ref}`server-expose` and {ref}`authentication` for more information.


### PR DESCRIPTION
Clean up the Images section - part of the content that is in there at the moment doesn't belong there, and a lot of instructional content is missing.

This PR adds this content, partly moving it over from the Getting Started and Advanced Guide on the website, partly adding new content.