### PR TITLE
Images: Only remove cached image files & volumes when image is expired in all projects that use it

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2263,22 +2263,50 @@ func pruneLeftoverImages(d *Daemon) {
 }
 
 func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Operation) error {
-	var projects []api.Project
-	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		var err error
+	var err error
+	var projectsImageRemoteCacheExpiryDays map[string]int64
+	var allImages map[string][]dbCluster.Image
+
+	err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
+		// Get an image remote cache expiry days value for each project and store keyed on project name.
+		globalImageRemoteCacheExpiryDays := s.GlobalConfig.ImagesRemoteCacheExpiryDays()
+
 		dbProjects, err := dbCluster.GetProjects(ctx, tx.Tx())
 		if err != nil {
 			return err
 		}
 
-		projects = make([]api.Project, 0, len(dbProjects))
-		for _, project := range dbProjects {
-			p, err := project.ToAPI(ctx, tx.Tx())
+		projectsImageRemoteCacheExpiryDays = make(map[string]int64, len(dbProjects))
+		for _, p := range dbProjects {
+			p, err := p.ToAPI(ctx, tx.Tx())
 			if err != nil {
 				return err
 			}
 
-			projects = append(projects, *p)
+			// If there is a project specific image expiry set use that.
+			if p.Config["images.remote_cache_expiry"] != "" {
+				expiry, err := strconv.ParseInt(p.Config["images.remote_cache_expiry"], 10, 64)
+				if err != nil {
+					return fmt.Errorf("Unable to fetch project configuration: %w", err)
+				}
+
+				projectsImageRemoteCacheExpiryDays[p.Name] = expiry
+			} else {
+				// Otherwise use the global default.
+				projectsImageRemoteCacheExpiryDays[p.Name] = globalImageRemoteCacheExpiryDays
+			}
+		}
+
+		// Get all cached images across all projects and store them keyed on fingerprint.
+		cached := true
+		images, err := dbCluster.GetImages(ctx, tx.Tx(), dbCluster.ImageFilter{Cached: &cached})
+		if err != nil {
+			return fmt.Errorf("Failed getting images: %w", err)
+		}
+
+		allImages = make(map[string][]dbCluster.Image, len(images))
+		for i := range images {
+			allImages[images[i].Fingerprint] = append(allImages[images[i].Fingerprint], images[i])
 		}
 
 		return nil
@@ -2287,52 +2315,58 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 		return fmt.Errorf("Unable to retrieve project names: %w", err)
 	}
 
-	for _, project := range projects {
-		err := pruneExpiredImagesInProject(ctx, s, project, op)
-		if err != nil {
-			return fmt.Errorf("Unable to prune images for project %q: %w", project.Name, err)
-		}
-	}
-
-	return nil
-}
-
-func pruneExpiredImagesInProject(ctx context.Context, s *state.State, project api.Project, op *operations.Operation) error {
-	var expiry int64
-	var err error
-	if project.Config["images.remote_cache_expiry"] != "" {
-		expiry, err = strconv.ParseInt(project.Config["images.remote_cache_expiry"], 10, 64)
-		if err != nil {
-			return fmt.Errorf("Unable to fetch project configuration: %w", err)
-		}
-	} else {
-		expiry = s.GlobalConfig.ImagesRemoteCacheExpiryDays()
-	}
-
-	// Check if we're supposed to prune at all
-	if expiry <= 0 {
-		return nil
-	}
-
-	// Get the list of expired images.
-	images, err := s.DB.Cluster.GetExpiredImagesInProject(expiry, project.Name)
-	if err != nil {
-		return fmt.Errorf("Unable to retrieve the list of expired images: %w", err)
-	}
-
-	// Delete them
-	for _, fingerprint := range images {
-		// At each iteration we check if we got cancelled in the
-		// meantime. It is safe to abort here since anything not
-		// expired now will be expired at the next run.
+	for fingerprint, dbImages := range allImages {
+		// At each iteration we check if we got cancelled in the meantime. It is safe to abort here since
+		// anything not expired now will be expired at the next run.
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
 		}
 
-		// Get the IDs of all storage pools on which a storage volume
-		// for the requested image currently exists.
+		dbImagesDeleted := 0
+		for _, dbImage := range dbImages {
+			// Get expiry days for image's project.
+			expiryDays := projectsImageRemoteCacheExpiryDays[dbImage.Project]
+
+			// Skip if no project expiry time set.
+			if expiryDays <= 0 {
+				continue
+			}
+
+			// Figure out the expiry of image.
+			timestamp := dbImage.UploadDate
+			if !dbImage.LastUseDate.Time.IsZero() {
+				timestamp = dbImage.LastUseDate.Time
+			}
+
+			imageExpiry := timestamp.Add(time.Duration(expiryDays) * time.Hour * 24)
+
+			// Skip if image is not expired.
+			if imageExpiry.After(time.Now()) {
+				continue
+			}
+
+			// Remove the database entry for the image.
+			err = s.DB.Cluster.DeleteImage(dbImage.ID)
+			if err != nil {
+				return fmt.Errorf("Error deleting image %q in project %q from database: %w", fingerprint, dbImage.Project, err)
+			}
+
+			dbImagesDeleted++
+
+			logger.Info("Deleted expired cached image record", logger.Ctx{"fingerprint": fingerprint, "project": dbImage.Project, "expiry": imageExpiry})
+
+			s.Events.SendLifecycle(dbImage.Project, lifecycle.ImageDeleted.Event(fingerprint, dbImage.Project, op.Requestor(), nil))
+		}
+
+		// Skip deleting the image files and image storage volumes on disk if image is not expired in all
+		// of its projects.
+		if dbImagesDeleted < len(dbImages) {
+			continue
+		}
+
+		// Get the IDs of all storage pools on which a storage volume for the image currently exists.
 		poolIDs, err := s.DB.Cluster.GetPoolsWithImage(fingerprint)
 		if err != nil {
 			continue
@@ -2347,45 +2381,30 @@ func pruneExpiredImagesInProject(ctx context.Context, s *state.State, project ap
 		for _, poolName := range poolNames {
 			pool, err := storagePools.LoadByName(s, poolName)
 			if err != nil {
-				return fmt.Errorf("Error loading storage pool %q to delete image %q: %w", poolName, fingerprint, err)
+				return fmt.Errorf("Error loading storage pool %q to delete image volume %q: %w", poolName, fingerprint, err)
 			}
 
 			err = pool.DeleteImage(fingerprint, op)
 			if err != nil {
-				return fmt.Errorf("Error deleting image %q from storage pool %q: %w", fingerprint, pool.Name(), err)
+				return fmt.Errorf("Error deleting image volume %q from storage pool %q: %w", fingerprint, pool.Name(), err)
 			}
 		}
 
 		// Remove main image file.
 		fname := filepath.Join(s.OS.VarDir, "images", fingerprint)
-		if shared.PathExists(fname) {
-			err = os.Remove(fname)
-			if err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("Error deleting image file %q: %w", fname, err)
-			}
+		err = os.Remove(fname)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("Error deleting image file %q: %w", fname, err)
 		}
 
 		// Remove the rootfs file for the image.
 		fname = filepath.Join(s.OS.VarDir, "images", fingerprint) + ".rootfs"
-		if shared.PathExists(fname) {
-			err = os.Remove(fname)
-			if err != nil && !os.IsNotExist(err) {
-				return fmt.Errorf("Error deleting image file %q: %w", fname, err)
-			}
+		err = os.Remove(fname)
+		if err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("Error deleting image file %q: %w", fname, err)
 		}
 
-		imgID, _, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &project.Name})
-		if err != nil {
-			return fmt.Errorf("Error retrieving image info for fingerprint %q and project %q: %w", fingerprint, project.Name, err)
-		}
-
-		// Remove the database entry for the image.
-		err = s.DB.Cluster.DeleteImage(imgID)
-		if err != nil {
-			return fmt.Errorf("Error deleting image %q from database: %w", fingerprint, err)
-		}
-
-		s.Events.SendLifecycle(project.Name, lifecycle.ImageDeleted.Event(fingerprint, project.Name, op.Requestor(), nil))
+		logger.Info("Deleted expired cached image files and volumes", logger.Ctx{"fingerprint": fingerprint})
 	}
 
 	return nil

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -12,8 +12,13 @@ test_image_expiry() {
   lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --password foo
   lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --password foo
 
-  # Create a container from a remote image
-  lxc_remote init l1:testimage l2:c1
+  # Create containers from a remote image in two projects.
+  lxc_remote project create l2:p1 -c features.images=true -c features.profiles=false
+  lxc_remote init l1:testimage l2:c1 --project default
+  lxc_remote project switch l2:p1
+  lxc_remote init l1:testimage l2:c2
+  lxc_remote project switch l2:default
+
   fp="$(lxc_remote image info testimage | awk '/^Fingerprint/ {print $2}')"
 
   # Confirm the image is cached
@@ -26,8 +31,8 @@ test_image_expiry() {
   lxc_remote image show "l2:${fp}" | sed "s/expires_at.*/expires_at: 3000-01-01T00:00:00-00:00/" | lxc_remote image edit "l2:${fp}"
   lxc_remote image info "l2:${fp}" | grep -q "Expires.*3000"
 
-  # Override the upload date
-  LXD_DIR="$LXD2_DIR" lxd sql global "UPDATE images SET last_use_date='$(date --rfc-3339=seconds -u -d "2 days ago")' WHERE fingerprint='${fp}'" | grep -q "Rows affected: 1"
+  # Override the upload date for the image record in the default project.
+  LXD_DIR="$LXD2_DIR" lxd sql global "UPDATE images SET last_use_date='$(date --rfc-3339=seconds -u -d "2 days ago")' WHERE fingerprint='${fp}' AND project_id = 1" | grep -q "Rows affected: 1"
 
   # Trigger the expiry
   lxc_remote config set l2: images.remote_cache_expiry 1
@@ -39,9 +44,33 @@ test_image_expiry() {
 
   ! lxc_remote image list l2: | grep -q "${fpbrief}" || false
 
+  # Check image is still in p1 project and has not been expired.
+  lxc_remote image list l2: --project p1 | grep -q "${fpbrief}"
+
+  # Test instance can still be created in p1 project.
+  lxc_remote project switch l2:p1
+  lxc_remote init l1:testimage l2:c3
+  lxc_remote project switch l2:default
+
+  # Override the upload date for the image record in the p1 project.
+  LXD_DIR="$LXD2_DIR" lxd sql global "UPDATE images SET last_use_date='$(date --rfc-3339=seconds -u -d "2 days ago")' WHERE fingerprint='${fp}' AND project_id > 1" | grep -q "Rows affected: 1"
+  lxc_remote project set l2:p1 images.remote_cache_expiry=1
+
+  # Trigger the expiry in p1 project by changing global images.remote_cache_expiry.
+  lxc_remote config unset l2: images.remote_cache_expiry
+
+  for _ in $(seq 20); do
+    sleep 1
+    ! lxc_remote image list l2: --project p1 | grep -q "${fpbrief}" && break
+  done
+
+  ! lxc_remote image list l2: --project p1 | grep -q "${fpbrief}" || false
+
   # Cleanup and reset
-  lxc_remote delete l2:c1
-  lxc_remote config set l2: images.remote_cache_expiry 10
+  lxc_remote delete -f l2:c1
+  lxc_remote delete -f l2:c2 --project p1
+  lxc_remote delete -f l2:c3 --project p1
+  lxc_remote project delete l2:p1
   lxc_remote remote remove l1
   lxc_remote remote remove l2
   kill_lxd "$LXD2_DIR"


### PR DESCRIPTION
Fixes #11355 

And uses fewer transactions and queries.