### PR TITLE
Network: Allow management of zone records in non-default project zones

### DIFF
--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -325,13 +325,13 @@ CREATE TABLE "networks_zones_config" (
 	UNIQUE (network_zone_id, key),
 	FOREIGN KEY (network_zone_id) REFERENCES "networks_zones" (id) ON DELETE CASCADE
 );
-CREATE TABLE networks_zones_records (
+CREATE TABLE "networks_zones_records" (
 	id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
 	network_zone_id INTEGER NOT NULL,
 	name TEXT NOT NULL,
 	description TEXT NOT NULL,
 	entries TEXT NOT NULL,
-	UNIQUE (name),
+	UNIQUE (network_zone_id, name),
 	FOREIGN KEY (network_zone_id) REFERENCES networks_zones (id) ON DELETE CASCADE
 );
 CREATE TABLE "networks_zones_records_config" (
@@ -340,7 +340,7 @@ CREATE TABLE "networks_zones_records_config" (
 	key TEXT NOT NULL,
 	value TEXT NOT NULL,
 	UNIQUE (network_zone_record_id, key),
-	FOREIGN KEY (network_zone_record_id) REFERENCES networks_zones_records (id) ON DELETE CASCADE
+	FOREIGN KEY (network_zone_record_id) REFERENCES "networks_zones_records" (id) ON DELETE CASCADE
 );
 CREATE TABLE "nodes" (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -621,5 +621,5 @@ CREATE TABLE "warnings" (
 );
 CREATE UNIQUE INDEX warnings_unique_node_id_project_id_entity_type_code_entity_id_type_code ON warnings(IFNULL(node_id, -1), IFNULL(project_id, -1), entity_type_code, entity_id, type_code);
 
-INSERT INTO schema (version, updated_at) VALUES (68, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (69, strftime("%s"))
 `

--- a/lxd/network_zones_records.go
+++ b/lxd/network_zones_records.go
@@ -129,7 +129,7 @@ var networkZoneRecordCmd = APIEndpoint{
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZoneRecordsGet(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -203,7 +203,7 @@ func networkZoneRecordsGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZoneRecordsPost(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -263,7 +263,7 @@ func networkZoneRecordsPost(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZoneRecordDelete(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -336,7 +336,7 @@ func networkZoneRecordDelete(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZoneRecordGet(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -436,7 +436,7 @@ func networkZoneRecordGet(d *Daemon, r *http.Request) response.Response {
 //   "500":
 //     $ref: "#/responses/InternalServerError"
 func networkZoneRecordPut(d *Daemon, r *http.Request) response.Response {
-	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
+	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
 		return response.SmartError(err)
 	}


### PR DESCRIPTION
Fixes #11364 

This PR fixes 2 bugs:

- Allows management of zone records in non-default project zones.
- Updates the `networks_zones_records` unique index to fix an issue that prevented creating records of the same name in different zones.