### PR TITLE
Instance: Remove erroneous empty log error in LXC driver

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1321,7 +1321,6 @@ func (d *lxc) IdmappedStorage(path string, fstype string) idmap.IdmapStorageType
 		}
 	}
 
-	d.logger.Error("", logger.Ctx{"path": path, "fstype": fstype})
 	if idmap.CanIdmapMount(path, fstype) {
 		// Use idmapped mounts.
 		mode = idmap.IdmapStorageIdmapped


### PR DESCRIPTION
Introduced by #ba67c05f6acce51629f731220d5dd1c74ecb3cf2

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>