### PR TITLE
tests: make it work when seccomp is enabled externally

### DIFF
--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -459,15 +459,19 @@ test_basic_usage() {
     echo "==> SKIP: apparmor tests (missing kernel support)"
   fi
 
-  lxc launch testimage lxd-seccomp-test
-  init=$(lxc info lxd-seccomp-test | awk '/^PID:/ {print $2}')
-  [ "$(awk '/^Seccomp:/ {print $2}' "/proc/${init}/status")" -eq "2" ]
-  lxc stop --force lxd-seccomp-test
-  lxc config set lxd-seccomp-test security.syscalls.deny_default false
-  lxc start lxd-seccomp-test
-  init=$(lxc info lxd-seccomp-test | awk '/^PID:/ {print $2}')
-  [ "$(awk '/^Seccomp:/ {print $2}' "/proc/${init}/status")" -eq "0" ]
-  lxc delete --force lxd-seccomp-test
+  if [ "$(awk '/^Seccomp:/ {print $2}' "/proc/self/status")" -eq "0" ]; then
+    lxc launch testimage lxd-seccomp-test
+    init=$(lxc info lxd-seccomp-test | awk '/^PID:/ {print $2}')
+    [ "$(awk '/^Seccomp:/ {print $2}' "/proc/${init}/status")" -eq "2" ]
+    lxc stop --force lxd-seccomp-test
+    lxc config set lxd-seccomp-test security.syscalls.deny_default false
+    lxc start lxd-seccomp-test
+    init=$(lxc info lxd-seccomp-test | awk '/^PID:/ {print $2}')
+    [ "$(awk '/^Seccomp:/ {print $2}' "/proc/${init}/status")" -eq "0" ]
+    lxc delete --force lxd-seccomp-test
+  else
+    echo "==> SKIP: seccomp tests (seccomp filtering is externally enabled)"
+  fi
 
   # make sure that privileged containers are not world-readable
   lxc profile create unconfined

--- a/test/suites/container_syscall_interception.sh
+++ b/test/suites/container_syscall_interception.sh
@@ -7,6 +7,11 @@ test_container_syscall_interception() {
     return
   fi
 
+  if [ "$(awk '/^Seccomp:/ {print $2}' "/proc/self/status")" -eq "0" ]; then
+    echo "==> SKIP: syscall interception (seccomp filtering is externally enabled)"
+    return
+  fi
+
   (
     cd syscall/sysinfo || return
     # Use -buildvcs=false here to prevent git complaining about untrusted directory when tests are run as root.


### PR DESCRIPTION
Let's check the seccomp state in `/proc/self/status` and if it has non-zero value then skip seccomp-related tests.