### PR TITLE
Instance: Get CRIU working again

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -992,7 +992,7 @@ func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName
 		}
 
 		req.ContainerPut.Stateful = snapshot.Stateful
-		req.Source.Live = args.Live
+		req.Source.Live = false // Snapshots are never running and so we don't need live migration.
 	}
 
 	req.Source.BaseImage = snapshot.Config["volatile.base_image"]

--- a/client/lxd_instances.go
+++ b/client/lxd_instances.go
@@ -1555,7 +1555,7 @@ func (r *ProtocolLXD) CopyInstanceSnapshot(source InstanceServer, instanceName s
 		}
 
 		req.InstancePut.Stateful = snapshot.Stateful
-		req.Source.Live = args.Live
+		req.Source.Live = false // Snapshots are never running and so we don't need live migration.
 	}
 
 	req.Source.BaseImage = snapshot.Config["volatile.base_image"]

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -900,11 +900,11 @@ func (d *common) maasDelete(inst instance.Instance) error {
 func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOperation, error) {
 	var err error
 
-	// Pick up the existing stop operation lock created in Stop() function.
-	// If there is another ongoing operation (such as start), wait until that has finished before proceeding
-	// to run the hook (this should be quick as it will fail showing instance is already running).
+	// Pick up the existing stop operation lock created in Start(), Restart(), Shutdown() or Stop() functions.
+	// If there is another ongoing operation that isn't in our inheritable list, wait until that has finished
+	// before proceeding to run the hook.
 	op := operationlock.Get(d.Project().Name, d.Name())
-	if op != nil && !op.ActionMatch(operationlock.ActionStop, operationlock.ActionRestart, operationlock.ActionRestore) {
+	if op != nil && !op.ActionMatch(operationlock.ActionStart, operationlock.ActionRestart, operationlock.ActionStop, operationlock.ActionRestore) {
 		d.logger.Debug("Waiting for existing operation lock to finish before running hook", logger.Ctx{"action": op.Action()})
 		_ = op.Wait()
 		op = nil

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2268,37 +2268,15 @@ func (d *lxc) detachInterfaceRename(netns string, ifName string, hostName string
 	return nil
 }
 
-// validateStartup checks any constraints that would prevent start up from succeeding under normal circumstances.
-func (d *lxc) validateStartup(stateful bool) error {
-	// Because the root disk is special and is mounted before the root disk device is setup we duplicate the
-	// pre-start check here before the isStartableStatusCode check below so that if there is a problem loading
-	// the instance status because the storage pool isn't available we don't mask the StatusServiceUnavailable
-	// error with an ERROR status code from the instance check instead.
-	_, rootDiskConf, err := shared.GetRootDiskDevice(d.expandedDevices.CloneNative())
-	if err != nil {
-		return err
-	}
-
-	if !storagePools.IsAvailable(rootDiskConf["pool"]) {
-		return api.StatusErrorf(http.StatusServiceUnavailable, "Storage pool %q unavailable on this server", rootDiskConf["pool"])
-	}
-
-	// Check that we are startable before creating an operation lock, so if the instance is in the
-	// process of stopping we don't prevent the stop hooks from running due to our start operation lock.
-	err = d.isStartableStatusCode(d.statusCode())
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // Start starts the instance.
 func (d *lxc) Start(stateful bool) error {
 	d.logger.Debug("Start started", logger.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Start finished", logger.Ctx{"stateful": stateful})
 
-	err := d.validateStartup(stateful)
+	// Check that we are startable before creating an operation lock.
+	// Must happen before creating operation Start lock to avoid the status check returning Stopped due to the
+	// existence of a Start operation lock.
+	err := d.validateStartup(stateful, d.statusCode())
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5104,9 +5104,22 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 			}
 		}
 	} else {
-		err := d.initLXC(true)
-		if err != nil {
-			return err
+		// Load the go-lxc struct
+		if d.expandedConfig["raw.lxc"] != "" {
+			err = d.initLXC(true)
+			if err != nil {
+				return err
+			}
+
+			err = d.loadRawLXCConfig()
+			if err != nil {
+				return err
+			}
+		} else {
+			err = d.initLXC(false)
+			if err != nil {
+				return err
+			}
 		}
 
 		script := ""

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2289,7 +2289,7 @@ func (d *lxc) Start(stateful bool) error {
 
 	var ctxMap logger.Ctx
 
-	// Setup a new operation
+	// Setup a new operation.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
 		if errors.Is(err, operationlock.ErrNonReusuableSucceeded) {
@@ -2326,7 +2326,7 @@ func (d *lxc) Start(stateful bool) error {
 		d.logger.Info("Starting instance", ctxMap)
 	}
 
-	// If stateful, restore now
+	// If stateful, restore now.
 	if stateful {
 		if !d.stateful {
 			err = fmt.Errorf("Instance has no existing state to restore")

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6895,24 +6895,6 @@ func (d *lxc) UpdateBackupFile() error {
 	return pool.UpdateInstanceBackupFile(d, nil)
 }
 
-// SaveConfigFile generates the LXC config file on disk.
-func (d *lxc) SaveConfigFile() error {
-	err := d.initLXC(true)
-	if err != nil {
-		return fmt.Errorf("Failed to generate LXC config: %w", err)
-	}
-
-	// Generate the LXC config.
-	configPath := filepath.Join(d.LogPath(), "lxc.conf")
-	err = d.c.SaveConfigFile(configPath)
-	if err != nil {
-		_ = os.Remove(configPath)
-		return fmt.Errorf("Failed to save LXC config to file %q: %w", configPath, err)
-	}
-
-	return nil
-}
-
 // Info returns "lxc" and the currently loaded version of LXC.
 func (d *lxc) Info() instance.Info {
 	return instance.Info{

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2237,6 +2237,14 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		return "", nil, err
 	}
 
+	// Update the backup.yaml file just before starting the instance process, but after all devices have been
+	// setup, so that the backup file contains the volatile keys used for this instance start, so that they
+	// can be used for instance cleanup.
+	err = d.UpdateBackupFile()
+	if err != nil {
+		return "", nil, err
+	}
+
 	revert.Success()
 	return configPath, postStartHooks, nil
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2287,8 +2287,6 @@ func (d *lxc) Start(stateful bool) error {
 		return err
 	}
 
-	var ctxMap logger.Ctx
-
 	// Setup a new operation.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionStart, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
@@ -2315,7 +2313,7 @@ func (d *lxc) Start(stateful bool) error {
 		return err
 	}
 
-	ctxMap = logger.Ctx{
+	ctxMap := logger.Ctx{
 		"action":    op.Action(),
 		"created":   d.creationDate,
 		"ephemeral": d.ephemeral,

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5035,10 +5035,14 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 			return fmt.Errorf("The container is already running")
 		}
 
-		// Run the shared start
-		_, postStartHooks, err := d.startCommon()
+		// Run the shared start code.
+		configPath, postStartHooks, err := d.startCommon()
 		if err != nil {
-			return fmt.Errorf("Failed preparing container for start: %w", err)
+			if args.Op != nil {
+				args.Op.Done(err)
+			}
+
+			return err
 		}
 
 		/*
@@ -5071,18 +5075,8 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 			}
 		}
 
-		configPath := filepath.Join(d.LogPath(), "lxc.conf")
-
 		if args.DumpDir != "" {
 			finalStateDir = fmt.Sprintf("%s/%s", args.StateDir, args.DumpDir)
-		}
-
-		// Update the backup.yaml file just before starting the instance process, but after all devices
-		// have been setup, so that the backup file contains the volatile keys used for this instance
-		// start, so that they can be used for instance cleanup.
-		err = d.UpdateBackupFile()
-		if err != nil {
-			return err
 		}
 
 		_, migrateErr = shared.RunCommand(
@@ -5092,14 +5086,20 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 			d.state.OS.LxcPath,
 			configPath,
 			finalStateDir,
-			fmt.Sprintf("%v", preservesInodes))
+			fmt.Sprintf("%v", preservesInodes),
+		)
 
 		if migrateErr == nil {
 			// Run any post start hooks.
-			err := d.runHooks(postStartHooks)
+			err = d.runHooks(postStartHooks)
 			if err != nil {
+				if args.Op != nil {
+					args.Op.Done(err) // Must come before Stop() otherwise stop will not proceed.
+				}
+
 				// Attempt to stop container.
 				_ = d.Stop(false)
+
 				return err
 			}
 		}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5003,8 +5003,6 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 		prettyCmd = "dump"
 	case liblxc.MIGRATE_RESTORE:
 		prettyCmd = "restore"
-	case liblxc.MIGRATE_FEATURE_CHECK:
-		prettyCmd = "feature-check"
 	default:
 		prettyCmd = "unknown"
 		d.logger.Warn("Unknown migrate call", logger.Ctx{"cmd": args.Cmd})
@@ -5105,23 +5103,6 @@ func (d *lxc) Migrate(args *instance.CriuMigrationArgs) error {
 				return err
 			}
 		}
-	} else if args.Cmd == liblxc.MIGRATE_FEATURE_CHECK {
-		err := d.initLXC(true)
-		if err != nil {
-			return err
-		}
-
-		opts := liblxc.MigrateOptions{
-			FeaturesToCheck: args.Features,
-		}
-
-		migrateErr = d.c.Migrate(args.Cmd, opts)
-		if migrateErr != nil {
-			d.logger.Info("CRIU feature check failed", ctxMap)
-			return migrateErr
-		}
-
-		return nil
 	} else {
 		err := d.initLXC(true)
 		if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -939,7 +939,10 @@ func (d *qemu) Start(stateful bool) error {
 	d.logger.Debug("Start started", logger.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Start finished", logger.Ctx{"stateful": stateful})
 
-	err := d.validateStartup(stateful)
+	// Check that we are startable before creating an operation lock.
+	// Must happen before creating operation Start lock to avoid the status check returning Stopped due to the
+	// existence of a Start operation lock.
+	err := d.validateStartup(stateful, d.statusCode())
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1719,12 +1719,6 @@ func (d *qemu) RegisterDevices() {
 	d.devicesRegister(d)
 }
 
-// SaveConfigFile is not used by VMs because the Qemu config file is generated at start up and is not needed
-// after that, so doesn't need to support being regenerated.
-func (d *qemu) SaveConfigFile() error {
-	return nil
-}
-
 func (d *qemu) saveConnectionInfo(connInfo *agentAPI.API10Put) error {
 	configDrivePath := filepath.Join(d.Path(), "config")
 

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -72,7 +72,6 @@ type Instance interface {
 	Restart(timeout time.Duration) error
 	Unfreeze() error
 	RegisterDevices()
-	SaveConfigFile() error
 
 	Info() Info
 	IsPrivileged() bool

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -188,6 +188,7 @@ type CriuMigrationArgs struct {
 	DumpDir      string
 	PreDumpDir   string
 	Features     liblxc.CriuFeatures
+	Op           *operationlock.InstanceOperation
 }
 
 // Info represents information about an instance driver.

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -659,7 +659,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		if reqNew.Live {
 			sourceName, _, _ := api.GetParentAndSnapshotName(containerName)
 			if sourceName != reqNew.Name {
-				return response.BadRequest(fmt.Errorf("Copying stateful instances requires that source %q and target %q name be identical", sourceName, reqNew.Name))
+				return response.BadRequest(fmt.Errorf("Instance name cannot be changed during stateful copy (%q to %q)", sourceName, reqNew.Name))
 			}
 		}
 

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -653,17 +653,13 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		}
 
 		if reqNew.Name == "" {
-			return response.BadRequest(fmt.Errorf(`A new name for the ` +
-				`container must be provided`))
+			return response.BadRequest(fmt.Errorf("A new name for the instance must be provided"))
 		}
 
 		if reqNew.Live {
 			sourceName, _, _ := api.GetParentAndSnapshotName(containerName)
 			if sourceName != reqNew.Name {
-				return response.BadRequest(fmt.Errorf(`Copying `+
-					`stateful containers requires that `+
-					`source "%s" and `+`target "%s" name `+
-					`be identical`, sourceName, reqNew.Name))
+				return response.BadRequest(fmt.Errorf("Copying stateful instances requires that source %q and target %q name be identical", sourceName, reqNew.Name))
 			}
 		}
 

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -486,7 +486,7 @@ func createFromCopy(d *Daemon, r *http.Request, projectName string, profiles []a
 	if req.Stateful {
 		sourceName, _, _ := api.GetParentAndSnapshotName(source.Name())
 		if sourceName != req.Name {
-			return response.BadRequest(fmt.Errorf("Copying stateful instances requires that source %q and target %q name be identical", sourceName, req.Name))
+			return response.BadRequest(fmt.Errorf("Instance name cannot be changed during stateful copy (%q to %q)", sourceName, req.Name))
 		}
 	}
 

--- a/lxd/main_forkmigrate.go
+++ b/lxd/main_forkmigrate.go
@@ -64,7 +64,7 @@ func (c *cmdForkmigrate) Run(cmd *cobra.Command, args []string) error {
 
 	err = d.LoadConfigFile(configPath)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed loading config file %q: %w", configPath, err)
 	}
 
 	/* see https://github.com/golang/go/issues/13155, startContainer, and dc3a229 */

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -165,7 +165,7 @@ func (s *migrationSourceWs) Metadata() any {
 func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w http.ResponseWriter) error {
 	secret := r.FormValue("secret")
 	if secret == "" {
-		return fmt.Errorf("missing secret")
+		return fmt.Errorf("Missing migration source secret")
 	}
 
 	var conn **websocket.Conn
@@ -348,7 +348,7 @@ func (s *migrationSink) Metadata() any {
 func (s *migrationSink) Connect(op *operations.Operation, r *http.Request, w http.ResponseWriter) error {
 	secret := r.FormValue("secret")
 	if secret == "" {
-		return fmt.Errorf("missing secret")
+		return fmt.Errorf("Missing migration sink secret")
 	}
 
 	var conn **websocket.Conn

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -253,7 +253,7 @@ func (s *migrationSourceWs) preDumpLoop(state *state.State, args *preDumpLoopArg
 
 	err := s.instance.Migrate(&criuMigrationArgs)
 	if err != nil {
-		return final, err
+		return final, fmt.Errorf("Failed sending instance: %w", err)
 	}
 
 	// Send the pre-dump.
@@ -577,7 +577,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 				func(op *operations.Operation, r *http.Request, w http.ResponseWriter) error {
 					secret := r.FormValue("secret")
 					if secret == "" {
-						return fmt.Errorf("missing secret")
+						return fmt.Errorf("Missing action script secret")
 					}
 
 					if secret != actionScriptOpSecret {

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -140,28 +140,14 @@ func snapshotToProtobuf(snap *api.InstanceSnapshot) *migration.Snapshot {
 	}
 }
 
-// Check if CRIU supports pre-dumping and number of
-// pre-dump iterations.
+// Check if CRIU supports pre-dumping and number of pre-dump iterations.
 func (s *migrationSourceWs) checkForPreDumpSupport() (bool, int) {
-	// Ask CRIU if this architecture/kernel/criu combination
-	// supports pre-copy (dirty memory tracking)
-	criuMigrationArgs := instance.CriuMigrationArgs{
-		Cmd:          liblxc.MIGRATE_FEATURE_CHECK,
-		StateDir:     "",
-		Function:     "feature-check",
-		Stop:         false,
-		ActionScript: false,
-		DumpDir:      "",
-		PreDumpDir:   "",
-		Features:     liblxc.FEATURE_MEM_TRACK,
-	}
-
 	if s.instance.Type() != instancetype.Container {
 		return false, 0
 	}
 
-	err := s.instance.Migrate(&criuMigrationArgs)
-
+	// Check if this architecture/kernel/criu combination supports pre-copy dirty memory tracking feature.
+	_, err := shared.RunCommand("criu", "check", "--feature", "mem_dirty_track")
 	if err != nil {
 		// CRIU says it does not know about dirty memory tracking.
 		// This means the rest of this function is irrelevant.

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -233,7 +233,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 	} else {
 		c.src.controlConn, err = c.connectWithSecret(c.src.controlSecret)
 		if err != nil {
-			logger.Errorf("Failed to connect migration sink control socket")
+			err = fmt.Errorf("Failed connecting control sink socket: %w", err)
 			return err
 		}
 
@@ -241,7 +241,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 
 		c.src.fsConn, err = c.connectWithSecret(c.src.fsSecret)
 		if err != nil {
-			logger.Errorf("Failed to connect migration sink filesystem socket")
+			err = fmt.Errorf("Failed connecting filesystem sink socket: %w", err)
 			c.src.sendControl(err)
 			return err
 		}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1022,7 +1022,7 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 	// Then check if the query is from an operation on another node, and, if so, forward it
 	secret := r.FormValue("secret")
 	if secret == "" {
-		return response.BadRequest(fmt.Errorf("missing secret"))
+		return response.BadRequest(fmt.Errorf("Missing websocket secret"))
 	}
 
 	var address string

--- a/lxd/storage/drivers/generic_vfs.go
+++ b/lxd/storage/drivers/generic_vfs.go
@@ -306,7 +306,9 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 			wrapper = migration.ProgressTracker(op, "fs_progress", volName)
 		}
 
-		d.Logger().Debug("Receiving filesystem volume", logger.Ctx{"volName": volName, "path": path})
+		d.Logger().Debug("Receiving filesystem volume started", logger.Ctx{"volName": volName, "path": path})
+		defer d.Logger().Debug("Receiving filesystem volume stopped", logger.Ctx{"volName": volName, "path": path})
+
 		return rsync.Recv(path, conn, wrapper, volTargetArgs.MigrationType.Features)
 	}
 
@@ -332,7 +334,9 @@ func genericVFSCreateVolumeFromMigration(d Driver, initVolume func(vol Volume) (
 			}
 		}
 
-		d.Logger().Debug("Receiving block volume", logger.Ctx{"volName": volName, "path": path})
+		d.Logger().Debug("Receiving block volume started", logger.Ctx{"volName": volName, "path": path})
+		defer d.Logger().Debug("Receiving block volume stopped", logger.Ctx{"volName": volName, "path": path})
+
 		_, err = io.Copy(to, fromPipe)
 		if err != nil {
 			return fmt.Errorf("Error copying from migration connection to %q: %w", path, err)

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -564,7 +564,7 @@ migration() {
   fi
 
   echo "==> CRIU: starting testing live-migration"
-  lxc_remote launch testimage l1:migratee
+  lxc_remote launch testimage l1:migratee -c raw.lxc=lxc.console.path=none
 
   # Wait for the container to be done booting
   sleep 1
@@ -574,10 +574,18 @@ migration() {
   lxc_remote start l1:migratee
 
   # Test stateful snapshots
+  # There is apparently a bug in CRIU that prevents checkpointing an instance that has been started from a
+  # checkpoint. So stop instance first before taking stateful snapshot.
+  lxc_remote stop -f l1:migratee
+  lxc_remote start l1:migratee
   lxc_remote snapshot --stateful l1:migratee
   lxc_remote restore l1:migratee snap0
 
   # Test live migration of container
+  # There is apparently a bug in CRIU that prevents checkpointing an instance that has been started from a
+  # checkpoint. So stop instance first before taking stateful snapshot.
+  lxc_remote stop -f l1:migratee
+  lxc_remote start l1:migratee
   lxc_remote move l1:migratee l2:migratee
 
   # Test copy of stateful snapshot


### PR DESCRIPTION
For very, very limited definitions of "working".

Using CRIU v1.17.1 (same as LXD snap uses) on Jammy, this is about all I could get working:

```
lxc launch images:busybox/1.34.1 c1 -c raw.lxc=lxc.console.path=none
lxc stop c1 --stateful
lxc start c1
```

Did also manage to get working migration and stateful snapshots.