### PR TITLE
Fix usage of --destination-server flag when copying/moving storage volumes between remotes

### DIFF
--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -511,7 +511,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, 
 		return nil, fmt.Errorf("Failed to get destination connection info: %w", err)
 	}
 
-	if destInfo.URL == sourceInfo.URL && destInfo.SocketPath == sourceInfo.SocketPath && volume.Location == r.clusterTarget {
+	if destInfo.URL == sourceInfo.URL && destInfo.SocketPath == sourceInfo.SocketPath && (volume.Location == r.clusterTarget || (volume.Location == "none" && r.clusterTarget == "")) {
 		// Project handling
 		if destInfo.Project != sourceInfo.Project {
 			if !r.HasExtension("storage_api_project") {

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -869,7 +869,7 @@ msgstr "Aliasname fehlt"
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 #, fuzzy
 msgid "All projects"
 msgstr "Fehlerhafte Profil URL %s"
@@ -985,17 +985,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -1012,7 +1012,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1055,7 +1055,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1151,7 +1151,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1172,6 +1172,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1286,14 +1295,14 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1301,7 +1310,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Spalten"
@@ -1348,7 +1357,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -1357,11 +1366,11 @@ msgstr "YAML Analyse Fehler %v\n"
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Erstellt: %s"
@@ -1449,7 +1458,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1562,7 +1571,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage buckets"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1625,7 +1634,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the instance with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -1656,7 +1665,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
@@ -1676,7 +1685,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1769,7 +1778,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -1865,26 +1874,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -1898,12 +1907,12 @@ msgstr "Netzwerkschnittstellen an Container anbinden"
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2137,7 +2146,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2146,7 +2155,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2230,8 +2239,8 @@ msgstr ""
 "\n"
 "lxc exec <Container> [--env EDITOR=/usr/bin/vim]... <Befehl>\n"
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -2255,7 +2264,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2270,12 +2279,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Export instances as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2515,7 +2524,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2651,8 +2660,13 @@ msgstr "Profil %s erstellt\n"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2736,7 +2750,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2750,7 +2764,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2802,7 +2816,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2810,7 +2824,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2831,7 +2845,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2951,7 +2965,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -2960,7 +2974,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2979,9 +2993,9 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Ungültige Quelle %s"
@@ -3027,7 +3041,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3323,12 +3337,12 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "List storage buckets"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3387,7 +3401,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3655,8 +3669,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3855,13 +3869,13 @@ msgstr "Fehlende Zusammenfassung."
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -3886,7 +3900,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -3925,8 +3939,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3961,7 +3975,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -3971,11 +3985,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4003,7 +4017,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -4047,8 +4061,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -4056,7 +4070,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4204,7 +4218,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -4221,11 +4235,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4239,7 +4253,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
@@ -4252,11 +4266,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4268,7 +4282,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4281,7 +4295,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4323,7 +4337,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4399,8 +4413,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4783,17 +4797,17 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4844,7 +4858,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5174,12 +5188,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5336,12 +5350,12 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Profil %s erstellt\n"
@@ -5403,16 +5417,16 @@ msgstr "Größe: %.2vMB\n"
 msgid "Size: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5518,22 +5532,22 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Profil %s erstellt\n"
@@ -5584,11 +5598,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5688,8 +5702,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -5760,7 +5774,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Erstellt: %s"
@@ -5775,7 +5789,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "unbekannter entfernter Instanz Name: %q"
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5830,7 +5844,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5852,13 +5866,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5891,7 +5905,7 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Unknown channel type for client %q: %s"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6008,7 +6022,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Alternatives config Verzeichnis."
@@ -6043,12 +6057,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6111,7 +6125,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -6168,7 +6182,7 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "You must specify a source instance name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -6913,7 +6927,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -6980,7 +6994,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -6991,7 +7005,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -6999,7 +7013,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -7015,7 +7029,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -7023,7 +7037,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -7031,7 +7045,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7040,7 +7054,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7049,7 +7063,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7058,7 +7072,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -7066,8 +7080,8 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -7076,7 +7090,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -7085,7 +7099,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -7093,7 +7107,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -7629,27 +7643,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453
@@ -7746,19 +7760,19 @@ msgstr ""
 #~ "\n"
 #~ "lxd %s <Name>\n"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to validate \"%s:%s\": %w"
 #~ msgstr "Akzeptiere Zertifikat"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "Alternatives config Verzeichnis."
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Akzeptiere Zertifikat"
 
@@ -7782,7 +7796,7 @@ msgstr ""
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Kein Zertifikat für diese Verbindung"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Profil %s wurde auf %s angewandt\n"
 
@@ -8699,7 +8713,7 @@ msgstr ""
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "der Name des Ursprung Containers muss angegeben werden"
 
@@ -8785,7 +8799,7 @@ msgstr ""
 #~ "\n"
 #~ "lxd %s <Name>\n"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Admin password for %s:"
 #~ msgstr "Administrator Passwort für %s: "
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -713,16 +713,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -739,7 +739,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -782,7 +782,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -868,7 +868,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -889,6 +889,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -998,14 +1007,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1013,7 +1022,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1057,7 +1066,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1066,11 +1075,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1154,7 +1163,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1260,7 +1269,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1314,7 +1323,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1344,7 +1353,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1364,7 +1373,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1452,7 +1461,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1547,26 +1556,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "  Χρήση δικτύου:"
@@ -1579,11 +1588,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1801,7 +1810,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1809,7 +1818,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1883,8 +1892,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1908,7 +1917,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1920,11 +1929,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2159,7 +2168,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2290,8 +2299,13 @@ msgstr "  Χρήση δικτύου:"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2372,7 +2386,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2386,7 +2400,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2436,7 +2450,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2444,7 +2458,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2463,7 +2477,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2581,7 +2595,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2589,7 +2603,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2607,9 +2621,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2650,7 +2664,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2922,11 +2936,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2984,7 +2998,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3226,8 +3240,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3418,13 +3432,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3446,7 +3460,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "  Χρήση δικτύου:"
@@ -3484,8 +3498,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3517,7 +3531,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3525,11 +3539,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3556,7 +3570,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3600,8 +3614,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3609,7 +3623,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3755,7 +3769,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3771,11 +3785,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3789,7 +3803,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3801,11 +3815,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3817,7 +3831,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3830,7 +3844,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3872,7 +3886,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3946,8 +3960,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4309,15 +4323,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4365,7 +4379,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4685,11 +4699,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4839,11 +4853,11 @@ msgstr "  Χρήση δικτύου:"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4902,15 +4916,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5011,21 +5025,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5074,11 +5088,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5171,8 +5185,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5239,7 +5253,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5254,7 +5268,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5308,7 +5322,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5330,13 +5344,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5368,7 +5382,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5480,7 +5494,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5512,12 +5526,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "  Χρήση CPU:"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5576,7 +5590,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5625,7 +5639,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5998,7 +6012,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6033,17 +6047,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6051,44 +6065,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6499,27 +6513,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453
@@ -6580,7 +6594,7 @@ msgstr ""
 msgid "yes"
 msgstr ""
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "  Χρήση δικτύου:"
 
@@ -6588,6 +6602,6 @@ msgstr ""
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "  Χρήση δικτύου:"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "  Χρήση δικτύου:"

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -850,7 +850,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -959,16 +959,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -985,7 +985,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1116,7 +1116,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1137,6 +1137,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1247,14 +1256,14 @@ msgstr "Perfil %s eliminado de %s"
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
@@ -1262,7 +1271,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Columnas"
@@ -1308,7 +1317,7 @@ msgstr "Perfil para aplicar al nuevo contenedor"
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1317,11 +1326,11 @@ msgstr ""
 msgid "Console log:"
 msgstr "Log de la consola:"
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Auto actualización: %s"
@@ -1406,7 +1415,7 @@ msgstr "Copiando la imagen: %s"
 msgid "Copying the image: %s"
 msgstr "Copiando la imagen: %s"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1516,7 +1525,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Perfil %s creado"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1570,7 +1579,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -1601,7 +1610,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
@@ -1621,7 +1630,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1710,7 +1719,7 @@ msgstr "Perfil %s creado"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1805,26 +1814,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Huella dactilar: %s"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nombre del Miembro del Cluster"
@@ -1837,11 +1846,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2061,7 +2070,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2069,7 +2078,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2144,8 +2153,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 #, fuzzy
 msgid "Expires at"
 msgstr "Expira: %s"
@@ -2170,7 +2179,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2184,11 +2193,11 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Export instances as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2425,7 +2434,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2556,8 +2565,13 @@ msgstr "Perfil %s creado"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2641,7 +2655,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2655,7 +2669,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2705,7 +2719,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2713,7 +2727,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2733,7 +2747,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2853,7 +2867,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -2862,7 +2876,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2880,9 +2894,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Nombre del contenedor es: %s"
@@ -2924,7 +2938,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3203,11 +3217,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3266,7 +3280,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3509,8 +3523,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3707,13 +3721,13 @@ msgstr "Nombre del contenedor es: %s"
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3736,7 +3750,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nombre del contenedor es: %s"
@@ -3776,8 +3790,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3810,7 +3824,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3818,11 +3832,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3849,7 +3863,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3893,8 +3907,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3902,7 +3916,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4046,7 +4060,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4062,11 +4076,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4080,7 +4094,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4092,11 +4106,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4108,7 +4122,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4121,7 +4135,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4163,7 +4177,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4237,8 +4251,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4606,15 +4620,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4665,7 +4679,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4986,11 +5000,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5140,11 +5154,11 @@ msgstr "Perfil %s creado"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5203,15 +5217,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5313,21 +5327,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5376,11 +5390,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5475,8 +5489,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Auto actualización: %s"
@@ -5559,7 +5573,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5615,7 +5629,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
@@ -5637,13 +5651,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5675,7 +5689,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5787,7 +5801,7 @@ msgstr "Perfil %s creado"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5820,12 +5834,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5884,7 +5898,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5933,7 +5947,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6391,7 +6405,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6434,19 +6448,19 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6456,53 +6470,53 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -6942,27 +6956,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453
@@ -7035,19 +7049,19 @@ msgstr ""
 #~ msgid "[<remote>:] <token>"
 #~ msgstr "No se puede proveer el nombre del container a la lista"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to validate \"%s:%s\": %w"
 #~ msgstr "Acepta certificado"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "Nombre del contenedor es: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Nombre del Miembro del Cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Acepta certificado"
 
@@ -7135,7 +7149,6 @@ msgstr ""
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Certificado del cliente almacenado en el servidor: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "No se peude leer desde stdin: %s"
 
@@ -7143,7 +7156,7 @@ msgstr ""
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Nombre del Miembro del Cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Nombre del Miembro del Cluster"
 
@@ -7223,6 +7236,6 @@ msgstr ""
 #~ msgid "[<remote>:]<network> <listen_address> [<default_target_address>]"
 #~ msgstr "No se puede proveer el nombre del container a la lista"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Admin password for %s:"
 #~ msgstr "Contraseña admin para %s: "

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -876,7 +876,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 #, fuzzy
 msgid "All projects"
 msgstr "Rendre l'image publique"
@@ -991,17 +991,17 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -1018,7 +1018,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1061,7 +1061,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1150,7 +1150,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1173,6 +1173,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1283,14 +1292,14 @@ msgstr "Périphérique %s retiré de %s"
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1298,7 +1307,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonnes"
@@ -1353,7 +1362,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -1362,11 +1371,11 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "État : %s"
@@ -1455,7 +1464,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -1584,7 +1593,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create new custom storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1647,7 +1656,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the instance with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -1678,7 +1687,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1698,7 +1707,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1795,7 +1804,7 @@ msgstr "Copie de l'image : %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
@@ -1892,26 +1901,26 @@ msgstr "Récupération de l'image : %s"
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -1924,12 +1933,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2160,7 +2169,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2169,7 +2178,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2261,8 +2270,8 @@ msgstr ""
 "sélectionné si à la fois stdin et stdout sont des terminaux (stderr\n"
 "est ignoré)."
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 #, fuzzy
 msgid "Expires at"
 msgstr "Expire : %s"
@@ -2288,7 +2297,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Copie de l'image : %s"
@@ -2303,12 +2312,12 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Export instances as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -2550,7 +2559,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2687,8 +2696,13 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2774,7 +2788,7 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2791,7 +2805,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2845,7 +2859,7 @@ msgstr "Image copiée avec succès !"
 msgid "Immediately attach to the console"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2853,7 +2867,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Copie de l'image : %s"
@@ -2875,7 +2889,7 @@ msgstr "Import de l'image : %s"
 msgid "Import instance backups"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -2996,7 +3010,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -3005,7 +3019,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -3024,9 +3038,9 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Le nom du conteneur est : %s"
@@ -3069,7 +3083,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3410,12 +3424,12 @@ msgstr "Copie de l'image : %s"
 msgid "List storage buckets"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3474,7 +3488,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3736,8 +3750,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3939,13 +3953,13 @@ msgstr "Résumé manquant."
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 #, fuzzy
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -3970,7 +3984,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nom de l'ensemble de stockage"
@@ -4011,8 +4025,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 #, fuzzy
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
@@ -4048,7 +4062,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
@@ -4058,11 +4072,11 @@ msgstr "Copie de l'image : %s"
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Copie de l'image : %s"
@@ -4090,7 +4104,7 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr "NOM"
 
@@ -4134,8 +4148,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 #, fuzzy
 msgid "Name"
 msgstr "Nom : %s"
@@ -4144,7 +4158,7 @@ msgstr "Nom : %s"
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -4292,7 +4306,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -4309,11 +4323,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4327,7 +4341,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
@@ -4342,13 +4356,13 @@ msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 #, fuzzy
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 #, fuzzy
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
@@ -4363,7 +4377,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 #, fuzzy
 msgid "Only instance or custom volumes are supported"
 msgstr ""
@@ -4379,7 +4393,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4422,7 +4436,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4499,8 +4513,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 #, fuzzy
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
@@ -4886,17 +4900,17 @@ msgstr "Créé : %s"
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4964,7 +4978,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -5299,12 +5313,12 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 #, fuzzy
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5466,12 +5480,12 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 #, fuzzy
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Afficher la configuration étendue"
@@ -5534,16 +5548,16 @@ msgstr "Taille : %.2f Mo"
 msgid "Size: %s"
 msgstr "État : %s"
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -5650,22 +5664,22 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 #, fuzzy
 msgid "Storage volume copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 #, fuzzy
 msgid "Storage volume moved successfully!"
 msgstr "Image copiée avec succès !"
@@ -5718,11 +5732,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 #, fuzzy
 msgid "Taken at"
 msgstr "pris à %s"
@@ -5825,8 +5839,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -5898,7 +5912,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Publié : %s"
@@ -5913,7 +5927,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5969,7 +5983,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
@@ -5991,13 +6005,13 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -6030,7 +6044,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6150,7 +6164,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 #, fuzzy
 msgid "Unset storage volume configuration keys"
 msgstr "Clé de configuration invalide"
@@ -6185,12 +6199,12 @@ msgstr "Publié : %s"
 msgid "Upper devices"
 msgstr "Création du conteneur"
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr "Utilisation : %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6250,7 +6264,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -6307,7 +6321,7 @@ msgstr "vous devez spécifier un nom de conteneur source"
 msgid "You must specify a source instance name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -7127,7 +7141,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -7194,7 +7208,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -7208,7 +7222,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -7216,7 +7230,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -7232,7 +7246,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -7240,7 +7254,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -7248,7 +7262,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -7260,7 +7274,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -7272,7 +7286,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -7284,7 +7298,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -7292,8 +7306,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -7305,7 +7319,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -7317,7 +7331,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -7325,7 +7339,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -7895,27 +7909,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453
@@ -8016,7 +8030,7 @@ msgstr "oui"
 #~ "\n"
 #~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to validate \"%s:%s\": %w"
 #~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
@@ -8027,18 +8041,18 @@ msgstr "oui"
 #~ msgstr ""
 #~ "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "Clé de configuration invalide"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #~ msgid "Ips:"
 #~ msgstr "IPs :"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Échec lors de la génération de 'lxc.1': %v"
 
@@ -8065,11 +8079,11 @@ msgstr "oui"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Nom du réseau"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to create alias %s"
 #~ msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Profil %s ajouté à %s"
 
@@ -9535,7 +9549,7 @@ msgstr "oui"
 #~ "\n"
 #~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %w"
 #~ msgstr "Échec lors de la génération de 'lxc.1': %v"
 
@@ -9543,7 +9557,6 @@ msgstr "oui"
 #~ msgid "Remote disconnected"
 #~ msgstr "Mot de passe de l'administrateur distant"
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Impossible de lire depuis stdin : %s"
 
@@ -9559,7 +9572,7 @@ msgstr "oui"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
@@ -9648,7 +9661,7 @@ msgstr "oui"
 #~ "\n"
 #~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Admin password for %s:"
 #~ msgstr "Mot de passe administrateur pour %s : "
 

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -712,16 +712,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -781,7 +781,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -887,6 +887,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -996,14 +1005,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1011,7 +1020,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1055,7 +1064,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1064,11 +1073,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1152,7 +1161,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1257,7 +1266,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1309,7 +1318,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1339,7 +1348,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1359,7 +1368,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1443,7 +1452,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1538,26 +1547,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1569,11 +1578,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1783,7 +1792,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1791,7 +1800,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1865,8 +1874,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1890,7 +1899,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1902,11 +1911,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2141,7 +2150,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2265,8 +2274,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2347,7 +2361,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2361,7 +2375,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2411,7 +2425,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2419,7 +2433,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2438,7 +2452,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2556,7 +2570,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2564,7 +2578,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2582,9 +2596,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2625,7 +2639,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2895,11 +2909,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2957,7 +2971,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3189,8 +3203,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3375,13 +3389,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3403,7 +3417,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3440,8 +3454,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3473,7 +3487,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3481,11 +3495,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3512,7 +3526,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3556,8 +3570,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3565,7 +3579,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3725,11 +3739,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3743,7 +3757,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3755,11 +3769,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3771,7 +3785,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3784,7 +3798,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3826,7 +3840,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3899,8 +3913,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4257,15 +4271,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4313,7 +4327,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4625,11 +4639,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4770,11 +4784,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4832,15 +4846,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4941,21 +4955,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5004,11 +5018,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5101,8 +5115,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5169,7 +5183,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5184,7 +5198,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5238,7 +5252,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5260,13 +5274,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5298,7 +5312,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5400,7 +5414,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5432,12 +5446,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5496,7 +5510,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5545,7 +5559,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5918,7 +5932,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5953,17 +5967,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5971,44 +5985,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6419,27 +6433,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -844,7 +844,7 @@ msgstr "Nome dell'alias mancante"
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -953,16 +953,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1022,7 +1022,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1108,7 +1108,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1129,6 +1129,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1239,14 +1248,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1254,7 +1263,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colonne"
@@ -1298,7 +1307,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1307,11 +1316,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -1395,7 +1404,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1506,7 +1515,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1561,7 +1570,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1592,7 +1601,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
@@ -1612,7 +1621,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1701,7 +1710,7 @@ msgstr "Il nome del container è: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1796,26 +1805,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Il nome del container è: %s"
@@ -1828,11 +1837,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2052,7 +2061,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2060,7 +2069,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2135,8 +2144,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -2160,7 +2169,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2174,11 +2183,11 @@ msgstr "Creazione del container in corso"
 msgid "Export instances as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -2415,7 +2424,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2545,8 +2554,13 @@ msgstr "Il nome del container è: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2628,7 +2642,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2642,7 +2656,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2693,7 +2707,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2701,7 +2715,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2721,7 +2735,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Creazione del container in corso"
@@ -2840,7 +2854,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -2849,7 +2863,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2868,9 +2882,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Il nome del container è: %s"
@@ -2912,7 +2926,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3192,11 +3206,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3255,7 +3269,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3503,8 +3517,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3700,13 +3714,13 @@ msgstr "Il nome del container è: %s"
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3729,7 +3743,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Il nome del container è: %s"
@@ -3768,8 +3782,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3802,7 +3816,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3810,11 +3824,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3841,7 +3855,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3885,8 +3899,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3894,7 +3908,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4038,7 +4052,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4054,11 +4068,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4072,7 +4086,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "'/' non è permesso nel nome di uno snapshot"
@@ -4085,11 +4099,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4101,7 +4115,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4114,7 +4128,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4156,7 +4170,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4231,8 +4245,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4600,15 +4614,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4659,7 +4673,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4978,11 +4992,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5132,11 +5146,11 @@ msgstr "Il nome del container è: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5195,15 +5209,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5306,21 +5320,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5370,11 +5384,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 #, fuzzy
 msgid "Taken at"
 msgstr "salvato alle %s"
@@ -5469,8 +5483,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5538,7 +5552,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -5553,7 +5567,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5608,7 +5622,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5630,13 +5644,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5669,7 +5683,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5779,7 +5793,7 @@ msgstr "Il nome del container è: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5813,12 +5827,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5877,7 +5891,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5928,7 +5942,7 @@ msgstr "Occorre specificare un nome di container come origine"
 msgid "You must specify a source instance name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -6386,7 +6400,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Creazione del container in corso"
@@ -6429,19 +6443,19 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "Creazione del container in corso"
@@ -6451,53 +6465,53 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Creazione del container in corso"
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Creazione del container in corso"
@@ -6937,27 +6951,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453
@@ -7031,19 +7045,19 @@ msgstr "si"
 #~ msgid "[<remote>:] <token>"
 #~ msgstr "Creazione del container in corso"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to validate \"%s:%s\": %w"
 #~ msgstr "Accetta certificato"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "Proprietà errata: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Il nome del container è: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Accetta certificato"
 
@@ -7140,7 +7154,6 @@ msgstr "si"
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Certificato del client salvato dal server: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Impossible leggere da stdin: %s"
 
@@ -7148,7 +7161,7 @@ msgstr "si"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Il nome del container è: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Il nome del container è: %s"
 
@@ -7225,6 +7238,6 @@ msgstr "si"
 #~ msgid "[<remote>:]<network> <listen_address> [<default_target_address>]"
 #~ msgstr "Creazione del container in corso"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Admin password for %s:"
 #~ msgstr "Password amministratore per %s: "

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-31 14:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -71,7 +71,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -850,7 +850,7 @@ msgstr "エイリアスを指定してください"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr "すべてのプロジェクト"
 
@@ -962,16 +962,16 @@ msgstr "BASE IMAGE"
 msgid "Backing up instance: %s"
 msgstr "インスタンスのバックアップ中: %s"
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr "ストレージボリュームのバックアップ中: %s"
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr "バックアップ:"
 
@@ -989,7 +989,7 @@ msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -1032,7 +1032,7 @@ msgstr "CANCELABLE"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr "CONTENT-TYPE"
 
@@ -1118,7 +1118,7 @@ msgstr "--project と --all-project は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -1140,6 +1140,17 @@ msgstr "使用する Candid ドメイン"
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
 msgstr ""
+
+#: lxc/storage_volume.go:406
+#, fuzzy
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr "移動先の LXD サーバはクラスタに属していません"
+
+#: lxc/storage_volume.go:368
+#, fuzzy
+msgid "Cannot set --target when source server is not clustered"
+msgstr "移動元の LXD サーバはクラスタに属していません"
 
 #: lxc/network_acl.go:781
 #, c-format
@@ -1249,14 +1260,14 @@ msgstr "クラスターメンバー %s がグループ %s から削除されま�
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
@@ -1264,7 +1275,7 @@ msgstr "クラスタメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "カラムレイアウト"
@@ -1312,7 +1323,7 @@ msgstr "移動先のインスタンスに適用するキー/値の設定"
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -1321,11 +1332,11 @@ msgstr "設定の構文エラー: %s"
 msgid "Console log:"
 msgstr "コンソールログ:"
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr "ストレージボリュームのタイプ、block もしくは filesystem"
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr "コンテンツタイプ: %s"
@@ -1424,7 +1435,7 @@ msgstr "仮想マシンイメージをコピーします"
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
@@ -1533,7 +1544,7 @@ msgstr "ストレージバケットに対する鍵を作成します"
 msgid "Create new custom storage buckets"
 msgstr "新たにカスタムストレージバケットを作成します"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
@@ -1585,7 +1596,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the instance with no profiles applied"
 msgstr "プロファイルを適用しないインスタンスを作成します"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -1615,7 +1626,7 @@ msgstr "DEFAULT TARGET ADDRESS"
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
@@ -1635,7 +1646,7 @@ msgstr "DRM:"
 msgid "Default VLAN ID"
 msgstr "デフォルト VLAN ID"
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr "圧縮アルゴリズムを指定します: backup or none"
 
@@ -1719,7 +1730,7 @@ msgstr "ストレージバケットを削除します"
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
@@ -1814,26 +1825,26 @@ msgstr "警告を削除します"
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "説明"
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr "説明: %s"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr "コピー先のクラスターメンバー名"
 
@@ -1845,11 +1856,11 @@ msgstr "インスタンスからネットワークインターフェースを取
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr "インスタンスからストレージボリュームを取り外します"
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr "プロファイルからストレージボリュームを取り外します"
 
@@ -2067,7 +2078,7 @@ msgstr "ストレージバケットの設定をYAMLで編集します"
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
@@ -2075,7 +2086,7 @@ msgstr "ストレージボリュームの設定をYAMLで編集します"
 msgid "Edit trust configurations as YAML"
 msgstr "信頼済みクライアント設定をYAMLで編集します"
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2171,8 +2182,8 @@ msgstr ""
 "デフォルトのモードは non-interactive です。もし標準入出力が両方ともターミナル"
 "の場合は interactive モードが選択されます (標準エラー出力は無視されます)。"
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr "失効日時"
 
@@ -2199,7 +2210,7 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr "カスタムストレージボリュームをエクスポートします"
 
@@ -2211,12 +2222,12 @@ msgstr "インスタンスのバックアップをエクスポートします"
 msgid "Export instances as backup tarballs."
 msgstr "インスタンスを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 "ボリュームをエクスポートします (スナップショットはエクスポートしません)"
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -2467,7 +2478,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr "フォーマット (csv|json|table|yaml|compact)"
 
@@ -2591,9 +2602,14 @@ msgstr "ストレージバケットの設定値を取得します"
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
+msgstr ""
 
 #: lxc/exec.go:60
 msgid "Group ID to run the command as (default 0)"
@@ -2673,7 +2689,7 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 "存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
@@ -2689,7 +2705,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr "設定されている自動でのインスタンスの有効期限設定を無視します"
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr "設定されている自動でのストレージボリュームの有効期限設定を無視します"
 
@@ -2739,7 +2755,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Immediately attach to the console"
 msgstr "起動直後にインスタンスのコンソールに接続します"
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 "カスタムボリュームのバックアップをスナップショットを含んだ状態でインポートし"
@@ -2750,7 +2766,7 @@ msgid "Import backups of instances including their snapshots."
 msgstr ""
 "インスタンスのバックアップをスナップショットを含んだ状態でインポートします。"
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr "新たにカスタムストレージボリュームをインポートします"
 
@@ -2773,7 +2789,7 @@ msgstr "イメージをイメージストアにインポートします"
 msgid "Import instance backups"
 msgstr "インスタンスのバックアップをインポートします"
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr "カスタムボリュームのインポート中: %s"
@@ -2895,7 +2911,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr "不適切な新しいスナップショット名"
 
@@ -2905,7 +2921,7 @@ msgstr ""
 "新しいスナップショット名が不正です。親のスナップショット名はソースと同じでな"
 "ければいけません"
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 "新しいスナップショット名が不正です。親のボリュームはソースと同じでなければな"
@@ -2925,9 +2941,9 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr "不正なスナップショット名"
 
@@ -2968,7 +2984,7 @@ msgstr "LISTEN ADDRESS"
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr "LOCATION"
 
@@ -3345,11 +3361,11 @@ msgstr "ストレージバケットの鍵を一覧表示します"
 msgid "List storage buckets"
 msgstr "ストレージバケットを一覧表示します"
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3439,7 +3455,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
@@ -3684,8 +3700,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -3874,13 +3890,13 @@ msgstr "ピア名を指定する必要があります"
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -3902,7 +3918,7 @@ msgstr "コピー元のプロファイル名を指定する必要があります
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
@@ -3942,8 +3958,8 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
@@ -3988,7 +4004,7 @@ msgstr ""
 "\n"
 "すべての LXD バージョンとの互換性のため、pull 転送モードがデフォルトです。\n"
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
@@ -3996,11 +4012,11 @@ msgstr "プール間でストレージボリュームを移動します"
 msgid "Move the instance without its snapshots"
 msgstr "インスタンスを移動します。スナップショットは移動しません"
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトに移動します"
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr "ストレージボリュームの移動中: %s"
@@ -4029,7 +4045,7 @@ msgstr "インスタンス名を指定する必要があります: "
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr "NAME"
 
@@ -4074,8 +4090,8 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr "名前"
 
@@ -4083,7 +4099,7 @@ msgstr "名前"
 msgid "Name of the project to use for this remote:"
 msgstr "このリモートで使うプロジェクト名:"
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -4230,7 +4246,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr "このストレージボリュームに対するデバイスがありません"
 
@@ -4246,11 +4262,11 @@ msgstr "マッチするポートが見つかりません"
 msgid "No matching rule(s) found"
 msgstr "マッチするルールが見つかりません"
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr "コピー元のボリュームに対するストレージプールが指定されていません"
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr "コピー先のボリュームに対するストレージプールが指定されていません"
 
@@ -4264,7 +4280,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Node %d:\n"
 msgstr "ノード %d:\n"
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr "スナップショット名ではありません"
 
@@ -4276,11 +4292,11 @@ msgstr "OVN:"
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr "\"カスタム\" のボリュームのみがインスタンスにアタッチできます"
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr "\"カスタム\" のボリュームのみがエクスポートできます"
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
@@ -4292,7 +4308,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr "インスタンスもしくはカスタムボリュームのみをサポートしています"
 
@@ -4305,7 +4321,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr "最適化されたストレージ"
 
@@ -4347,7 +4363,7 @@ msgstr "PROCESSES"
 msgid "PROFILES"
 msgstr "PROFILES"
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr "PROJECT"
 
@@ -4420,8 +4436,8 @@ msgstr "終了するには ctrl+c を押してください"
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 "再度エディタを開くためには Enter キーを、変更を取り消すには ctrl+c を入力しま"
@@ -4780,16 +4796,16 @@ msgstr "プロジェクト名を変更します"
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr "ストレージボリューム名を変更します"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 "ストレージボリューム名とストレージボリュームのスナップショット名を変更します"
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しました"
@@ -4843,7 +4859,7 @@ msgstr ""
 "\n"
 "--stateful オプションを指定すると、インスタンスの実行状態もリストアします。"
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr "スナップショットからストレージボリュームをリストアします"
 
@@ -5207,11 +5223,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行うには次の形式でも設定できます:\n"
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5357,11 +5373,11 @@ msgstr "ストレージバケットの鍵の設定を表示する"
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr "ストレージボリュームの状態を表示します"
 
@@ -5420,15 +5436,15 @@ msgstr "サイズ: %.2fMB"
 msgid "Size: %s"
 msgstr "サイズ: %s"
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr "スナップショットは読み取り専用です。設定を変更することはできません"
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -5529,21 +5545,21 @@ msgstr "ストレージプール %s はメンバ %s 上でペンディング状�
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr "ストレージボリュームのコピーが成功しました!"
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr "ストレージボリュームの移動が成功しました!"
 
@@ -5592,11 +5608,11 @@ msgstr "TOKEN"
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr "取得日時"
 
@@ -5694,8 +5710,8 @@ msgstr "サーバには新しい v2 resource API が実装されていません"
 msgid "The source LXD server is not clustered"
 msgstr "移動元の LXD サーバはクラスタに属していません"
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -5782,7 +5798,7 @@ msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
 "りません"
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr "合計: %s"
@@ -5797,7 +5813,7 @@ msgstr "合計: %v"
 msgid "Transceiver type: %s"
 msgstr "トランシーバータイプ: %s"
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
@@ -5853,7 +5869,7 @@ msgstr ""
 "フィカル出力の場合は 'vga'"
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
@@ -5875,13 +5891,13 @@ msgstr "UPLOAD DATE"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr "USAGE"
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr "USED BY"
 
@@ -5913,7 +5929,7 @@ msgstr "未知の証明書タイプ %q"
 msgid "Unknown channel type for client %q: %s"
 msgstr "クライアント %q の未知のチャンネルタイプ: %s"
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -6015,7 +6031,7 @@ msgstr "ストレージバケットの設定を削除します"
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr "ストレージボリュームの設定を削除します"
 
@@ -6048,12 +6064,12 @@ msgstr "アップロード日時: %s"
 msgid "Upper devices"
 msgstr "上位デバイス"
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr "使い方: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -6116,7 +6132,7 @@ msgstr "ベンダ: %v (%v)"
 msgid "Verb: %s (%s)"
 msgstr "Verb: %s (%s)"
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr "Volume Only"
 
@@ -6168,7 +6184,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr "コピー元のインスタンス名を指定してください"
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr "[<remote:>]<pool> <volume> <profile> [<device name>]"
 
@@ -6552,7 +6568,7 @@ msgstr "[<remote>:]<operation>"
 msgid "[<remote>:]<pool>"
 msgstr "[<remote>:]<pool>"
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "[<remote>:]<pool> <backup file> [<volume name>]"
 
@@ -6587,7 +6603,7 @@ msgstr "[<remote>:]<pool> <key>"
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr "[<remote>:]<pool> <key> <value>"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
@@ -6595,11 +6611,11 @@ msgstr ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr "[<remote>:]<pool> <volume>"
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 
@@ -6607,44 +6623,44 @@ msgstr "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr "[<remote>:]<pool> <volume> <key>"
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "[<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr "[<remote>:]<pool> <volume> <snapshot>"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "[<remote>:]<pool> <volume> [<path>]"
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "[<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr "[<remote>:]<pool> <volume> [key=value...]"
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "[<remote>:]<pool> [<filter>...]"
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 
@@ -7192,7 +7208,7 @@ msgstr ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    pool.yaml の内容でストレージプールを更新します。"
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
@@ -7200,7 +7216,7 @@ msgstr ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    pool.yaml の内容でストレージボリュームを更新します。"
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
@@ -7208,15 +7224,15 @@ msgstr ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tbackup0.tar.gz を使って新しいカスタムボリュームを作成します。"
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 "lxc storage volume show default data\n"
 "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
@@ -7317,7 +7333,7 @@ msgstr "yes"
 #~ msgid "[<remote>:] <token>"
 #~ msgstr "[<remote>:] <token>"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to validate \"%s:%s\": %w"
 #~ msgstr "エイリアス %s の削除に失敗しました: %w"
 
@@ -7357,18 +7373,16 @@ msgstr "yes"
 #~ "lxc launch ubuntu:20.04 v1 --vm\n"
 #~ "    仮想マシンを作成し、起動します"
 
-#, c-format
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "不適切な キー=値 のペア: %w"
 
-#, c-format
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "クライアント %s の証明書追加トークン: %s"
 
 #~ msgid "Ips:"
 #~ msgstr "IPアドレス:"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "ピアのステータスの取得に失敗しました: %w"
 
@@ -7385,7 +7399,7 @@ msgstr "yes"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "ネットワークゾーンレコードエントリを管理します"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "メンバ %s の join トークン:"
 
@@ -8929,8 +8943,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect "
-#~ "\"custom\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect \"custom"
+#~ "\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"
@@ -9482,7 +9496,7 @@ msgstr "yes"
 #~ "lxc init ubuntu:18.04 u1 < config.yaml\n"
 #~ "    config.yaml の設定を使ってインスタンスを作成します"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %w"
 #~ msgstr "ピアのステータスの取得に失敗しました: %w"
 
@@ -9490,7 +9504,6 @@ msgstr "yes"
 #~ msgid "Remote disconnected"
 #~ msgstr "リモートの管理者パスワード"
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "標準入力から読み込めません: %s"
 
@@ -9548,7 +9561,6 @@ msgstr "yes"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "クラスタグループからクラスタメンバを削除します"
 
-#, c-format
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "設定 %q はクラスタメンバー %q に存在しません"
 
@@ -9735,14 +9747,12 @@ msgstr "yes"
 #~ "    L - インスタンスの場所 (例: its cluster member)\n"
 #~ "    U - 現在のディスク使用量"
 
-#, c-format
 #~ msgid "Admin password for %s:"
 #~ msgstr "%s の管理者パスワード:"
 
 #~ msgid "Path to an alternate server directory"
 #~ msgstr "別のサーバ用設定ディレクトリ"
 
-#, c-format
 #~ msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 #~ msgstr ""
 #~ "書式が不適切です。次のような形式で指定してください <device>,"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2023-01-20 15:06+0000\n"
+        "POT-Creation-Date: 2023-02-09 08:52+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -44,7 +44,7 @@ msgid   "### This is a YAML representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid   "### This is a YAML representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -570,7 +570,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid   "All projects"
 msgstr  ""
 
@@ -676,16 +676,16 @@ msgstr  ""
 msgid   "Backing up instance: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid   "Backing up storage volume: %s"
 msgstr  ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid   "Backups:"
 msgstr  ""
 
@@ -699,7 +699,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178 lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178 lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -742,7 +742,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid   "CONTENT-TYPE"
 msgstr  ""
 
@@ -827,7 +827,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -847,6 +847,14 @@ msgstr  ""
 #: lxc/init.go:314
 #, c-format
 msgid   "Cannot override config for device %q: Device not found in profile devices"
+msgstr  ""
+
+#: lxc/storage_volume.go:406
+msgid   "Cannot set --destination-target when destination server is not clustered"
+msgstr  ""
+
+#: lxc/storage_volume.go:368
+msgid   "Cannot set --target when source server is not clustered"
 msgstr  ""
 
 #: lxc/network_acl.go:781
@@ -936,7 +944,7 @@ msgstr  ""
 msgid   "Cluster member %s removed from group %s"
 msgstr  ""
 
-#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713 lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178 lxc/network.go:1240 lxc/network_forward.go:171 lxc/network_forward.go:235 lxc/network_forward.go:390 lxc/network_forward.go:491 lxc/network_forward.go:633 lxc/network_forward.go:710 lxc/network_forward.go:776 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636 lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939 lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:642 lxc/storage.go:714 lxc/storage.go:797 lxc/storage_bucket.go:86 lxc/storage_bucket.go:186 lxc/storage_bucket.go:249 lxc/storage_bucket.go:378 lxc/storage_bucket.go:523 lxc/storage_bucket.go:599 lxc/storage_bucket.go:663 lxc/storage_bucket.go:814 lxc/storage_bucket.go:892 lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093 lxc/storage_volume.go:334 lxc/storage_volume.go:524 lxc/storage_volume.go:603 lxc/storage_volume.go:844 lxc/storage_volume.go:1045 lxc/storage_volume.go:1133 lxc/storage_volume.go:1564 lxc/storage_volume.go:1596 lxc/storage_volume.go:1712 lxc/storage_volume.go:1803 lxc/storage_volume.go:1896 lxc/storage_volume.go:1933 lxc/storage_volume.go:2026 lxc/storage_volume.go:2098 lxc/storage_volume.go:2240
+#: lxc/cluster.go:767 lxc/config.go:98 lxc/config.go:376 lxc/config.go:479 lxc/config.go:626 lxc/config.go:745 lxc/copy.go:61 lxc/info.go:46 lxc/init.go:56 lxc/move.go:66 lxc/network.go:292 lxc/network.go:713 lxc/network.go:771 lxc/network.go:1111 lxc/network.go:1178 lxc/network.go:1240 lxc/network_forward.go:171 lxc/network_forward.go:235 lxc/network_forward.go:390 lxc/network_forward.go:491 lxc/network_forward.go:633 lxc/network_forward.go:710 lxc/network_forward.go:776 lxc/network_load_balancer.go:173 lxc/network_load_balancer.go:237 lxc/network_load_balancer.go:392 lxc/network_load_balancer.go:493 lxc/network_load_balancer.go:636 lxc/network_load_balancer.go:712 lxc/network_load_balancer.go:776 lxc/network_load_balancer.go:877 lxc/network_load_balancer.go:939 lxc/storage.go:100 lxc/storage.go:346 lxc/storage.go:407 lxc/storage.go:642 lxc/storage.go:714 lxc/storage.go:797 lxc/storage_bucket.go:86 lxc/storage_bucket.go:186 lxc/storage_bucket.go:249 lxc/storage_bucket.go:378 lxc/storage_bucket.go:523 lxc/storage_bucket.go:599 lxc/storage_bucket.go:663 lxc/storage_bucket.go:814 lxc/storage_bucket.go:892 lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093 lxc/storage_volume.go:334 lxc/storage_volume.go:528 lxc/storage_volume.go:607 lxc/storage_volume.go:848 lxc/storage_volume.go:1049 lxc/storage_volume.go:1137 lxc/storage_volume.go:1568 lxc/storage_volume.go:1600 lxc/storage_volume.go:1716 lxc/storage_volume.go:1807 lxc/storage_volume.go:1900 lxc/storage_volume.go:1937 lxc/storage_volume.go:2030 lxc/storage_volume.go:2102 lxc/storage_volume.go:2244
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -944,7 +952,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352 lxc/warning.go:93
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356 lxc/warning.go:93
 msgid   "Columns"
 msgstr  ""
 
@@ -979,7 +987,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target instance"
 msgstr  ""
 
-#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308 lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056 lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/cluster.go:732 lxc/cluster_group.go:327 lxc/config.go:263 lxc/config.go:338 lxc/config_metadata.go:147 lxc/config_trust.go:308 lxc/image.go:457 lxc/network.go:678 lxc/network_acl.go:582 lxc/network_forward.go:597 lxc/network_load_balancer.go:600 lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067 lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311 lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056 lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -988,11 +996,11 @@ msgstr  ""
 msgid   "Console log:"
 msgstr  ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid   "Content type, block or filesystem"
 msgstr  ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid   "Content type: %s"
 msgstr  ""
@@ -1069,7 +1077,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid   "Copying the storage volume: %s"
 msgstr  ""
@@ -1173,7 +1181,7 @@ msgstr  ""
 msgid   "Create new custom storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
@@ -1225,7 +1233,7 @@ msgstr  ""
 msgid   "Create the instance with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -1248,7 +1256,7 @@ msgstr  ""
 msgid   "DEFAULT TARGET ADDRESS"
 msgstr  ""
 
-#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059 lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964 lxc/network_acl.go:149 lxc/network_forward.go:146 lxc/network_load_balancer.go:149 lxc/network_peer.go:141 lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164 lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619 lxc/storage_bucket.go:496 lxc/storage_bucket.go:791 lxc/storage_volume.go:1459
+#: lxc/cluster.go:189 lxc/cluster_group.go:423 lxc/image.go:1059 lxc/image_alias.go:238 lxc/list.go:558 lxc/network.go:964 lxc/network_acl.go:149 lxc/network_forward.go:146 lxc/network_load_balancer.go:149 lxc/network_peer.go:141 lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164 lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619 lxc/storage_bucket.go:496 lxc/storage_bucket.go:791 lxc/storage_volume.go:1463
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -1268,7 +1276,7 @@ msgstr  ""
 msgid   "Default VLAN ID"
 msgstr  ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid   "Define a compression algorithm: for backup or none"
 msgstr  ""
 
@@ -1352,7 +1360,7 @@ msgstr  ""
 msgid   "Delete storage pools"
 msgstr  ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid   "Delete storage volumes"
 msgstr  ""
 
@@ -1360,16 +1368,16 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207 lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404 lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651 lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018 lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:521 lxc/storage_volume.go:600 lxc/storage_volume.go:675 lxc/storage_volume.go:757 lxc/storage_volume.go:838 lxc/storage_volume.go:1042 lxc/storage_volume.go:1130 lxc/storage_volume.go:1270 lxc/storage_volume.go:1354 lxc/storage_volume.go:1560 lxc/storage_volume.go:1593 lxc/storage_volume.go:1706 lxc/storage_volume.go:1794 lxc/storage_volume.go:1893 lxc/storage_volume.go:1927 lxc/storage_volume.go:2024 lxc/storage_volume.go:2091 lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207 lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404 lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651 lxc/cluster.go:766 lxc/cluster.go:837 lxc/cluster.go:939 lxc/cluster.go:1018 lxc/cluster.go:1125 lxc/cluster.go:1146 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:230 lxc/config_trust.go:344 lxc/config_trust.go:426 lxc/config_trust.go:528 lxc/config_trust.go:574 lxc/config_trust.go:645 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:364 lxc/network.go:414 lxc/network.go:499 lxc/network.go:584 lxc/network.go:710 lxc/network.go:768 lxc/network.go:891 lxc/network.go:984 lxc/network.go:1055 lxc/network.go:1105 lxc/network.go:1175 lxc/network.go:1237 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:33 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:625 lxc/remote.go:661 lxc/remote.go:749 lxc/remote.go:821 lxc/remote.go:875 lxc/remote.go:913 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:525 lxc/storage_volume.go:604 lxc/storage_volume.go:679 lxc/storage_volume.go:761 lxc/storage_volume.go:842 lxc/storage_volume.go:1046 lxc/storage_volume.go:1134 lxc/storage_volume.go:1274 lxc/storage_volume.go:1358 lxc/storage_volume.go:1564 lxc/storage_volume.go:1597 lxc/storage_volume.go:1710 lxc/storage_volume.go:1798 lxc/storage_volume.go:1897 lxc/storage_volume.go:1931 lxc/storage_volume.go:2028 lxc/storage_volume.go:2095 lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid   "Description: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid   "Destination cluster member name"
 msgstr  ""
 
@@ -1381,11 +1389,11 @@ msgstr  ""
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid   "Detach storage volumes from instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid   "Detach storage volumes from profiles"
 msgstr  ""
 
@@ -1588,7 +1596,7 @@ msgstr  ""
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
@@ -1596,7 +1604,7 @@ msgstr  ""
 msgid   "Edit trust configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487 lxc/warning.go:236
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491 lxc/warning.go:236
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -1663,7 +1671,7 @@ msgid   "Execute commands in instances\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271 lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275 lxc/storage_volume.go:1325
 msgid   "Expires at"
 msgstr  ""
 
@@ -1686,7 +1694,7 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid   "Export custom storage volume"
 msgstr  ""
 
@@ -1698,11 +1706,11 @@ msgstr  ""
 msgid   "Export instances as backup tarballs."
 msgstr  ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid   "Export the volume without its snapshots"
 msgstr  ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -1921,7 +1929,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561 lxc/storage_bucket.go:443 lxc/storage_bucket.go:734 lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/alias.go:105 lxc/cluster.go:125 lxc/cluster.go:838 lxc/cluster_group.go:370 lxc/config_template.go:243 lxc/config_trust.go:346 lxc/config_trust.go:428 lxc/image.go:1046 lxc/image_alias.go:158 lxc/list.go:134 lxc/network.go:895 lxc/network.go:986 lxc/network_acl.go:98 lxc/network_forward.go:90 lxc/network_load_balancer.go:94 lxc/network_peer.go:85 lxc/network_zone.go:89 lxc/network_zone.go:654 lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396 lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561 lxc/storage_bucket.go:443 lxc/storage_bucket.go:734 lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid   "Format (csv|json|table|yaml|compact)"
 msgstr  ""
 
@@ -2045,8 +2053,13 @@ msgstr  ""
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid   "Get values for storage volume configuration keys"
+msgstr  ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid   "Given target %q does not match source volume location %q"
 msgstr  ""
 
 #: lxc/exec.go:60
@@ -2127,7 +2140,7 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
 
@@ -2139,7 +2152,7 @@ msgstr  ""
 msgid   "Ignore any configured auto-expiry for the instance"
 msgstr  ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid   "Ignore any configured auto-expiry for the storage volume"
 msgstr  ""
 
@@ -2189,7 +2202,7 @@ msgstr  ""
 msgid   "Immediately attach to the console"
 msgstr  ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid   "Import backups of custom volumes including their snapshots."
 msgstr  ""
 
@@ -2197,7 +2210,7 @@ msgstr  ""
 msgid   "Import backups of instances including their snapshots."
 msgstr  ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid   "Import custom storage volumes"
 msgstr  ""
 
@@ -2215,7 +2228,7 @@ msgstr  ""
 msgid   "Import instance backups"
 msgstr  ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid   "Importing custom volume: %s"
 msgstr  ""
@@ -2332,7 +2345,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid   "Invalid new snapshot name"
 msgstr  ""
 
@@ -2340,7 +2353,7 @@ msgstr  ""
 msgid   "Invalid new snapshot name, parent must be the same as source"
 msgstr  ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid   "Invalid new snapshot name, parent volume must be the same as source"
 msgstr  ""
 
@@ -2358,7 +2371,7 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078 lxc/storage_volume.go:1166 lxc/storage_volume.go:1629 lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082 lxc/storage_volume.go:1170 lxc/storage_volume.go:1633 lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid   "Invalid snapshot name"
 msgstr  ""
 
@@ -2397,7 +2410,7 @@ msgstr  ""
 msgid   "LISTEN ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152 lxc/network_load_balancer.go:154 lxc/operation.go:169 lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152 lxc/network_load_balancer.go:154 lxc/operation.go:169 lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid   "LOCATION"
 msgstr  ""
 
@@ -2656,11 +2669,11 @@ msgstr  ""
 msgid   "List storage buckets"
 msgstr  ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid   "List storage volumes\n"
         "\n"
         "The -c option takes a (optionally comma-separated) list of arguments\n"
@@ -2716,7 +2729,7 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
@@ -3077,7 +3090,7 @@ msgstr  ""
 msgid   "Missing peer name"
 msgstr  ""
 
-#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429 lxc/storage.go:665 lxc/storage.go:742 lxc/storage_bucket.go:108 lxc/storage_bucket.go:208 lxc/storage_bucket.go:284 lxc/storage_bucket.go:400 lxc/storage_bucket.go:466 lxc/storage_bucket.go:545 lxc/storage_bucket.go:621 lxc/storage_bucket.go:757 lxc/storage_bucket.go:838 lxc/storage_bucket.go:913 lxc/storage_bucket.go:992 lxc/storage_bucket.go:1115 lxc/storage_volume.go:188 lxc/storage_volume.go:263 lxc/storage_volume.go:547 lxc/storage_volume.go:624 lxc/storage_volume.go:699 lxc/storage_volume.go:781 lxc/storage_volume.go:880 lxc/storage_volume.go:1067 lxc/storage_volume.go:1393 lxc/storage_volume.go:1618 lxc/storage_volume.go:1733 lxc/storage_volume.go:1825 lxc/storage_volume.go:1953 lxc/storage_volume.go:2048
+#: lxc/storage.go:195 lxc/storage.go:265 lxc/storage.go:368 lxc/storage.go:429 lxc/storage.go:665 lxc/storage.go:742 lxc/storage_bucket.go:108 lxc/storage_bucket.go:208 lxc/storage_bucket.go:284 lxc/storage_bucket.go:400 lxc/storage_bucket.go:466 lxc/storage_bucket.go:545 lxc/storage_bucket.go:621 lxc/storage_bucket.go:757 lxc/storage_bucket.go:838 lxc/storage_bucket.go:913 lxc/storage_bucket.go:992 lxc/storage_bucket.go:1115 lxc/storage_volume.go:188 lxc/storage_volume.go:263 lxc/storage_volume.go:551 lxc/storage_volume.go:628 lxc/storage_volume.go:703 lxc/storage_volume.go:785 lxc/storage_volume.go:884 lxc/storage_volume.go:1071 lxc/storage_volume.go:1397 lxc/storage_volume.go:1622 lxc/storage_volume.go:1737 lxc/storage_volume.go:1829 lxc/storage_volume.go:1957 lxc/storage_volume.go:2052
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -3097,7 +3110,7 @@ msgstr  ""
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid   "Missing storage pool name"
 msgstr  ""
 
@@ -3133,7 +3146,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719 lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723 lxc/storage_volume.go:804
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -3160,7 +3173,7 @@ msgid   "Move instances within or in between LXD servers\n"
         "The pull transfer mode is the default as it is compatible with all LXD versions.\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
@@ -3168,11 +3181,11 @@ msgstr  ""
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid   "Move to a project different from the source"
 msgstr  ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid   "Moving the storage volume: %s"
 msgstr  ""
@@ -3193,7 +3206,7 @@ msgstr  ""
 msgid   "Must supply instance name for: "
 msgstr  ""
 
-#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566 lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1458
+#: lxc/cluster.go:184 lxc/cluster.go:921 lxc/cluster_group.go:422 lxc/config_trust.go:403 lxc/config_trust.go:508 lxc/list.go:566 lxc/network.go:959 lxc/network_acl.go:148 lxc/network_peer.go:140 lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633 lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611 lxc/storage_bucket.go:495 lxc/storage_bucket.go:790 lxc/storage_volume.go:1462
 msgid   "NAME"
 msgstr  ""
 
@@ -3235,7 +3248,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269 lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273 lxc/storage_volume.go:1323
 msgid   "Name"
 msgstr  ""
 
@@ -3243,7 +3256,7 @@ msgstr  ""
 msgid   "Name of the project to use for this remote:"
 msgstr  ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -3386,7 +3399,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid   "No device found for this storage volume"
 msgstr  ""
 
@@ -3402,11 +3415,11 @@ msgstr  ""
 msgid   "No matching rule(s) found"
 msgstr  ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid   "No storage pool for source volume specified"
 msgstr  ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid   "No storage pool for target volume specified"
 msgstr  ""
 
@@ -3420,7 +3433,7 @@ msgstr  ""
 msgid   "Node %d:\n"
 msgstr  ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid   "Not a snapshot name"
 msgstr  ""
 
@@ -3432,11 +3445,11 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to instances"
 msgstr  ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid   "Only \"custom\" volumes can be exported"
 msgstr  ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
@@ -3448,7 +3461,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid   "Only instance or custom volumes are supported"
 msgstr  ""
 
@@ -3461,7 +3474,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid   "Optimized Storage"
 msgstr  ""
 
@@ -3503,7 +3516,7 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid   "PROJECT"
 msgstr  ""
 
@@ -3569,7 +3582,7 @@ msgstr  ""
 msgid   "Press ctrl+c to finish"
 msgstr  ""
 
-#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207 lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679 lxc/network_acl.go:583 lxc/network_forward.go:598 lxc/network_load_balancer.go:601 lxc/network_peer.go:574 lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509 lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345 lxc/storage_bucket.go:1057 lxc/storage_volume.go:978 lxc/storage_volume.go:1010
+#: lxc/cluster.go:733 lxc/cluster_group.go:328 lxc/config.go:264 lxc/config.go:339 lxc/config_metadata.go:148 lxc/config_template.go:207 lxc/config_trust.go:309 lxc/image.go:458 lxc/network.go:679 lxc/network_acl.go:583 lxc/network_forward.go:598 lxc/network_load_balancer.go:601 lxc/network_peer.go:574 lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509 lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345 lxc/storage_bucket.go:1057 lxc/storage_volume.go:982 lxc/storage_volume.go:1014
 msgid   "Press enter to open the editor again or ctrl+c to abort change"
 msgstr  ""
 
@@ -3924,15 +3937,15 @@ msgstr  ""
 msgid   "Rename remotes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid   "Rename storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid   "Rename storage volumes and storage volume snapshots"
 msgstr  ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid   "Renamed storage volume from \"%s\" to \"%s\""
 msgstr  ""
@@ -3978,7 +3991,7 @@ msgid   "Restore instances from snapshots\n"
         "If --stateful is passed, then the running state will be restored too."
 msgstr  ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid   "Restore storage volume snapshots"
 msgstr  ""
 
@@ -4263,11 +4276,11 @@ msgid   "Set storage pool configuration keys\n"
         "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid   "Set storage volume configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -4406,11 +4419,11 @@ msgstr  ""
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid   "Show storage volume state information"
 msgstr  ""
 
@@ -4468,15 +4481,15 @@ msgstr  ""
 msgid   "Size: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid   "Snapshots are read-only and can't have their configuration changed"
 msgstr  ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -4577,21 +4590,21 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid   "Storage volume copied successfully!"
 msgstr  ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid   "Storage volume moved successfully!"
 msgstr  ""
 
@@ -4638,11 +4651,11 @@ msgstr  ""
 msgid   "TOKEN"
 msgstr  ""
 
-#: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237 lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163 lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237 lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163 lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid   "Taken at"
 msgstr  ""
 
@@ -4733,7 +4746,7 @@ msgstr  ""
 msgid   "The source LXD server is not clustered"
 msgstr  ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733 lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737 lxc/storage_volume.go:818
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -4794,7 +4807,7 @@ msgstr  ""
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid   "Total: %s"
 msgstr  ""
@@ -4809,7 +4822,7 @@ msgstr  ""
 msgid   "Transceiver type: %s"
 msgstr  ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
@@ -4860,7 +4873,7 @@ msgstr  ""
 msgid   "Type of connection to establish: 'console' for serial console, 'vga' for SPICE graphical output"
 msgstr  ""
 
-#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816 lxc/storage_volume.go:1218
+#: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816 lxc/storage_volume.go:1222
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
@@ -4882,11 +4895,11 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid   "USAGE"
 msgstr  ""
 
-#: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141 lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620 lxc/storage_volume.go:1461
+#: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141 lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620 lxc/storage_volume.go:1465
 msgid   "USED BY"
 msgstr  ""
 
@@ -4918,7 +4931,7 @@ msgstr  ""
 msgid   "Unknown channel type for client %q: %s"
 msgstr  ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495 lxc/warning.go:244
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499 lxc/warning.go:244
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -5019,7 +5032,7 @@ msgstr  ""
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid   "Unset storage volume configuration keys"
 msgstr  ""
 
@@ -5049,12 +5062,12 @@ msgstr  ""
 msgid   "Upper devices"
 msgstr  ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -5111,7 +5124,7 @@ msgstr  ""
 msgid   "Verb: %s (%s)"
 msgstr  ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid   "Volume Only"
 msgstr  ""
 
@@ -5156,7 +5169,7 @@ msgstr  ""
 msgid   "You must specify a source instance name"
 msgstr  ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid   "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
@@ -5504,7 +5517,7 @@ msgstr  ""
 msgid   "[<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid   "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr  ""
 
@@ -5536,15 +5549,15 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <key> <value>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid   "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid   "[<remote>:]<pool> <volume>"
 msgstr  ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr  ""
 
@@ -5552,43 +5565,43 @@ msgstr  ""
 msgid   "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid   "[<remote>:]<pool> <volume> <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid   "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid   "[<remote>:]<pool> <volume> <snapshot>"
 msgstr  ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid   "[<remote>:]<pool> <volume> [<path>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid   "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid   "[<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836 lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840 lxc/storage_volume.go:1796
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid   "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid   "[<remote>:]<pool> [<filter>...]"
 msgstr  ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid   "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr  ""
 
@@ -5952,17 +5965,17 @@ msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid   "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
         "    Update a storage volume using the content of pool.yaml."
 msgstr  ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid   "lxc storage volume import default backup0.tar.gz\n"
         "		Create a new custom volume using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid   "lxc storage volume show default data\n"
         "    Will show the properties of a custom volume called \"data\" in the \"default\" pool.\n"
         "\n"

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -821,7 +821,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -928,16 +928,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -954,7 +954,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -997,7 +997,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1082,7 +1082,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1103,6 +1103,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1212,14 +1221,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1227,7 +1236,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1271,7 +1280,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1280,11 +1289,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1368,7 +1377,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1473,7 +1482,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1525,7 +1534,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1555,7 +1564,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1575,7 +1584,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1659,7 +1668,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1754,26 +1763,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1785,11 +1794,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1999,7 +2008,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2007,7 +2016,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2081,8 +2090,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -2106,7 +2115,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2118,11 +2127,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2357,7 +2366,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2481,8 +2490,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2577,7 +2591,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2627,7 +2641,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2635,7 +2649,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2654,7 +2668,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2772,7 +2786,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2780,7 +2794,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2798,9 +2812,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2841,7 +2855,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3111,11 +3125,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3173,7 +3187,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3405,8 +3419,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3591,13 +3605,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3619,7 +3633,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3656,8 +3670,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3689,7 +3703,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3697,11 +3711,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3728,7 +3742,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3772,8 +3786,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3781,7 +3795,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3925,7 +3939,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3941,11 +3955,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3959,7 +3973,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3971,11 +3985,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3987,7 +4001,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4000,7 +4014,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4042,7 +4056,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4115,8 +4129,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4473,15 +4487,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4529,7 +4543,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4841,11 +4855,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4986,11 +5000,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5048,15 +5062,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5157,21 +5171,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5220,11 +5234,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5317,8 +5331,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5385,7 +5399,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5400,7 +5414,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5454,7 +5468,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5476,13 +5490,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5514,7 +5528,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5616,7 +5630,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5648,12 +5662,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5712,7 +5726,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5761,7 +5775,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6134,7 +6148,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6169,17 +6183,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6187,44 +6201,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6635,27 +6649,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -72,7 +72,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -855,7 +855,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -962,16 +962,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -988,7 +988,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1116,7 +1116,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1137,6 +1137,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1246,14 +1255,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1261,7 +1270,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1305,7 +1314,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1314,11 +1323,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1402,7 +1411,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1507,7 +1516,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1559,7 +1568,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1589,7 +1598,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1609,7 +1618,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1693,7 +1702,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1788,26 +1797,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1819,11 +1828,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2033,7 +2042,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2041,7 +2050,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2115,8 +2124,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -2140,7 +2149,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2152,11 +2161,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2391,7 +2400,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2515,8 +2524,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2597,7 +2611,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2611,7 +2625,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2661,7 +2675,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2669,7 +2683,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2688,7 +2702,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2806,7 +2820,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2814,7 +2828,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2832,9 +2846,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2875,7 +2889,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3145,11 +3159,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3207,7 +3221,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3439,8 +3453,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3625,13 +3639,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3653,7 +3667,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3690,8 +3704,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3723,7 +3737,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3731,11 +3745,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3762,7 +3776,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3806,8 +3820,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3815,7 +3829,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3959,7 +3973,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3975,11 +3989,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3993,7 +4007,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4005,11 +4019,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4021,7 +4035,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4034,7 +4048,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4076,7 +4090,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4149,8 +4163,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4507,15 +4521,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4563,7 +4577,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4875,11 +4889,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5020,11 +5034,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -5082,15 +5096,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5191,21 +5205,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5254,11 +5268,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5351,8 +5365,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5419,7 +5433,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5434,7 +5448,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5488,7 +5502,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5510,13 +5524,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5548,7 +5562,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5650,7 +5664,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5682,12 +5696,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5746,7 +5760,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5795,7 +5809,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6168,7 +6182,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6203,17 +6217,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6221,44 +6235,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6669,27 +6683,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -76,7 +76,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -861,7 +861,7 @@ msgstr "Nome do alias ausente"
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 #, fuzzy
 msgid "All projects"
 msgstr "Criar projetos"
@@ -977,16 +977,16 @@ msgstr "IMAGEM BASE"
 msgid "Backing up instance: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -1003,7 +1003,7 @@ msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -1046,7 +1046,7 @@ msgstr "CANCELÁVEL"
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1133,7 +1133,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -1154,6 +1154,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1264,14 +1273,14 @@ msgstr "Dispositivo %s removido de %s"
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
@@ -1279,7 +1288,7 @@ msgstr "Nome de membro do cluster"
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Colunas"
@@ -1332,7 +1341,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -1341,11 +1350,11 @@ msgstr "Erro de análise de configuração: %s"
 msgid "Console log:"
 msgstr "Log de Console:"
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1431,7 +1440,7 @@ msgstr "Copiar a imagem: %s"
 msgid "Copying the image: %s"
 msgstr "Copiar a imagem: %s"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1543,7 +1552,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr "Criar novas redes"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1602,7 +1611,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
@@ -1633,7 +1642,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1653,7 +1662,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 #, fuzzy
 msgid "Define a compression algorithm: for backup or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1749,7 +1758,7 @@ msgstr "Apagar projetos"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1844,26 +1853,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, fuzzy, c-format
 msgid "Description: %s"
 msgstr "Descrição"
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Nome de membro do cluster"
@@ -1877,12 +1886,12 @@ msgstr "Desconectar interfaces de rede dos containers"
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Desconectar volumes de armazenamento dos containers"
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr "Desconectar volumes de armazenamento dos perfis"
 
@@ -2109,7 +2118,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2118,7 +2127,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2193,8 +2202,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -2218,7 +2227,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2230,11 +2239,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2470,7 +2479,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2606,8 +2615,13 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2688,7 +2702,7 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2702,7 +2716,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2754,7 +2768,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2762,7 +2776,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2781,7 +2795,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Editar arquivos no container"
@@ -2899,7 +2913,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Editar arquivos no container"
@@ -2908,7 +2922,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2926,9 +2940,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Editar arquivos no container"
@@ -2970,7 +2984,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3246,11 +3260,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3308,7 +3322,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3561,8 +3575,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3759,13 +3773,13 @@ msgstr "Nome de membro do cluster"
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3787,7 +3801,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Nome de membro do cluster"
@@ -3826,8 +3840,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3860,7 +3874,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3868,11 +3882,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3899,7 +3913,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3943,8 +3957,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3952,7 +3966,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4096,7 +4110,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -4112,11 +4126,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4130,7 +4144,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -4142,11 +4156,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4158,7 +4172,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4171,7 +4185,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4213,7 +4227,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4287,8 +4301,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4663,15 +4677,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4726,7 +4740,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -5052,11 +5066,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5213,11 +5227,11 @@ msgstr "Editar configurações do container ou do servidor como YAML"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Editar configurações do container ou do servidor como YAML"
@@ -5278,15 +5292,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5387,21 +5401,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5451,11 +5465,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5553,8 +5567,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5622,7 +5636,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5637,7 +5651,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5692,7 +5706,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5714,13 +5728,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5753,7 +5767,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5871,7 +5885,7 @@ msgstr "Editar configurações de perfil como YAML"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5905,12 +5919,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Editar arquivos no container"
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Criado: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5969,7 +5983,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -6018,7 +6032,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6429,7 +6443,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr "Criar perfis"
@@ -6469,18 +6483,18 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6489,46 +6503,46 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr "Criar perfis"
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr "Criar perfis"
@@ -6952,27 +6966,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453
@@ -7041,19 +7055,19 @@ msgstr "sim"
 #~ msgid "[<remote>:] <token>"
 #~ msgstr "Criar perfis"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to validate \"%s:%s\": %w"
 #~ msgstr "Aceitar certificado"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "par de chave=valor inválido %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Nome de membro do cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Aceitar certificado"
 
@@ -7069,7 +7083,7 @@ msgstr "sim"
 #~ msgid "Manage network zone record entriess"
 #~ msgstr "Criar novas redes"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s join token: %s"
 #~ msgstr "Versão do cliente: %s\n"
 
@@ -7095,7 +7109,6 @@ msgstr "sim"
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Certificado do cliente armazenado no servidor: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Não é possível ler stdin: %s"
 
@@ -7103,7 +7116,7 @@ msgstr "sim"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Nome de membro do cluster"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Nome de membro do cluster"
 
@@ -7184,10 +7197,9 @@ msgstr "sim"
 #~ "###\n"
 #~ "### Note que o nome é exibido, porém não pode ser alterado."
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Admin password for %s:"
 #~ msgstr "Senha de administrador para %s: "
 
-#, c-format
 #~ msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 #~ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -78,7 +78,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 #, fuzzy
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
@@ -864,7 +864,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 #, fuzzy
 msgid "All projects"
 msgstr "Доступные команды:"
@@ -976,16 +976,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, fuzzy, c-format
 msgid "Backing up storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -1002,7 +1002,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -1045,7 +1045,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -1132,7 +1132,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1153,6 +1153,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1263,14 +1272,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1278,7 +1287,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr "Столбцы"
@@ -1322,7 +1331,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1331,11 +1340,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, fuzzy, c-format
 msgid "Content type: %s"
 msgstr "Авто-обновление: %s"
@@ -1421,7 +1430,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, fuzzy, c-format
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -1532,7 +1541,7 @@ msgstr "Копирование образа: %s"
 msgid "Create new custom storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 #, fuzzy
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -1593,7 +1602,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the instance with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1624,7 +1633,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1644,7 +1653,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1736,7 +1745,7 @@ msgstr "Копирование образа: %s"
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 #, fuzzy
 msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
@@ -1832,26 +1841,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 #, fuzzy
 msgid "Destination cluster member name"
 msgstr "Копирование образа: %s"
@@ -1864,12 +1873,12 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 #, fuzzy
 msgid "Detach storage volumes from instances"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -2090,7 +2099,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -2098,7 +2107,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -2176,8 +2185,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -2202,7 +2211,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 #, fuzzy
 msgid "Export custom storage volume"
 msgstr "Копирование образа: %s"
@@ -2217,12 +2226,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Export instances as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 #, fuzzy
 msgid "Export the volume without its snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -2458,7 +2467,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2589,8 +2598,13 @@ msgstr "Копирование образа: %s"
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2672,7 +2686,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2686,7 +2700,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2737,7 +2751,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2745,7 +2759,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 #, fuzzy
 msgid "Import custom storage volumes"
 msgstr "Копирование образа: %s"
@@ -2767,7 +2781,7 @@ msgstr "Копирование образа: %s"
 msgid "Import instance backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, fuzzy, c-format
 msgid "Importing custom volume: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -2887,7 +2901,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 #, fuzzy
 msgid "Invalid new snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -2896,7 +2910,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2914,9 +2928,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 #, fuzzy
 msgid "Invalid snapshot name"
 msgstr "Имя контейнера: %s"
@@ -2958,7 +2972,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3240,12 +3254,12 @@ msgstr "Копирование образа: %s"
 msgid "List storage buckets"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 #, fuzzy
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3304,7 +3318,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3559,8 +3573,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3758,13 +3772,13 @@ msgstr "Имя контейнера: %s"
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3788,7 +3802,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 #, fuzzy
 msgid "Missing storage pool name"
 msgstr "Копирование образа: %s"
@@ -3827,8 +3841,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3861,7 +3875,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 #, fuzzy
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
@@ -3870,11 +3884,11 @@ msgstr "Копирование образа: %s"
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, fuzzy, c-format
 msgid "Moving the storage volume: %s"
 msgstr "Копирование образа: %s"
@@ -3901,7 +3915,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3945,8 +3959,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3954,7 +3968,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -4100,7 +4114,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 #, fuzzy
 msgid "No device found for this storage volume"
 msgstr "Копирование образа: %s"
@@ -4117,11 +4131,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -4135,7 +4149,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 #, fuzzy
 msgid "Not a snapshot name"
 msgstr "Нельзя использовать '/' в имени снимка"
@@ -4148,11 +4162,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -4164,7 +4178,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -4177,7 +4191,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -4219,7 +4233,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4293,8 +4307,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4661,17 +4675,17 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 #, fuzzy
 msgid "Rename storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 #, fuzzy
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4722,7 +4736,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 #, fuzzy
 msgid "Restore storage volume snapshots"
 msgstr "Копирование образа: %s"
@@ -5044,11 +5058,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -5201,11 +5215,11 @@ msgstr "Копирование образа: %s"
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 #, fuzzy
 msgid "Show storage volume state information"
 msgstr "Копирование образа: %s"
@@ -5266,16 +5280,16 @@ msgstr ""
 msgid "Size: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 #, fuzzy
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5379,21 +5393,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5443,11 +5457,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5540,8 +5554,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5608,7 +5622,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, fuzzy, c-format
 msgid "Total: %s"
 msgstr "Авто-обновление: %s"
@@ -5623,7 +5637,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5678,7 +5692,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5700,13 +5714,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5738,7 +5752,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5850,7 +5864,7 @@ msgstr "Копирование образа: %s"
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5884,12 +5898,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr "Копирование образа: %s"
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, fuzzy, c-format
 msgid "Usage: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5948,7 +5962,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5997,7 +6011,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 #, fuzzy
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
@@ -6714,7 +6728,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 #, fuzzy
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
@@ -6781,7 +6795,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 #, fuzzy
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
@@ -6791,7 +6805,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
@@ -6799,7 +6813,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
@@ -6815,7 +6829,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
@@ -6823,7 +6837,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
@@ -6831,7 +6845,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
@@ -6839,7 +6853,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
@@ -6847,7 +6861,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
@@ -6855,7 +6869,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 #, fuzzy
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
@@ -6863,8 +6877,8 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
@@ -6872,7 +6886,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 #, fuzzy
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
@@ -6880,7 +6894,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 #, fuzzy
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
@@ -6888,7 +6902,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 #, fuzzy
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
@@ -7415,27 +7429,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453
@@ -7531,19 +7545,19 @@ msgstr "да"
 #~ "\n"
 #~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed to validate \"%s:%s\": %w"
 #~ msgstr "Принять сертификат"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Invalid key=value configuration: %w"
 #~ msgstr "Имя контейнера: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Client %s certificate add token: %s"
 #~ msgstr "Копирование образа: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Failed finding sshfs: %v\n"
 #~ msgstr "Принять сертификат"
 
@@ -7762,7 +7776,6 @@ msgstr "да"
 #~ msgid "Client certificate stored at server:"
 #~ msgstr "Сертификат клиента хранится на сервере: "
 
-#, c-format
 #~ msgid "Can't read from stdin: %s"
 #~ msgstr "Невозможно прочитать из стандартного ввода: %s"
 
@@ -7770,7 +7783,7 @@ msgstr "да"
 #~ msgid "Removes a cluster member from a cluster group"
 #~ msgstr "Копирование образа: %s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "The key %q doest not exist on cluster member %q"
 #~ msgstr "Копирование образа: %s"
 
@@ -7855,6 +7868,6 @@ msgstr "да"
 #~ "\n"
 #~ "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#, fuzzy, c-format
+#, fuzzy
 #~ msgid "Admin password for %s:"
 #~ msgstr "Пароль администратора для %s: "

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
-"n%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
+"%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -712,16 +712,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -781,7 +781,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -887,6 +887,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -996,14 +1005,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1011,7 +1020,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1055,7 +1064,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1064,11 +1073,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1152,7 +1161,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1257,7 +1266,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1309,7 +1318,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1339,7 +1348,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1359,7 +1368,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1443,7 +1452,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1538,26 +1547,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1569,11 +1578,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1783,7 +1792,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1791,7 +1800,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1865,8 +1874,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1890,7 +1899,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1902,11 +1911,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2141,7 +2150,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2265,8 +2274,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2347,7 +2361,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2361,7 +2375,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2411,7 +2425,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2419,7 +2433,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2438,7 +2452,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2556,7 +2570,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2564,7 +2578,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2582,9 +2596,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2625,7 +2639,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2895,11 +2909,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2957,7 +2971,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3189,8 +3203,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3375,13 +3389,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3403,7 +3417,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3440,8 +3454,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3473,7 +3487,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3481,11 +3495,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3512,7 +3526,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3556,8 +3570,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3565,7 +3579,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3725,11 +3739,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3743,7 +3757,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3755,11 +3769,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3771,7 +3785,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3784,7 +3798,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3826,7 +3840,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3899,8 +3913,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4257,15 +4271,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4313,7 +4327,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4625,11 +4639,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4770,11 +4784,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4832,15 +4846,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4941,21 +4955,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5004,11 +5018,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5101,8 +5115,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5169,7 +5183,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5184,7 +5198,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5238,7 +5252,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5260,13 +5274,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5298,7 +5312,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5400,7 +5414,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5432,12 +5446,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5496,7 +5510,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5545,7 +5559,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5918,7 +5932,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5953,17 +5967,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5971,44 +5985,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6419,27 +6433,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -712,16 +712,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -781,7 +781,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -887,6 +887,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -996,14 +1005,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1011,7 +1020,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1055,7 +1064,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1064,11 +1073,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1152,7 +1161,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1257,7 +1266,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1309,7 +1318,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1339,7 +1348,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1359,7 +1368,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1443,7 +1452,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1538,26 +1547,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1569,11 +1578,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1783,7 +1792,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1791,7 +1800,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1865,8 +1874,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1890,7 +1899,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1902,11 +1911,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2141,7 +2150,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2265,8 +2274,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2347,7 +2361,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2361,7 +2375,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2411,7 +2425,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2419,7 +2433,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2438,7 +2452,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2556,7 +2570,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2564,7 +2578,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2582,9 +2596,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2625,7 +2639,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2895,11 +2909,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2957,7 +2971,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3189,8 +3203,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3375,13 +3389,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3403,7 +3417,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3440,8 +3454,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3473,7 +3487,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3481,11 +3495,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3512,7 +3526,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3556,8 +3570,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3565,7 +3579,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3725,11 +3739,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3743,7 +3757,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3755,11 +3769,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3771,7 +3785,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3784,7 +3798,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3826,7 +3840,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3899,8 +3913,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4257,15 +4271,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4313,7 +4327,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4625,11 +4639,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4770,11 +4784,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4832,15 +4846,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4941,21 +4955,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5004,11 +5018,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5101,8 +5115,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5169,7 +5183,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5184,7 +5198,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5238,7 +5252,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5260,13 +5274,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5298,7 +5312,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5400,7 +5414,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5432,12 +5446,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5496,7 +5510,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5545,7 +5559,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5918,7 +5932,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5953,17 +5967,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5971,44 +5985,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6419,27 +6433,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -46,7 +46,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -708,16 +708,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -734,7 +734,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -777,7 +777,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -883,6 +883,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -992,14 +1001,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1007,7 +1016,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1051,7 +1060,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1060,11 +1069,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1148,7 +1157,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1253,7 +1262,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1305,7 +1314,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1335,7 +1344,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1355,7 +1364,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1439,7 +1448,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1534,26 +1543,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1565,11 +1574,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1779,7 +1788,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1787,7 +1796,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1861,8 +1870,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1886,7 +1895,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1898,11 +1907,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2137,7 +2146,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2261,8 +2270,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2343,7 +2357,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2357,7 +2371,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2415,7 +2429,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2434,7 +2448,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2552,7 +2566,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2560,7 +2574,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2578,9 +2592,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2621,7 +2635,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2891,11 +2905,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2953,7 +2967,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3185,8 +3199,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3371,13 +3385,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3399,7 +3413,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3436,8 +3450,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3469,7 +3483,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3477,11 +3491,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3508,7 +3522,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3552,8 +3566,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3561,7 +3575,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3705,7 +3719,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3721,11 +3735,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3739,7 +3753,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3751,11 +3765,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3767,7 +3781,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3780,7 +3794,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3822,7 +3836,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3895,8 +3909,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4253,15 +4267,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4309,7 +4323,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4621,11 +4635,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4766,11 +4780,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4828,15 +4842,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4937,21 +4951,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5000,11 +5014,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5097,8 +5111,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5165,7 +5179,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5180,7 +5194,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5234,7 +5248,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5256,13 +5270,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5294,7 +5308,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5396,7 +5410,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5428,12 +5442,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5492,7 +5506,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5541,7 +5555,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5914,7 +5928,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5949,17 +5963,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5967,44 +5981,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6415,27 +6429,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
-"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
+"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -50,7 +50,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -605,7 +605,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -712,16 +712,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -781,7 +781,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -866,7 +866,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -887,6 +887,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -996,14 +1005,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1011,7 +1020,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1055,7 +1064,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1064,11 +1073,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1152,7 +1161,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1257,7 +1266,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1309,7 +1318,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1339,7 +1348,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1359,7 +1368,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1443,7 +1452,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1538,26 +1547,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1569,11 +1578,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1783,7 +1792,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1791,7 +1800,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1865,8 +1874,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1890,7 +1899,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1902,11 +1911,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2141,7 +2150,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2265,8 +2274,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2347,7 +2361,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2361,7 +2375,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2411,7 +2425,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2419,7 +2433,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2438,7 +2452,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2556,7 +2570,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2564,7 +2578,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2582,9 +2596,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2625,7 +2639,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2895,11 +2909,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2957,7 +2971,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3189,8 +3203,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3375,13 +3389,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3403,7 +3417,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3440,8 +3454,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3473,7 +3487,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3481,11 +3495,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3512,7 +3526,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3556,8 +3570,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3565,7 +3579,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3725,11 +3739,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3743,7 +3757,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3755,11 +3769,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3771,7 +3785,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3784,7 +3798,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3826,7 +3840,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3899,8 +3913,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4257,15 +4271,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4313,7 +4327,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4625,11 +4639,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4770,11 +4784,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4832,15 +4846,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4941,21 +4955,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5004,11 +5018,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5101,8 +5115,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5169,7 +5183,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5184,7 +5198,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5238,7 +5252,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5260,13 +5274,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5298,7 +5312,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5400,7 +5414,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5432,12 +5446,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5496,7 +5510,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5545,7 +5559,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5918,7 +5932,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5953,17 +5967,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5971,44 +5985,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6419,27 +6433,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -73,7 +73,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -825,16 +825,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -851,7 +851,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -894,7 +894,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -979,7 +979,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -1000,6 +1000,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -1109,14 +1118,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1124,7 +1133,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1168,7 +1177,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1177,11 +1186,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1265,7 +1274,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1370,7 +1379,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1422,7 +1431,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1452,7 +1461,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1472,7 +1481,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1556,7 +1565,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1651,26 +1660,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1682,11 +1691,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1896,7 +1905,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1904,7 +1913,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1978,8 +1987,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -2003,7 +2012,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -2015,11 +2024,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2254,7 +2263,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2378,8 +2387,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2460,7 +2474,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2474,7 +2488,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2524,7 +2538,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2532,7 +2546,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2551,7 +2565,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2669,7 +2683,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2677,7 +2691,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2695,9 +2709,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2738,7 +2752,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -3008,11 +3022,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -3070,7 +3084,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3302,8 +3316,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3488,13 +3502,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3516,7 +3530,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3553,8 +3567,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3586,7 +3600,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3594,11 +3608,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3625,7 +3639,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3669,8 +3683,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3678,7 +3692,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3822,7 +3836,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3838,11 +3852,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3856,7 +3870,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3868,11 +3882,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3884,7 +3898,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3897,7 +3911,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3939,7 +3953,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -4012,8 +4026,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4370,15 +4384,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4426,7 +4440,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4738,11 +4752,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4883,11 +4897,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4945,15 +4959,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -5054,21 +5068,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5117,11 +5131,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5214,8 +5228,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5282,7 +5296,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5351,7 +5365,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5373,13 +5387,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5411,7 +5425,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5513,7 +5527,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5545,12 +5559,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5609,7 +5623,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5658,7 +5672,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -6031,7 +6045,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -6066,17 +6080,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -6084,44 +6098,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6532,27 +6546,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-01-20 15:06+0000\n"
+"POT-Creation-Date: 2023-02-08 17:01+0000\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -49,7 +49,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage_volume.go:851
+#: lxc/storage_volume.go:855
 msgid ""
 "### This is a YAML representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/storage_volume.go:1353
+#: lxc/storage_volume.go:1357
 msgid "All projects"
 msgstr ""
 
@@ -711,16 +711,16 @@ msgstr ""
 msgid "Backing up instance: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:2151
+#: lxc/storage_volume.go:2155
 #, c-format
 msgid "Backing up storage volume: %s"
 msgstr ""
 
-#: lxc/export.go:166 lxc/storage_volume.go:2220
+#: lxc/export.go:166 lxc/storage_volume.go:2224
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/info.go:645 lxc/storage_volume.go:1284
+#: lxc/info.go:645 lxc/storage_volume.go:1288
 msgid "Backups:"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgid "Bad key/value pair: %s"
 msgstr ""
 
 #: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
-#: lxc/storage.go:131 lxc/storage_volume.go:565
+#: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -780,7 +780,7 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/storage_volume.go:1460
+#: lxc/storage_volume.go:1464
 msgid "CONTENT-TYPE"
 msgstr ""
 
@@ -865,7 +865,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:603 lxc/storage_volume.go:1470 lxc/warning.go:225
+#: lxc/list.go:603 lxc/storage_volume.go:1474 lxc/warning.go:225
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -886,6 +886,15 @@ msgstr ""
 #, c-format
 msgid ""
 "Cannot override config for device %q: Device not found in profile devices"
+msgstr ""
+
+#: lxc/storage_volume.go:406
+msgid ""
+"Cannot set --destination-target when destination server is not clustered"
+msgstr ""
+
+#: lxc/storage_volume.go:368
+msgid "Cannot set --target when source server is not clustered"
 msgstr ""
 
 #: lxc/network_acl.go:781
@@ -995,14 +1004,14 @@ msgstr ""
 #: lxc/storage_bucket.go:599 lxc/storage_bucket.go:663
 #: lxc/storage_bucket.go:814 lxc/storage_bucket.go:892
 #: lxc/storage_bucket.go:957 lxc/storage_bucket.go:1093
-#: lxc/storage_volume.go:334 lxc/storage_volume.go:524
-#: lxc/storage_volume.go:603 lxc/storage_volume.go:844
-#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1133
-#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1596
-#: lxc/storage_volume.go:1712 lxc/storage_volume.go:1803
-#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1933
-#: lxc/storage_volume.go:2026 lxc/storage_volume.go:2098
-#: lxc/storage_volume.go:2240
+#: lxc/storage_volume.go:334 lxc/storage_volume.go:528
+#: lxc/storage_volume.go:607 lxc/storage_volume.go:848
+#: lxc/storage_volume.go:1049 lxc/storage_volume.go:1137
+#: lxc/storage_volume.go:1568 lxc/storage_volume.go:1600
+#: lxc/storage_volume.go:1716 lxc/storage_volume.go:1807
+#: lxc/storage_volume.go:1900 lxc/storage_volume.go:1937
+#: lxc/storage_volume.go:2030 lxc/storage_volume.go:2102
+#: lxc/storage_volume.go:2244
 msgid "Cluster member name"
 msgstr ""
 
@@ -1010,7 +1019,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1352
+#: lxc/image.go:1045 lxc/list.go:133 lxc/storage_volume.go:1356
 #: lxc/warning.go:93
 msgid "Columns"
 msgstr ""
@@ -1054,7 +1063,7 @@ msgstr ""
 #: lxc/network_peer.go:573 lxc/network_zone.go:513 lxc/network_zone.go:1067
 #: lxc/profile.go:508 lxc/project.go:312 lxc/storage.go:311
 #: lxc/storage_bucket.go:344 lxc/storage_bucket.go:1056
-#: lxc/storage_volume.go:977 lxc/storage_volume.go:1009
+#: lxc/storage_volume.go:981 lxc/storage_volume.go:1013
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -1063,11 +1072,11 @@ msgstr ""
 msgid "Console log:"
 msgstr ""
 
-#: lxc/storage_volume.go:525
+#: lxc/storage_volume.go:529
 msgid "Content type, block or filesystem"
 msgstr ""
 
-#: lxc/storage_volume.go:1224
+#: lxc/storage_volume.go:1228
 #, c-format
 msgid "Content type: %s"
 msgstr ""
@@ -1151,7 +1160,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:398
+#: lxc/storage_volume.go:428
 #, c-format
 msgid "Copying the storage volume: %s"
 msgstr ""
@@ -1256,7 +1265,7 @@ msgstr ""
 msgid "Create new custom storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:520 lxc/storage_volume.go:521
+#: lxc/storage_volume.go:524 lxc/storage_volume.go:525
 msgid "Create new custom storage volumes"
 msgstr ""
 
@@ -1308,7 +1317,7 @@ msgstr ""
 msgid "Create the instance with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1238
+#: lxc/image.go:953 lxc/info.go:488 lxc/storage_volume.go:1242
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -1338,7 +1347,7 @@ msgstr ""
 #: lxc/network_zone.go:140 lxc/network_zone.go:704 lxc/operation.go:164
 #: lxc/profile.go:634 lxc/project.go:489 lxc/storage.go:619
 #: lxc/storage_bucket.go:496 lxc/storage_bucket.go:791
-#: lxc/storage_volume.go:1459
+#: lxc/storage_volume.go:1463
 msgid "DESCRIPTION"
 msgstr ""
 
@@ -1358,7 +1367,7 @@ msgstr ""
 msgid "Default VLAN ID"
 msgstr ""
 
-#: lxc/storage_volume.go:2097
+#: lxc/storage_volume.go:2101
 msgid "Define a compression algorithm: for backup or none"
 msgstr ""
 
@@ -1442,7 +1451,7 @@ msgstr ""
 msgid "Delete storage pools"
 msgstr ""
 
-#: lxc/storage_volume.go:599 lxc/storage_volume.go:600
+#: lxc/storage_volume.go:603 lxc/storage_volume.go:604
 msgid "Delete storage volumes"
 msgstr ""
 
@@ -1537,26 +1546,26 @@ msgstr ""
 #: lxc/storage_bucket.go:889 lxc/storage_bucket.go:953
 #: lxc/storage_bucket.go:1088 lxc/storage_volume.go:42
 #: lxc/storage_volume.go:164 lxc/storage_volume.go:239
-#: lxc/storage_volume.go:330 lxc/storage_volume.go:521
-#: lxc/storage_volume.go:600 lxc/storage_volume.go:675
-#: lxc/storage_volume.go:757 lxc/storage_volume.go:838
-#: lxc/storage_volume.go:1042 lxc/storage_volume.go:1130
-#: lxc/storage_volume.go:1270 lxc/storage_volume.go:1354
-#: lxc/storage_volume.go:1560 lxc/storage_volume.go:1593
-#: lxc/storage_volume.go:1706 lxc/storage_volume.go:1794
-#: lxc/storage_volume.go:1893 lxc/storage_volume.go:1927
-#: lxc/storage_volume.go:2024 lxc/storage_volume.go:2091
-#: lxc/storage_volume.go:2235 lxc/version.go:22 lxc/warning.go:30
+#: lxc/storage_volume.go:330 lxc/storage_volume.go:525
+#: lxc/storage_volume.go:604 lxc/storage_volume.go:679
+#: lxc/storage_volume.go:761 lxc/storage_volume.go:842
+#: lxc/storage_volume.go:1046 lxc/storage_volume.go:1134
+#: lxc/storage_volume.go:1274 lxc/storage_volume.go:1358
+#: lxc/storage_volume.go:1564 lxc/storage_volume.go:1597
+#: lxc/storage_volume.go:1710 lxc/storage_volume.go:1798
+#: lxc/storage_volume.go:1897 lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:2028 lxc/storage_volume.go:2095
+#: lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30
 #: lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid "Description"
 msgstr ""
 
-#: lxc/storage_volume.go:1211
+#: lxc/storage_volume.go:1215
 #, c-format
 msgid "Description: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:335 lxc/storage_volume.go:1565
+#: lxc/storage_volume.go:335 lxc/storage_volume.go:1569
 msgid "Destination cluster member name"
 msgstr ""
 
@@ -1568,11 +1577,11 @@ msgstr ""
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
-#: lxc/storage_volume.go:674 lxc/storage_volume.go:675
+#: lxc/storage_volume.go:678 lxc/storage_volume.go:679
 msgid "Detach storage volumes from instances"
 msgstr ""
 
-#: lxc/storage_volume.go:756 lxc/storage_volume.go:757
+#: lxc/storage_volume.go:760 lxc/storage_volume.go:761
 msgid "Detach storage volumes from profiles"
 msgstr ""
 
@@ -1782,7 +1791,7 @@ msgstr ""
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
-#: lxc/storage_volume.go:837 lxc/storage_volume.go:838
+#: lxc/storage_volume.go:841 lxc/storage_volume.go:842
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
@@ -1790,7 +1799,7 @@ msgstr ""
 msgid "Edit trust configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1487
+#: lxc/image.go:1071 lxc/list.go:615 lxc/storage_volume.go:1491
 #: lxc/warning.go:236
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
@@ -1864,8 +1873,8 @@ msgid ""
 "AND stdout are terminals (stderr is ignored)."
 msgstr ""
 
-#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1271
-#: lxc/storage_volume.go:1321
+#: lxc/info.go:631 lxc/info.go:682 lxc/storage_volume.go:1275
+#: lxc/storage_volume.go:1325
 msgid "Expires at"
 msgstr ""
 
@@ -1889,7 +1898,7 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/storage_volume.go:2090 lxc/storage_volume.go:2091
+#: lxc/storage_volume.go:2094 lxc/storage_volume.go:2095
 msgid "Export custom storage volume"
 msgstr ""
 
@@ -1901,11 +1910,11 @@ msgstr ""
 msgid "Export instances as backup tarballs."
 msgstr ""
 
-#: lxc/storage_volume.go:2094
+#: lxc/storage_volume.go:2098
 msgid "Export the volume without its snapshots"
 msgstr ""
 
-#: lxc/export.go:144 lxc/storage_volume.go:2203
+#: lxc/export.go:144 lxc/storage_volume.go:2207
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -2140,7 +2149,7 @@ msgstr ""
 #: lxc/operation.go:107 lxc/profile.go:593 lxc/project.go:396
 #: lxc/project.go:765 lxc/remote.go:665 lxc/storage.go:561
 #: lxc/storage_bucket.go:443 lxc/storage_bucket.go:734
-#: lxc/storage_volume.go:1370 lxc/warning.go:94
+#: lxc/storage_volume.go:1374 lxc/warning.go:94
 msgid "Format (csv|json|table|yaml|compact)"
 msgstr ""
 
@@ -2264,8 +2273,13 @@ msgstr ""
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1041 lxc/storage_volume.go:1042
+#: lxc/storage_volume.go:1045 lxc/storage_volume.go:1046
 msgid "Get values for storage volume configuration keys"
+msgstr ""
+
+#: lxc/storage_volume.go:389
+#, c-format
+msgid "Given target %q does not match source volume location %q"
 msgstr ""
 
 #: lxc/exec.go:60
@@ -2346,7 +2360,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/snapshot.go:40 lxc/storage_volume.go:1932
+#: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
 
@@ -2360,7 +2374,7 @@ msgstr ""
 msgid "Ignore any configured auto-expiry for the instance"
 msgstr ""
 
-#: lxc/storage_volume.go:1931
+#: lxc/storage_volume.go:1935
 msgid "Ignore any configured auto-expiry for the storage volume"
 msgstr ""
 
@@ -2410,7 +2424,7 @@ msgstr ""
 msgid "Immediately attach to the console"
 msgstr ""
 
-#: lxc/storage_volume.go:2235
+#: lxc/storage_volume.go:2239
 msgid "Import backups of custom volumes including their snapshots."
 msgstr ""
 
@@ -2418,7 +2432,7 @@ msgstr ""
 msgid "Import backups of instances including their snapshots."
 msgstr ""
 
-#: lxc/storage_volume.go:2234
+#: lxc/storage_volume.go:2238
 msgid "Import custom storage volumes"
 msgstr ""
 
@@ -2437,7 +2451,7 @@ msgstr ""
 msgid "Import instance backups"
 msgstr ""
 
-#: lxc/storage_volume.go:2289
+#: lxc/storage_volume.go:2293
 #, c-format
 msgid "Importing custom volume: %s"
 msgstr ""
@@ -2555,7 +2569,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/move.go:135 lxc/storage_volume.go:1644
+#: lxc/move.go:135 lxc/storage_volume.go:1648
 msgid "Invalid new snapshot name"
 msgstr ""
 
@@ -2563,7 +2577,7 @@ msgstr ""
 msgid "Invalid new snapshot name, parent must be the same as source"
 msgstr ""
 
-#: lxc/storage_volume.go:1640
+#: lxc/storage_volume.go:1644
 msgid "Invalid new snapshot name, parent volume must be the same as source"
 msgstr ""
 
@@ -2581,9 +2595,9 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:891 lxc/storage_volume.go:1078
-#: lxc/storage_volume.go:1166 lxc/storage_volume.go:1629
-#: lxc/storage_volume.go:1750 lxc/storage_volume.go:1836
+#: lxc/storage_volume.go:895 lxc/storage_volume.go:1082
+#: lxc/storage_volume.go:1170 lxc/storage_volume.go:1633
+#: lxc/storage_volume.go:1754 lxc/storage_volume.go:1840
 msgid "Invalid snapshot name"
 msgstr ""
 
@@ -2624,7 +2638,7 @@ msgstr ""
 
 #: lxc/list.go:599 lxc/network.go:1038 lxc/network_forward.go:152
 #: lxc/network_load_balancer.go:154 lxc/operation.go:169
-#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1466 lxc/warning.go:221
+#: lxc/storage_bucket.go:500 lxc/storage_volume.go:1470 lxc/warning.go:221
 msgid "LOCATION"
 msgstr ""
 
@@ -2894,11 +2908,11 @@ msgstr ""
 msgid "List storage buckets"
 msgstr ""
 
-#: lxc/storage_volume.go:1349
+#: lxc/storage_volume.go:1353
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1354
+#: lxc/storage_volume.go:1358
 msgid ""
 "List storage volumes\n"
 "\n"
@@ -2956,7 +2970,7 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:480 lxc/storage_volume.go:1227
+#: lxc/info.go:480 lxc/storage_volume.go:1231
 #, c-format
 msgid "Location: %s"
 msgstr ""
@@ -3188,8 +3202,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect "
-"\"custom\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect \"custom"
+"\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3374,13 +3388,13 @@ msgstr ""
 #: lxc/storage_bucket.go:757 lxc/storage_bucket.go:838
 #: lxc/storage_bucket.go:913 lxc/storage_bucket.go:992
 #: lxc/storage_bucket.go:1115 lxc/storage_volume.go:188
-#: lxc/storage_volume.go:263 lxc/storage_volume.go:547
-#: lxc/storage_volume.go:624 lxc/storage_volume.go:699
-#: lxc/storage_volume.go:781 lxc/storage_volume.go:880
-#: lxc/storage_volume.go:1067 lxc/storage_volume.go:1393
-#: lxc/storage_volume.go:1618 lxc/storage_volume.go:1733
-#: lxc/storage_volume.go:1825 lxc/storage_volume.go:1953
-#: lxc/storage_volume.go:2048
+#: lxc/storage_volume.go:263 lxc/storage_volume.go:551
+#: lxc/storage_volume.go:628 lxc/storage_volume.go:703
+#: lxc/storage_volume.go:785 lxc/storage_volume.go:884
+#: lxc/storage_volume.go:1071 lxc/storage_volume.go:1397
+#: lxc/storage_volume.go:1622 lxc/storage_volume.go:1737
+#: lxc/storage_volume.go:1829 lxc/storage_volume.go:1957
+#: lxc/storage_volume.go:2052
 msgid "Missing pool name"
 msgstr ""
 
@@ -3402,7 +3416,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/storage_volume.go:1155
+#: lxc/storage_volume.go:1159
 msgid "Missing storage pool name"
 msgstr ""
 
@@ -3439,8 +3453,8 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:719
-#: lxc/storage_volume.go:800
+#: lxc/network.go:458 lxc/network.go:543 lxc/storage_volume.go:723
+#: lxc/storage_volume.go:804
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
@@ -3472,7 +3486,7 @@ msgid ""
 "versions.\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1559 lxc/storage_volume.go:1560
+#: lxc/storage_volume.go:1563 lxc/storage_volume.go:1564
 msgid "Move storage volumes between pools"
 msgstr ""
 
@@ -3480,11 +3494,11 @@ msgstr ""
 msgid "Move the instance without its snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1566
+#: lxc/storage_volume.go:1570
 msgid "Move to a project different from the source"
 msgstr ""
 
-#: lxc/storage_volume.go:402
+#: lxc/storage_volume.go:432
 #, c-format
 msgid "Moving the storage volume: %s"
 msgstr ""
@@ -3511,7 +3525,7 @@ msgstr ""
 #: lxc/network_zone.go:139 lxc/network_zone.go:703 lxc/profile.go:633
 #: lxc/project.go:482 lxc/remote.go:726 lxc/storage.go:611
 #: lxc/storage_bucket.go:495 lxc/storage_bucket.go:790
-#: lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1462
 msgid "NAME"
 msgstr ""
 
@@ -3555,8 +3569,8 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1269
-#: lxc/storage_volume.go:1319
+#: lxc/info.go:629 lxc/info.go:680 lxc/storage_volume.go:1273
+#: lxc/storage_volume.go:1323
 msgid "Name"
 msgstr ""
 
@@ -3564,7 +3578,7 @@ msgstr ""
 msgid "Name of the project to use for this remote:"
 msgstr ""
 
-#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1209
+#: lxc/info.go:463 lxc/network.go:812 lxc/storage_volume.go:1213
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -3708,7 +3722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage_volume.go:728 lxc/storage_volume.go:809
+#: lxc/storage_volume.go:732 lxc/storage_volume.go:813
 msgid "No device found for this storage volume"
 msgstr ""
 
@@ -3724,11 +3738,11 @@ msgstr ""
 msgid "No matching rule(s) found"
 msgstr ""
 
-#: lxc/storage_volume.go:379
+#: lxc/storage_volume.go:374
 msgid "No storage pool for source volume specified"
 msgstr ""
 
-#: lxc/storage_volume.go:386
+#: lxc/storage_volume.go:416
 msgid "No storage pool for target volume specified"
 msgstr ""
 
@@ -3742,7 +3756,7 @@ msgstr ""
 msgid "Node %d:\n"
 msgstr ""
 
-#: lxc/storage_volume.go:1656
+#: lxc/storage_volume.go:1660
 msgid "Not a snapshot name"
 msgstr ""
 
@@ -3754,11 +3768,11 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to instances"
 msgstr ""
 
-#: lxc/storage_volume.go:2133
+#: lxc/storage_volume.go:2137
 msgid "Only \"custom\" volumes can be exported"
 msgstr ""
 
-#: lxc/storage_volume.go:1966
+#: lxc/storage_volume.go:1970
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
@@ -3770,7 +3784,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/storage_volume.go:1173
+#: lxc/storage_volume.go:1177
 msgid "Only instance or custom volumes are supported"
 msgstr ""
 
@@ -3783,7 +3797,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/info.go:684 lxc/storage_volume.go:1323
+#: lxc/info.go:684 lxc/storage_volume.go:1327
 msgid "Optimized Storage"
 msgstr ""
 
@@ -3825,7 +3839,7 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/list.go:560 lxc/storage_volume.go:1477 lxc/warning.go:213
+#: lxc/list.go:560 lxc/storage_volume.go:1481 lxc/warning.go:213
 msgid "PROJECT"
 msgstr ""
 
@@ -3898,8 +3912,8 @@ msgstr ""
 #: lxc/network_load_balancer.go:601 lxc/network_peer.go:574
 #: lxc/network_zone.go:514 lxc/network_zone.go:1068 lxc/profile.go:509
 #: lxc/project.go:313 lxc/storage.go:312 lxc/storage_bucket.go:345
-#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:978
-#: lxc/storage_volume.go:1010
+#: lxc/storage_bucket.go:1057 lxc/storage_volume.go:982
+#: lxc/storage_volume.go:1014
 msgid "Press enter to open the editor again or ctrl+c to abort change"
 msgstr ""
 
@@ -4256,15 +4270,15 @@ msgstr ""
 msgid "Rename remotes"
 msgstr ""
 
-#: lxc/storage_volume.go:1593
+#: lxc/storage_volume.go:1597
 msgid "Rename storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1592
+#: lxc/storage_volume.go:1596
 msgid "Rename storage volumes and storage volume snapshots"
 msgstr ""
 
-#: lxc/storage_volume.go:1669 lxc/storage_volume.go:1689
+#: lxc/storage_volume.go:1673 lxc/storage_volume.go:1693
 #, c-format
 msgid "Renamed storage volume from \"%s\" to \"%s\""
 msgstr ""
@@ -4312,7 +4326,7 @@ msgid ""
 "If --stateful is passed, then the running state will be restored too."
 msgstr ""
 
-#: lxc/storage_volume.go:2023 lxc/storage_volume.go:2024
+#: lxc/storage_volume.go:2027 lxc/storage_volume.go:2028
 msgid "Restore storage volume snapshots"
 msgstr ""
 
@@ -4624,11 +4638,11 @@ msgid ""
 "    lxc storage set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1705
+#: lxc/storage_volume.go:1709
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1706
+#: lxc/storage_volume.go:1710
 msgid ""
 "Set storage volume configuration keys\n"
 "\n"
@@ -4769,11 +4783,11 @@ msgstr ""
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
-#: lxc/storage_volume.go:1793 lxc/storage_volume.go:1794
+#: lxc/storage_volume.go:1797 lxc/storage_volume.go:1798
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/storage_volume.go:1129 lxc/storage_volume.go:1130
+#: lxc/storage_volume.go:1133 lxc/storage_volume.go:1134
 msgid "Show storage volume state information"
 msgstr ""
 
@@ -4831,15 +4845,15 @@ msgstr ""
 msgid "Size: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1926 lxc/storage_volume.go:1927
+#: lxc/storage_volume.go:1930 lxc/storage_volume.go:1931
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/storage_volume.go:1756
+#: lxc/storage_volume.go:1760
 msgid "Snapshots are read-only and can't have their configuration changed"
 msgstr ""
 
-#: lxc/info.go:598 lxc/storage_volume.go:1248
+#: lxc/info.go:598 lxc/storage_volume.go:1252
 msgid "Snapshots:"
 msgstr ""
 
@@ -4940,21 +4954,21 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage_volume.go:582
+#: lxc/storage_volume.go:586
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage_volume.go:658
+#: lxc/storage_volume.go:662
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/storage_volume.go:399
+#: lxc/storage_volume.go:429
 msgid "Storage volume copied successfully!"
 msgstr ""
 
-#: lxc/storage_volume.go:403
+#: lxc/storage_volume.go:433
 msgid "Storage volume moved successfully!"
 msgstr ""
 
@@ -5003,11 +5017,11 @@ msgstr ""
 
 #: lxc/config_trust.go:402 lxc/image.go:1063 lxc/image_alias.go:237
 #: lxc/list.go:572 lxc/network.go:960 lxc/network.go:1034 lxc/operation.go:163
-#: lxc/storage_volume.go:1457 lxc/warning.go:216
+#: lxc/storage_volume.go:1461 lxc/warning.go:216
 msgid "TYPE"
 msgstr ""
 
-#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1320
+#: lxc/info.go:630 lxc/info.go:681 lxc/storage_volume.go:1324
 msgid "Taken at"
 msgstr ""
 
@@ -5100,8 +5114,8 @@ msgstr ""
 msgid "The source LXD server is not clustered"
 msgstr ""
 
-#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:733
-#: lxc/storage_volume.go:814
+#: lxc/network.go:472 lxc/network.go:557 lxc/storage_volume.go:737
+#: lxc/storage_volume.go:818
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -5168,7 +5182,7 @@ msgstr ""
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
-#: lxc/storage_volume.go:1233
+#: lxc/storage_volume.go:1237
 #, c-format
 msgid "Total: %s"
 msgstr ""
@@ -5183,7 +5197,7 @@ msgstr ""
 msgid "Transceiver type: %s"
 msgstr ""
 
-#: lxc/storage_volume.go:1563
+#: lxc/storage_volume.go:1567
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
@@ -5237,7 +5251,7 @@ msgid ""
 msgstr ""
 
 #: lxc/image.go:947 lxc/info.go:274 lxc/info.go:474 lxc/network.go:816
-#: lxc/storage_volume.go:1218
+#: lxc/storage_volume.go:1222
 #, c-format
 msgid "Type: %s"
 msgstr ""
@@ -5259,13 +5273,13 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/project.go:825 lxc/storage_volume.go:1462
+#: lxc/project.go:825 lxc/storage_volume.go:1466
 msgid "USAGE"
 msgstr ""
 
 #: lxc/network.go:965 lxc/network_acl.go:150 lxc/network_zone.go:141
 #: lxc/profile.go:635 lxc/project.go:490 lxc/storage.go:620
-#: lxc/storage_volume.go:1461
+#: lxc/storage_volume.go:1465
 msgid "USED BY"
 msgstr ""
 
@@ -5297,7 +5311,7 @@ msgstr ""
 msgid "Unknown channel type for client %q: %s"
 msgstr ""
 
-#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1495
+#: lxc/image.go:1079 lxc/list.go:630 lxc/storage_volume.go:1499
 #: lxc/warning.go:244
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
@@ -5399,7 +5413,7 @@ msgstr ""
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage_volume.go:1892 lxc/storage_volume.go:1893
+#: lxc/storage_volume.go:1896 lxc/storage_volume.go:1897
 msgid "Unset storage volume configuration keys"
 msgstr ""
 
@@ -5431,12 +5445,12 @@ msgstr ""
 msgid "Upper devices"
 msgstr ""
 
-#: lxc/storage_volume.go:1231
+#: lxc/storage_volume.go:1235
 #, c-format
 msgid "Usage: %s"
 msgstr ""
 
-#: lxc/export.go:42 lxc/storage_volume.go:2096
+#: lxc/export.go:42 lxc/storage_volume.go:2100
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -5495,7 +5509,7 @@ msgstr ""
 msgid "Verb: %s (%s)"
 msgstr ""
 
-#: lxc/storage_volume.go:1322
+#: lxc/storage_volume.go:1326
 msgid "Volume Only"
 msgstr ""
 
@@ -5544,7 +5558,7 @@ msgstr ""
 msgid "You must specify a source instance name"
 msgstr ""
 
-#: lxc/storage_volume.go:755
+#: lxc/storage_volume.go:759
 msgid "[<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
@@ -5917,7 +5931,7 @@ msgstr ""
 msgid "[<remote>:]<pool>"
 msgstr ""
 
-#: lxc/storage_volume.go:2233
+#: lxc/storage_volume.go:2237
 msgid "[<remote>:]<pool> <backup file> [<volume name>]"
 msgstr ""
 
@@ -5952,17 +5966,17 @@ msgstr ""
 msgid "[<remote>:]<pool> <key> <value>"
 msgstr ""
 
-#: lxc/storage_volume.go:1591
+#: lxc/storage_volume.go:1595
 msgid ""
 "[<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot "
 "name>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1128
+#: lxc/storage_volume.go:1132
 msgid "[<remote>:]<pool> <volume>"
 msgstr ""
 
-#: lxc/storage_volume.go:673
+#: lxc/storage_volume.go:677
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>]"
 msgstr ""
 
@@ -5970,44 +5984,44 @@ msgstr ""
 msgid "[<remote>:]<pool> <volume> <instance> [<device name>] [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1891
+#: lxc/storage_volume.go:1895
 msgid "[<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1704
+#: lxc/storage_volume.go:1708
 msgid "[<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage_volume.go:2022
+#: lxc/storage_volume.go:2026
 msgid "[<remote>:]<pool> <volume> <snapshot>"
 msgstr ""
 
-#: lxc/storage_volume.go:2089
+#: lxc/storage_volume.go:2093
 msgid "[<remote>:]<pool> <volume> [<path>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1925
+#: lxc/storage_volume.go:1929
 msgid "[<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:519
+#: lxc/storage_volume.go:523
 msgid "[<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/storage_volume.go:597 lxc/storage_volume.go:836
-#: lxc/storage_volume.go:1792
+#: lxc/storage_volume.go:601 lxc/storage_volume.go:840
+#: lxc/storage_volume.go:1796
 msgid "[<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/storage_volume.go:1040
+#: lxc/storage_volume.go:1044
 msgid "[<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/storage_volume.go:1347
+#: lxc/storage_volume.go:1351
 msgid "[<remote>:]<pool> [<filter>...]"
 msgstr ""
 
-#: lxc/storage_volume.go:1557
+#: lxc/storage_volume.go:1561
 msgid "[<remote>:]<pool>/<volume> [<remote>:]<pool>/<volume>"
 msgstr ""
 
@@ -6418,27 +6432,27 @@ msgid ""
 "    Update a storage pool using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:840
+#: lxc/storage_volume.go:844
 msgid ""
 "lxc storage volume edit [<remote>:]<pool> <volume> < volume.yaml\n"
 "    Update a storage volume using the content of pool.yaml."
 msgstr ""
 
-#: lxc/storage_volume.go:2237
+#: lxc/storage_volume.go:2241
 msgid ""
 "lxc storage volume import default backup0.tar.gz\n"
 "\t\tCreate a new custom volume using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/storage_volume.go:1796
+#: lxc/storage_volume.go:1800
 msgid ""
 "lxc storage volume show default data\n"
 "    Will show the properties of a custom volume called \"data\" in the "
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called "
-"\"data\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called \"data"
+"\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453


### PR DESCRIPTION
This commit https://github.com/lxc/lxd/commit/0468e1caf403ddfb11963d58eadece1bb454e8f9 (see https://github.com/lxc/lxd/issues/11061) disallowed usage of `--destination-server` when the source and destination were different remotes. This was to prevent an error that occurs when the destination server is not clustered.

This PR introduces a few checks on both `--target` and `--destination` target to ensure correct usage:
* `--target` is no longer allowed if the source server is not clustered.
* If the source server is clustered and the source volume is in local storage, validate that the `--target` flag matches the location of the source volume.
* `--destination-target` is no longer allowed if the destination server is not clustered.

Note, I'm not certain that #11061 is truly fixed by this PR.