### PR TITLE
lxd: hotplug mounts

### DIFF
--- a/lxd/include/macro.h
+++ b/lxd/include/macro.h
@@ -338,4 +338,17 @@ enum {
 #define STRINGIFY(a) __STRINGIFY(a)
 #define __STRINGIFY(a) #a
 
+#define log_stderr(format, ...)                                               \
+	fprintf(stderr, "%s: %d: %s - %m - " format "\n", __FILE__, __LINE__, \
+		__func__, ##__VA_ARGS__)
+
+#define die_errno(__errno__, format, ...)          \
+	({                                         \
+		errno = (__errno__);               \
+		log_stderr(format, ##__VA_ARGS__); \
+		_exit(EXIT_FAILURE);               \
+	})
+
+#define die(format, ...) die_errno(errno, format, ##__VA_ARGS__)
+
 #endif /* __LXC_MACRO_H */

--- a/lxd/include/mount_utils.h
+++ b/lxd/include/mount_utils.h
@@ -5,16 +5,19 @@
 #define _GNU_SOURCE 1
 #endif
 #include <linux/sched.h>
+#include <linux/types.h>
 #include <sched.h>
 #include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include "compiler.h"
+#include "syscall_numbers.h"
 
 // open_tree() flags
 #ifndef OPEN_TREE_CLONE
@@ -25,7 +28,48 @@
 #define OPEN_TREE_CLOEXEC O_CLOEXEC
 #endif
 
+// fsmount() flags
+#ifndef FSMOUNT_CLOEXEC
+#define FSMOUNT_CLOEXEC 0x00000001
+#endif
+
 // mount attributes
+#ifndef MOUNT_ATTR_RDONLY
+#define MOUNT_ATTR_RDONLY 0x00000001 /* Mount read-only */
+#endif
+
+#ifndef MOUNT_ATTR_NOSUID
+#define MOUNT_ATTR_NOSUID 0x00000002 /* Ignore suid and sgid bits */
+#endif
+
+#ifndef MOUNT_ATTR_NODEV
+#define MOUNT_ATTR_NODEV 0x00000004 /* Disallow access to device special files */
+#endif
+
+#ifndef MOUNT_ATTR_NOEXEC
+#define MOUNT_ATTR_NOEXEC 0x00000008 /* Disallow program execution */
+#endif
+
+#ifndef MOUNT_ATTR__ATIME
+#define MOUNT_ATTR__ATIME 0x00000070 /* Setting on how atime should be updated */
+#endif
+
+#ifndef MOUNT_ATTR_RELATIME
+#define MOUNT_ATTR_RELATIME 0x00000000 /* - Update atime relative to mtime/ctime. */
+#endif
+
+#ifndef MOUNT_ATTR_NOATIME
+#define MOUNT_ATTR_NOATIME 0x00000010 /* - Do not update access times. */
+#endif
+
+#ifndef MOUNT_ATTR_STRICTATIME
+#define MOUNT_ATTR_STRICTATIME 0x00000020 /* - Always perform atime updates */
+#endif
+
+#ifndef MOUNT_ATTR_NODIRATIME
+#define MOUNT_ATTR_NODIRATIME 0x00000080 /* Do not update directory access times */
+#endif
+
 #ifndef MOUNT_ATTR_IDMAP
 #define MOUNT_ATTR_IDMAP 0x00100000
 #endif
@@ -58,6 +102,61 @@
 #ifndef MOVE_MOUNT__MASK
 #define MOVE_MOUNT__MASK 0x00000077
 #endif
+
+#ifndef FSCONFIG_SET_STRING
+#define FSCONFIG_SET_STRING 1 /* Set parameter, supplying a string value */
+#endif
+
+#ifndef FSCONFIG_CMD_CREATE
+#define FSCONFIG_CMD_CREATE 6 /* Invoke superblock creation */
+#endif
+
+#ifndef FSOPEN_CLOEXEC
+#define FSOPEN_CLOEXEC 0x00000001
+#endif
+
+static inline int lxd_fsopen(const char *fs_name, unsigned int flags)
+{
+	return syscall(__NR_fsopen, fs_name, flags);
+}
+
+static inline int lxd_fsconfig(int fd, unsigned int cmd, const char *key,
+			       const void *value, int aux)
+{
+	return syscall(__NR_fsconfig, fd, cmd, key, value, aux);
+}
+
+static inline int lxd_fsmount(int fs_fd, unsigned int flags,
+			      unsigned int attr_flags)
+{
+	return syscall(__NR_fsmount, fs_fd, flags, attr_flags);
+}
+
+static inline int lxd_open_tree(int dfd, const char *filename, unsigned int flags)
+{
+	return syscall(__NR_open_tree, dfd, filename, flags);
+}
+
+struct lxc_mount_attr {
+	__u64 attr_set;
+	__u64 attr_clr;
+	__u64 propagation;
+	__u64 userns_fd;
+};
+
+static inline int lxd_mount_setattr(int dfd, const char *path, unsigned int flags,
+				    struct lxc_mount_attr *attr, size_t size)
+{
+	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
+}
+
+static inline int lxd_move_mount(int from_dfd, const char *from_pathname,
+				 int to_dfd, const char *to_pathname,
+				 unsigned int flags)
+{
+	return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd,
+		       to_pathname, flags);
+}
 
 #endif /* __LXD_MOUNT_UTILS_H */
 

--- a/lxd/include/syscall_numbers.h
+++ b/lxd/include/syscall_numbers.h
@@ -243,4 +243,64 @@
 	#endif
 #endif
 
+#ifndef __NR_fsopen
+	#if defined __alpha__
+		#define __NR_fsopen 540
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_fsopen 4430
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_fsopen 6430
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_fsopen 5430
+		#endif
+	#elif defined __ia64__
+		#define __NR_fsopen (430 + 1024)
+	#else
+		#define __NR_fsopen 430
+	#endif
+#endif
+
+#ifndef __NR_fsconfig
+	#if defined __alpha__
+		#define __NR_fsconfig 541
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_fsconfig 4431
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_fsconfig 6431
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_fsconfig 5431
+		#endif
+	#elif defined __ia64__
+		#define __NR_fsconfig (431 + 1024)
+	#else
+		#define __NR_fsconfig 431
+	#endif
+#endif
+
+#ifndef __NR_fsmount
+	#if defined __alpha__
+		#define __NR_fsmount 542
+	#elif defined _MIPS_SIM
+		#if _MIPS_SIM == _MIPS_SIM_ABI32	/* o32 */
+			#define __NR_fsmount 4432
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_NABI32	/* n32 */
+			#define __NR_fsmount 6432
+		#endif
+		#if _MIPS_SIM == _MIPS_SIM_ABI64	/* n64 */
+			#define __NR_fsmount 5432
+		#endif
+	#elif defined __ia64__
+		#define __NR_fsmount (432 + 1024)
+	#else
+		#define __NR_fsmount 432
+	#endif
+#endif
+
 #endif /* __LXD_SYSCALL_NUMBERS_H */

--- a/lxd/include/syscall_wrappers.h
+++ b/lxd/include/syscall_wrappers.h
@@ -27,35 +27,6 @@ static inline int lxd_close_range(unsigned int fd, unsigned int max_fd, unsigned
 	return syscall(__NR_close_range, fd, max_fd, flags);
 }
 
-static inline int lxd_open_tree(int dfd, const char *filename, unsigned int flags)
-{
-	return syscall(__NR_open_tree, dfd, filename, flags);
-}
-
-/*
- * mount_setattr()
- */
-struct lxc_mount_attr {
-	__u64 attr_set;
-	__u64 attr_clr;
-	__u64 propagation;
-	__u64 userns_fd;
-};
-
-static inline int lxd_mount_setattr(int dfd, const char *path, unsigned int flags,
-				    struct lxc_mount_attr *attr, size_t size)
-{
-	return syscall(__NR_mount_setattr, dfd, path, flags, attr, size);
-}
-
-static inline int lxd_move_mount(int from_dfd, const char *from_pathname,
-				 int to_dfd, const char *to_pathname,
-				 unsigned int flags)
-{
-	return syscall(__NR_move_mount, from_dfd, from_pathname, to_dfd,
-		       to_pathname, flags);
-}
-
 /* arg1 of prctl() */
 #ifndef PR_SCHED_CORE
 #define PR_SCHED_CORE 62

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6180,7 +6180,7 @@ func (d *lxc) insertMountLXD(source, target, fstype string, flags int, mntnsPID 
 	}
 
 	_, err = shared.RunCommandInheritFds(
-		context.TODO(),
+		context.Background(),
 		[]*os.File{pidFd},
 		d.state.OS.ExecPath,
 		"forkmount",
@@ -6229,7 +6229,58 @@ func (d *lxc) insertMountLXC(source, target, fstype string, flags int) error {
 	return nil
 }
 
+func (d *lxc) moveMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
+	// Get the init PID
+	pid := d.InitPID()
+	if pid == -1 {
+		// Container isn't running
+		return fmt.Errorf("Can't insert mount into stopped container")
+	}
+
+	switch idmapType {
+	case idmap.IdmapStorageIdmapped:
+	case idmap.IdmapStorageNone:
+	default:
+		return fmt.Errorf("Invalid idmap value specified")
+	}
+
+	pidFdNr, pidFd := seccomp.MakePidFd(pid, d.state)
+	if pidFdNr >= 0 {
+		defer func() { _ = pidFd.Close() }()
+	}
+
+	pidStr := fmt.Sprintf("%d", pid)
+
+	if !strings.HasPrefix(target, "/") {
+		target = "/" + target
+	}
+
+	_, err := shared.RunCommandInheritFds(
+		context.Background(),
+		[]*os.File{pidFd},
+		d.state.OS.ExecPath,
+		"forkmount",
+		"move-mount",
+		"--",
+		pidStr,
+		fmt.Sprintf("%d", pidFdNr),
+		fstype,
+		source,
+		target,
+		string(idmapType),
+		fmt.Sprintf("%d", flags))
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (d *lxc) insertMount(source, target, fstype string, flags int, idmapType idmap.IdmapStorageType) error {
+	if d.state.OS.IdmappedMounts && idmapType != idmap.IdmapStorageShiftfs {
+		return d.moveMount(source, target, fstype, flags, idmapType)
+	}
+
 	if d.state.OS.LXCFeatures["mount_injection_file"] && idmapType == idmap.IdmapStorageNone {
 		return d.insertMountLXC(source, target, fstype, flags)
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1276,11 +1276,13 @@ func (d *lxc) initLXC(config bool) error {
 }
 
 var idmappedStorageMap map[unix.Fsid]idmap.IdmapStorageType = map[unix.Fsid]idmap.IdmapStorageType{}
+var idmappedStorageMapString map[string]idmap.IdmapStorageType = map[string]idmap.IdmapStorageType{}
 var idmappedStorageMapLock sync.Mutex
 
 // IdmappedStorage determines if the container can use idmapped mounts or shiftfs.
-func (d *lxc) IdmappedStorage(path string) idmap.IdmapStorageType {
+func (d *lxc) IdmappedStorage(path string, fstype string) idmap.IdmapStorageType {
 	var mode idmap.IdmapStorageType = idmap.IdmapStorageNone
+	var bindMount bool = fstype == "none" || fstype == ""
 
 	if d.state.OS.Shiftfs {
 		// Fallback to shiftfs.
@@ -1292,28 +1294,44 @@ func (d *lxc) IdmappedStorage(path string) idmap.IdmapStorageType {
 	}
 
 	buf := &unix.Statfs_t{}
-	err := unix.Statfs(path, buf)
-	if err != nil {
-		// Log error but fallback to shiftfs
-		d.logger.Error("Failed to statfs", logger.Ctx{"path": path, "err": err})
-		return mode
+
+	if bindMount {
+		err := unix.Statfs(path, buf)
+		if err != nil {
+			// Log error but fallback to shiftfs
+			d.logger.Error("Failed to statfs", logger.Ctx{"path": path, "err": err})
+			return mode
+		}
 	}
 
 	idmappedStorageMapLock.Lock()
 	defer idmappedStorageMapLock.Unlock()
 
-	val, ok := idmappedStorageMap[buf.Fsid]
-	if ok {
-		// Return recorded idmapping type.
-		return val
+	if bindMount {
+		val, ok := idmappedStorageMap[buf.Fsid]
+		if ok {
+			// Return recorded idmapping type.
+			return val
+		}
+	} else {
+		val, ok := idmappedStorageMapString[fstype]
+		if ok {
+			// Return recorded idmapping type.
+			return val
+		}
 	}
 
-	if idmap.CanIdmapMount(path) {
+	d.logger.Error("", logger.Ctx{"path": path, "fstype": fstype})
+	if idmap.CanIdmapMount(path, fstype) {
 		// Use idmapped mounts.
 		mode = idmap.IdmapStorageIdmapped
 	}
 
-	idmappedStorageMap[buf.Fsid] = mode
+	if bindMount {
+		idmappedStorageMap[buf.Fsid] = mode
+	} else {
+		idmappedStorageMapString[fstype] = mode
+	}
 
 	return mode
 }
@@ -1628,7 +1646,7 @@ func (d *lxc) deviceHandleMounts(mounts []deviceConfig.MountEntryItem) error {
 
 			var idmapType idmap.IdmapStorageType = idmap.IdmapStorageNone
 			if !d.IsPrivileged() && mount.OwnerShift == deviceConfig.MountOwnerShiftDynamic {
-				idmapType = d.IdmappedStorage(mount.DevPath)
+				idmapType = d.IdmappedStorage(mount.DevPath, mount.FSType)
 				if idmapType == idmap.IdmapStorageNone {
 					return fmt.Errorf("Required idmapping abilities not available")
 				}
@@ -1758,7 +1776,7 @@ func (d *lxc) handleIdmappedStorage() (idmap.IdmapStorageType, *idmap.IdmapSet, 
 
 	// There's no on-disk idmap applied and the container can use idmapped
 	// storage.
-	idmapType := d.IdmappedStorage(d.RootfsPath())
+	idmapType := d.IdmappedStorage(d.RootfsPath(), "none")
 	if diskIdmap == nil && idmapType != idmap.IdmapStorageNone {
 		return idmapType, nextIdmap, nil
 	}
@@ -2090,7 +2108,7 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 				mntOptions := strings.Join(mount.Opts, ",")
 
 				if !d.IsPrivileged() && mount.OwnerShift == deviceConfig.MountOwnerShiftDynamic {
-					switch d.IdmappedStorage(mount.DevPath) {
+					switch d.IdmappedStorage(mount.DevPath, mount.FSType) {
 					case idmap.IdmapStorageIdmapped:
 						mntOptions = strings.Join([]string{mntOptions, "idmap=container"}, ",")
 					case idmap.IdmapStorageShiftfs:
@@ -6060,7 +6078,7 @@ func (d *lxc) unmount() error {
 		return err
 	}
 
-	if d.IdmappedStorage(d.RootfsPath()) == idmap.IdmapStorageShiftfs && !d.IsPrivileged() && diskIdmap == nil {
+	if d.IdmappedStorage(d.RootfsPath(), "none") == idmap.IdmapStorageShiftfs && !d.IsPrivileged() && diskIdmap == nil {
 		_ = unix.Unmount(d.RootfsPath(), unix.MNT_DETACH)
 	}
 

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -169,7 +169,7 @@ type Container interface {
 	ConsoleLog(opts liblxc.ConsoleLogOptions) (string, error)
 	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 	DevptsFd() (*os.File, error)
-	IdmappedStorage(path string) idmap.IdmapStorageType
+	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
 }
 
 // VM interface is for VM specific functions.

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -30,6 +30,7 @@ import (
 #include <sys/xattr.h>
 #include <unistd.h>
 
+#include "include/macro.h"
 #include "include/memory_utils.h"
 #include "include/mount_utils.h"
 #include "include/syscall_numbers.h"
@@ -41,19 +42,6 @@ extern int pidfd_nsfd(int pidfd, pid_t pid);
 extern int preserve_ns(pid_t pid, int ns_fd, const char *ns);
 extern bool change_namespaces(int pidfd, int nsfd, unsigned int flags);
 extern int mount_detach_idmap(const char *path, int fd_userns);
-
-#define log_stderr(format, ...)                                                         \
-	fprintf(stderr, "%s: %d: %s - %m - " format "\n", __FILE__, __LINE__, __func__, \
-		##__VA_ARGS__)
-
-#define die_errno(__errno__, format, ...)          \
-	({                                         \
-		errno = (__errno__);               \
-		log_stderr(format, ##__VA_ARGS__); \
-		_exit(EXIT_FAILURE);                \
-	})
-
-#define die(format, ...) die_errno(errno, format, ##__VA_ARGS__)
 
 static bool chdirchroot_in_mntns(int cwd_fd, int root_fd)
 {

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -614,7 +614,7 @@ type Instance interface {
 	CGroup() (*cgroup.CGroup, error)
 	CurrentIdmap() (*idmap.IdmapSet, error)
 	DiskIdmap() (*idmap.IdmapSet, error)
-	IdmappedStorage(path string) idmap.IdmapStorageType
+	IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
 	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 }
 
@@ -2463,7 +2463,7 @@ func (s *Server) MountSyscallShift(c Instance, path string) idmap.IdmapStorageTy
 		}
 
 		if diskIdmap == nil {
-			return c.IdmappedStorage(path)
+			return c.IdmappedStorage(path, "none")
 		}
 	}
 

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -334,6 +334,7 @@ static int create_detached_idmapped_mount(const char *path, const char *fstype)
 	} else {
 		mnt_fd = lxd_open_tree(-EBADF, path, OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC);
 	}
+
 	if (mnt_fd < 0)
 		return -errno;
 

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -307,9 +307,9 @@ static int get_userns_fd(void)
 	return ret;
 }
 
-static int create_detached_idmapped_mount(const char *path)
+static int create_detached_idmapped_mount(const char *path, const char *fstype)
 {
-	__do_close int fd_tree = -EBADF, fd_userns = -EBADF;
+	__do_close int fs_fd = -EBADF, mnt_fd = -EBADF, fd_userns = -EBADF;
 	struct lxc_mount_attr attr = {
 	    .attr_set		= MOUNT_ATTR_IDMAP,
 	    .propagation	= MS_SLAVE,
@@ -317,8 +317,24 @@ static int create_detached_idmapped_mount(const char *path)
 	};
 	int ret;
 
-	fd_tree = lxd_open_tree(-EBADF, path, OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC);
-	if (fd_tree < 0)
+	if (strcmp(fstype, "") && strcmp(fstype, "none")) {
+		fs_fd = lxd_fsopen(fstype, FSOPEN_CLOEXEC);
+		if (fs_fd < 0)
+			return -errno;
+
+		ret = lxd_fsconfig(fs_fd, FSCONFIG_SET_STRING, "source", path, 0);
+		if (ret < 0)
+			return -errno;
+
+		ret = lxd_fsconfig(fs_fd, FSCONFIG_CMD_CREATE, NULL, NULL, 0);
+		if (ret < 0)
+			return -errno;
+
+		mnt_fd = lxd_fsmount(fs_fd, FSMOUNT_CLOEXEC, 0);
+	} else {
+		mnt_fd = lxd_open_tree(-EBADF, path, OPEN_TREE_CLONE | OPEN_TREE_CLOEXEC);
+	}
+	if (mnt_fd < 0)
 		return -errno;
 
 	fd_userns = get_userns_fd();
@@ -327,7 +343,7 @@ static int create_detached_idmapped_mount(const char *path)
 
 	attr.userns_fd = fd_userns;
 
-	ret = lxd_mount_setattr(fd_tree, "", AT_EMPTY_PATH, &attr, sizeof(attr));
+	ret = lxd_mount_setattr(mnt_fd, "", AT_EMPTY_PATH, &attr, sizeof(attr));
 	if (ret < 0)
 		return -errno;
 
@@ -609,9 +625,11 @@ const (
 	IdmapStorageShiftfs  = "shiftfs"
 )
 
-func CanIdmapMount(path string) bool {
+func CanIdmapMount(path string, fstype string) bool {
 	cpath := C.CString(path)
 	defer C.free(unsafe.Pointer(cpath))
+	cfstype := C.CString(fstype)
+	defer C.free(unsafe.Pointer(cfstype))
 
-	return bool(C.create_detached_idmapped_mount(cpath) == 0)
+	return bool(C.create_detached_idmapped_mount(cpath, cfstype) == 0)
 }


### PR DESCRIPTION
For centuries we've worked ourselves to the bone with mount propagation
to hotplug mounts. No more! The new mount api does have proper support
for moving a mount into a container. I've had that on my ToDo for a
while but due to recent events this has been bumped up on my priority
list.

So here it is. A way to simply have LXD prepare a mount with exactly the
options we want and then to hand that fd to the container and the
container can just attach it to the correct place. No more pointless
mount propagation shenaningans.

I would also like to call out that this has some elegant properties. For
example, every filesystem that supports idmapped mounts can be exposed
to a container completely idmapped. The filesystem can be directly
created with the idmap applied. Neither does the filesystem have to
appear anywhere before applying the idmapping nor are any additional
mounts required before applying the idmapping.

Signed-off-by: Christian Brauner (Microsoft) <brauner@kernel.org>