### PR TITLE
Instance: Fix panic if metric collection occurs during stop operation

### DIFF
--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
+	instanceDrivers "github.com/lxc/lxd/lxd/instance/drivers"
 	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/metrics"
 	"github.com/lxc/lxd/lxd/response"
@@ -215,7 +217,10 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 				projectName := inst.Project().Name
 				instanceMetrics, err := inst.Metrics(hostInterfaces)
 				if err != nil {
-					logger.Warn("Failed getting instance metrics", logger.Ctx{"instance": inst.Name(), "project": projectName, "err": err})
+					// Ignore stopped instances.
+					if !errors.Is(err, instanceDrivers.ErrInstanceIsStopped) {
+						logger.Warn("Failed getting instance metrics", logger.Ctx{"instance": inst.Name(), "project": projectName, "err": err})
+					}
 				} else {
 					// Add the metrics.
 					newMetricsLock.Lock()
@@ -237,11 +242,6 @@ func metricsGet(d *Daemon, r *http.Request) response.Response {
 
 	// Fetch what's missing.
 	for _, inst := range instances {
-		// Ignore stopped instances.
-		if !inst.IsRunning() {
-			continue
-		}
-
 		wg.Add(1)
 		instMetricsCh <- inst
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6856,6 +6856,10 @@ func (d *lxc) cgroup(cc *liblxc.Container) (*cgroup.CGroup, error) {
 		rw.cc = d.c
 	}
 
+	if rw.cc == nil {
+		return nil, fmt.Errorf("Container not initialized for cgroup")
+	}
+
 	cg, err := cgroup.New(&rw)
 	if err != nil {
 		return nil, err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6923,6 +6923,10 @@ func (d *lxc) Info() instance.Info {
 func (d *lxc) Metrics(hostInterfaces []net.Interface) (*metrics.MetricSet, error) {
 	out := metrics.NewMetricSet(map[string]string{"project": d.project.Name, "name": d.name, "type": instancetype.Container.String()})
 
+	if !d.IsRunning() {
+		return nil, ErrInstanceIsStopped
+	}
+
 	// Load cgroup abstraction
 	cg, err := d.cgroup(nil)
 	if err != nil {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -4179,11 +4179,6 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 		}
 	}
 
-	cg, err := d.cgroup(nil)
-	if err != nil {
-		return err
-	}
-
 	// If raw.lxc changed, re-validate the config.
 	if shared.StringInSlice("raw.lxc", changedConfig) && d.expandedConfig["raw.lxc"] != "" {
 		// Get a new liblxc instance.
@@ -4274,6 +4269,11 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 
 	// Apply the live changes
 	if isRunning {
+		cg, err := d.cgroup(nil)
+		if err != nil {
+			return err
+		}
+
 		// Live update the container config
 		for _, key := range changedConfig {
 			value := d.expandedConfig[key]


### PR DESCRIPTION
The commit https://github.com/lxc/lxd/commit/ba24d18dcba4fca6f55f264ef5d9bf3fafd2e1be introduced an optimisation that avoided the need to initialize liblxc in order to ascertain the container's state during a running start/stop operation.

This aligned LXC driver behaviour with the QEMU driver, by inferring the instance's state by the presence of an ongoing operation.

Unfortunately this change has had the unintended consequence of causing panics in LXD when instance metrics are collected during an instance stop operation.

```
Feb 18 03:52:56 abydos lxd.daemon[1380579]: panic: runtime error: invalid memory address or nil pointer dereference
Feb 18 03:52:56 abydos lxd.daemon[1380579]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1222382]
Feb 18 03:52:56 abydos lxd.daemon[1380579]: goroutine 9333 [running]:
Feb 18 03:52:56 abydos lxd.daemon[1380579]: github.com/lxc/go-lxc.(*Container).CgroupItem(0xc00006b43a?, {0x1ce6733?, 0xc000b632a0?})
Feb 18 03:52:56 abydos lxd.daemon[1380579]:         /build/lxd/parts/lxd/src/.go/pkg/mod/github.com/lxc/go-lxc@v0.0.0-20220627182551-ad3d9f7cb822/container.go:1003 +0x42
Feb 18 03:52:56 abydos lxd.daemon[1380579]: github.com/lxc/lxd/lxd/instance/drivers.(*lxcCgroupReadWriter).Get(0x1a18840?, 0xc000337170?, {0x1cb354a?, 0x6?}, {0x1ce6733?, 0xc000cb0000?})
Feb 18 03:52:56 abydos lxd.daemon[1380579]:         /build/lxd/parts/lxd/src/lxd/instance/drivers/driver_lxc.go:6895 +0x112
Feb 18 03:52:56 abydos lxd.daemon[1380579]: github.com/lxc/lxd/lxd/cgroup.(*CGroup).GetMemoryLimit(0xc001051200)
Feb 18 03:52:56 abydos lxd.daemon[1380579]:         /build/lxd/parts/lxd/src/lxd/cgroup/abstraction.go:100 +0x1f2
Feb 18 03:52:56 abydos lxd.daemon[1380579]: github.com/lxc/lxd/lxd/cgroup.(*CGroup).GetEffectiveMemoryLimit(0xc000897380?)
Feb 18 03:52:56 abydos lxd.daemon[1380579]:         /build/lxd/parts/lxd/src/lxd/cgroup/abstraction.go:137 +0x8d
Feb 18 03:52:56 abydos lxd.daemon[1380579]: github.com/lxc/lxd/lxd/instance/drivers.(*lxc).Metrics(0xc000897380, {0xc0007f8000, 0x25, 0x40})
Feb 18 03:52:56 abydos lxd.daemon[1380579]:         /build/lxd/parts/lxd/src/lxd/instance/drivers/driver_lxc.go:6958 +0x26b
Feb 18 03:52:56 abydos lxd.daemon[1380579]: main.metricsGet.func4(0xc0003e61e0?)
Feb 18 03:52:56 abydos lxd.daemon[1380579]:         /build/lxd/parts/lxd/src/lxd/api_metrics.go:216 +0x1a2
Feb 18 03:52:56 abydos lxd.daemon[1380579]: created by main.metricsGet
Feb 18 03:52:56 abydos lxd.daemon[1380579]:         /build/lxd/parts/lxd/src/lxd/api_metrics.go:213 +0x7fe
Feb 18 03:52:56 abydos lxd.daemon[1380393]: => LXD failed with return code 2
```

This is because the `metricsGet` was calling the instance's `IsRunning()` function and if the instance was considered running then it was calling the instance's `Metrics()` function. However the `Metrics()` function expected that the internal liblxc reference was still initialised from the call to `IsRunning()`, but the recent change meant that during a stop operation there was no need to initialise the liblxc reference.

This PR fixes the issue by correctly checking that the liblxc reference is initialised before trying to access cgroup metrics.
