### PR TITLE
lxd/db: Remove needless semi-colons in queries

### DIFF
--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -82,7 +82,7 @@ func (c *ClusterTx) AddNodeToClusterGroup(ctx context.Context, groupName string,
 		return fmt.Errorf("Failed to get node info: %w", err)
 	}
 
-	_, err = c.tx.Exec(`INSERT INTO nodes_cluster_groups (node_id, group_id) VALUES(?, ?);`, nodeInfo.ID, groupID)
+	_, err = c.tx.Exec(`INSERT INTO nodes_cluster_groups (node_id, group_id) VALUES(?, ?)`, nodeInfo.ID, groupID)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/network_zones.go
+++ b/lxd/db/network_zones.go
@@ -79,7 +79,7 @@ func (c *Cluster) GetNetworkZoneKeys() (map[string]string, error) {
 	q := `SELECT networks_zones.name, networks_zones_config.key, networks_zones_config.value
 		FROM networks_zones
 		JOIN networks_zones_config ON networks_zones_config.network_zone_id=networks_zones.id
-		WHERE networks_zones_config.key LIKE 'peers.%.key';
+		WHERE networks_zones_config.key LIKE 'peers.%.key'
 	`
 
 	secrets := map[string]string{}

--- a/lxd/db/patches.go
+++ b/lxd/db/patches.go
@@ -26,7 +26,7 @@ func (n *Node) GetAppliedPatches() ([]string, error) {
 
 // MarkPatchAsApplied marks the patch with the given name as applied on this node.
 func (n *Node) MarkPatchAsApplied(patch string) error {
-	stmt := `INSERT INTO patches (name, applied_at) VALUES (?, strftime("%s"));`
+	stmt := `INSERT INTO patches (name, applied_at) VALUES (?, strftime("%s"))`
 	_, err := n.db.Exec(stmt, patch)
 	return err
 }


### PR DESCRIPTION
This also happens to workaround a temporary dqlite regression.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>