### PR TITLE
Scriptlet: Fixes unpredictable ordering of Starlark dict keys

### DIFF
--- a/doc/explanation/clustering.md
+++ b/doc/explanation/clustering.md
@@ -187,7 +187,7 @@ def instance_placement(request, candidate_members):
         # Example of logging an error, this will appear in LXD's log.
         log_error("Invalid name supplied: ", request.name)
 
-        return "Invalid name" # Return an error to reject instance placement.
+        fail("Invalid name") # Exit with an error to reject instance placement.
 
     # Place the instance on the first candidate server provided.
     set_target(candidate_members[0].server_name)

--- a/lxd/scriptlet/starlark.go
+++ b/lxd/scriptlet/starlark.go
@@ -111,11 +111,8 @@ func starlarkMarshal(input any, parent *starlark.Dict) (starlark.Value, error) {
 		mKeys := v.MapKeys()
 		d := starlark.NewDict(len(mKeys))
 
-		for _, k := range mKeys {
-			kind := k.Kind()
-			if kind != reflect.String {
-				return nil, fmt.Errorf("Only string keys are supported, found %s", kind)
-			}
+		if v.Type().Key().Kind() != reflect.String {
+			return nil, fmt.Errorf("Only string keys are supported, found %s", v.Type().Key().Kind())
 		}
 
 		sort.Slice(mKeys, func(i, j int) bool {

--- a/lxd/scriptlet/starlark.go
+++ b/lxd/scriptlet/starlark.go
@@ -119,7 +119,7 @@ func starlarkMarshal(input any, parent *starlark.Dict) (starlark.Value, error) {
 			return mKeys[i].String() < mKeys[j].String()
 		})
 
-		for _, k := range v.MapKeys() {
+		for _, k := range mKeys {
 			mv := v.MapIndex(k)
 			dv, err := StarlarkMarshal(mv.Interface())
 			if err != nil {


### PR DESCRIPTION
Fixes unpredictable ordering of Starlark dict keys.

https://jenkins.linuxcontainers.org/job/lxd-github-pull-test/8930/arch=arm64,backend=dir,compiler=golang-tip,section=standalone/console#console-section-3

