### PR TITLE
Instance: Add support for VM generation ID

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
 	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/lxd/backup"
@@ -787,6 +788,12 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 	if err != nil {
 		return err
 	}
+
+	// Generate a new UUID for the instance doing a backup.
+	// We will later use this new instance UUID as a VM Generation ID
+	// in order to differentiate the two instances before and after snapshot
+	// restore that changes that instance's place in time (moving it backwards)
+	instDBArgs.Config["volatile.uuid"] = uuid.New()
 
 	_, instOp, cleanup, err := instance.CreateInternal(s, *instDBArgs, true)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1238,6 +1238,7 @@ func (d *qemu) Start(stateful bool) error {
 		"-name", d.Name(),
 		"-uuid", instUUID,
 		"-daemonize",
+		"-device", fmt.Sprintf("vmgenid,guid=%s", instUUID),
 		"-cpu", cpuType,
 		"-nographic",
 		"-serial", "chardev:console",

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
@@ -201,6 +202,12 @@ func instanceSnapRestore(s *state.State, projectName string, name string, snap s
 			return err
 		}
 	}
+
+	// Generate a new UUID for the instance when restoring it.
+	// We will later use this new instance UUID as a VM Generation ID
+	// in order to differentiate the two instances before and after snapshot
+	// restore that changes that instance's place in time (moving it backwards).
+	source.LocalConfig()["volatile.uuid"] = uuid.New()
 
 	err = inst.Restore(source, stateful)
 	if err != nil {

--- a/test/main.sh
+++ b/test/main.sh
@@ -328,6 +328,7 @@ if [ "${1:-"all"}" != "cluster" ]; then
     run_test test_backup_rename "backup rename"
     run_test test_backup_volume_export "backup volume export"
     run_test test_backup_volume_rename_delete "backup volume rename and delete"
+    run_test test_backup_different_instance_uuid "backup instance and check instance UUIDs"
     run_test test_container_local_cross_pool_handling "container local cross pool handling"
     run_test test_incremental_copy "incremental container copy"
     run_test test_profiles_project_default "profiles in default project"


### PR DESCRIPTION
This PR causes an instance's `volatile.uuid` key to be regenerated upon snapshot restore and backup import.
The `volatile.uuid` key is then used for VM instances as its generation ID.

In this way the VM's generation ID will change whenever the VM's place in time moves backwards.
This allows for the VM guest OS to reinitialize any state it needs to avoid duplicating potential state that has already occurred.