### PR TITLE
Network: Improve network forward and load balancer conflict validation between networks

### DIFF
--- a/lxd/db/network_forwards.go
+++ b/lxd/db/network_forwards.go
@@ -268,46 +268,60 @@ func (c *Cluster) GetNetworkForwardListenAddresses(networkID int64, memberSpecif
 
 // GetProjectNetworkForwardListenAddressesByUplink returns map of Network Forward Listen Addresses that belong to
 // networks connected to the specified uplinkNetworkName.
-// Returns a map keyed on project name and network ID containing a slice of listen addresses.
-func (c *ClusterTx) GetProjectNetworkForwardListenAddressesByUplink(ctx context.Context, uplinkNetworkName string) (map[string]map[int64][]string, error) {
+// Returns a map keyed on project name and network name containing a slice of listen addresses.
+func (c *ClusterTx) GetProjectNetworkForwardListenAddressesByUplink(ctx context.Context, uplinkNetworkName string, memberSpecific bool) (map[string]map[string][]string, error) {
+	q := strings.Builder{}
+	args := []any{uplinkNetworkName}
+
 	// As uplink networks can only be in default project, it is safe to look for networks that reference the
-	// specified uplinkNetworkName in their "network" config property.
-	q := `
+	// specified uplinkNetworkName in their "network" config property, or are the uplink network themselves in
+	// the default project.
+	q.WriteString(`
 	SELECT
 		projects.name,
-		networks.id,
+		networks.name,
 		networks_forwards.listen_address
 	FROM networks_forwards
 	JOIN networks on networks.id = networks_forwards.network_id
 	JOIN networks_config on networks.id = networks_config.network_id
 	JOIN projects ON projects.id = networks.project_id
-	WHERE networks_config.key = "network"
-	AND networks_config.value = ?
-	`
-	forwards := make(map[string]map[int64][]string)
+	WHERE (
+		(networks_config.key = "network" AND networks_config.value = ?1)
+		OR (projects.name = "default" AND networks.name = ?1)
+	)
+	`)
 
-	err := query.Scan(ctx, c.Tx(), q, func(scan func(dest ...any) error) error {
+	if memberSpecific {
+		q.WriteString("AND (networks_forwards.node_id = ?2 OR networks_forwards.node_id IS NULL) ")
+		args = append(args, c.nodeID)
+	}
+
+	q.WriteString("GROUP BY projects.name, networks.id, networks_forwards.listen_address")
+
+	forwards := make(map[string]map[string][]string)
+
+	err := query.Scan(ctx, c.Tx(), q.String(), func(scan func(dest ...any) error) error {
 		var projectName string
-		var networkID int64 = int64(-1)
+		var networkName string
 		var listenAddress string
 
-		err := scan(&projectName, &networkID, &listenAddress)
+		err := scan(&projectName, &networkName, &listenAddress)
 		if err != nil {
 			return err
 		}
 
 		if forwards[projectName] == nil {
-			forwards[projectName] = make(map[int64][]string)
+			forwards[projectName] = make(map[string][]string)
 		}
 
-		if forwards[projectName][networkID] == nil {
-			forwards[projectName][networkID] = make([]string, 0)
+		if forwards[projectName][networkName] == nil {
+			forwards[projectName][networkName] = make([]string, 0)
 		}
 
-		forwards[projectName][networkID] = append(forwards[projectName][networkID], listenAddress)
+		forwards[projectName][networkName] = append(forwards[projectName][networkName], listenAddress)
 
 		return nil
-	}, uplinkNetworkName)
+	}, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -2499,6 +2499,7 @@ func (n *bridge) getExternalSubnetInUse() ([]externalSubnetUsage, error) {
 	var err error
 	var projectNetworks map[string]map[int64]api.Network
 	var projectNetworksForwardsOnUplink map[string]map[int64][]string
+	var externalSubnets []externalSubnetUsage
 
 	err = n.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		// Get all managed networks across all projects.
@@ -2511,6 +2512,11 @@ func (n *bridge) getExternalSubnetInUse() ([]externalSubnetUsage, error) {
 		projectNetworksForwardsOnUplink, err = tx.GetProjectNetworkForwardListenAddressesOnMember(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed loading network forward listen addresses: %w", err)
+		}
+
+		externalSubnets, err = n.common.getExternalSubnetInUse(ctx, tx, n.name, true)
+		if err != nil {
+			return fmt.Errorf("Failed getting external subnets in use: %w", err)
 		}
 
 		return nil
@@ -2534,7 +2540,6 @@ func (n *bridge) getExternalSubnetInUse() ([]externalSubnetUsage, error) {
 		return nil, err
 	}
 
-	externalSubnets := make([]externalSubnetUsage, 0, len(bridgeNetworkExternalSubnets)+len(bridgedNICExternalRoutes))
 	externalSubnets = append(externalSubnets, bridgeNetworkExternalSubnets...)
 	externalSubnets = append(externalSubnets, bridgedNICExternalRoutes...)
 

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -484,7 +484,7 @@ func (n *ovn) Validate(config map[string]string) error {
 				if SubnetContains(&externalSubnetUser.subnet, externalSubnet) || SubnetContains(externalSubnet, &externalSubnetUser.subnet) {
 					// This error is purposefully vague so that it doesn't reveal any names of
 					// resources potentially outside of the network's project.
-					return fmt.Errorf("External subnet %q overlaps with another OVN network or NIC", externalSubnet.String())
+					return fmt.Errorf("External subnet %q overlaps with another network or NIC", externalSubnet.String())
 				}
 			}
 		}
@@ -3211,7 +3211,7 @@ func (n *ovn) InstanceDevicePortValidateExternalRoutes(deviceInstance instance.I
 			if SubnetContains(&externalSubnetUser.subnet, portExternalRoute) || SubnetContains(portExternalRoute, &externalSubnetUser.subnet) {
 				// This error is purposefully vague so that it doesn't reveal any names of
 				// resources potentially outside of the network's project.
-				return fmt.Errorf("External subnet %q overlaps with another OVN network or NIC", portExternalRoute.String())
+				return fmt.Errorf("External subnet %q overlaps with another network or NIC", portExternalRoute.String())
 			}
 		}
 	}
@@ -4362,7 +4362,7 @@ func (n *ovn) ForwardCreate(forward api.NetworkForwardsPost, clientType request.
 			if SubnetContains(&externalSubnetUser.subnet, listenAddressNet) || SubnetContains(listenAddressNet, &externalSubnetUser.subnet) {
 				// This error is purposefully vague so that it doesn't reveal any names of
 				// resources potentially outside of the network's project.
-				return fmt.Errorf("Forward listen address %q overlaps with another OVN network or NIC", listenAddressNet.String())
+				return fmt.Errorf("Forward listen address %q overlaps with another network or NIC", listenAddressNet.String())
 			}
 		}
 
@@ -4673,7 +4673,7 @@ func (n *ovn) LoadBalancerCreate(loadBalancer api.NetworkLoadBalancersPost, clie
 			if SubnetContains(&externalSubnetUser.subnet, listenAddressNet) || SubnetContains(listenAddressNet, &externalSubnetUser.subnet) {
 				// This error is purposefully vague so that it doesn't reveal any names of
 				// resources potentially outside of the network's project.
-				return fmt.Errorf("Load balancer listen address %q overlaps with another OVN network or NIC", listenAddressNet.String())
+				return fmt.Errorf("Load balancer listen address %q overlaps with another network or NIC", listenAddressNet.String())
 			}
 		}
 


### PR DESCRIPTION
Something I noticed whilst advising @gabrielmougard on how to approach #11332

Detects network forward & load balancer listen address conflicts between OVN networks and those defined on a bridge uplink network.

E.g. this is now prevented:

```
lxc network forward create lxdbr0 10.0.0.1
lxc network forward create ovn1 10.0.0.1 # Where ovn1 network uses lxdbr0 for uplink.
Error: Failed creating forward: Forward listen address "10.0.0.1/32" overlaps with another network or NIC
```


Associated tests https://github.com/lxc/lxc-ci/pull/709
