### PR TITLE
Add missing docs about txqueuelen

### DIFF
--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -42,3 +42,5 @@ Complete the following steps to increase the network bandwidth on the LXD host:
 ## Increase the transmit queue length on the instances
 
 You must also change the `txqueuelen` value for all Ethernet interfaces in your instances, in the same way as described for the LXD host.
+
+Since LXD version 5.10 you can set the `queue.tx.length` value on the profile for network devices.

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -43,4 +43,4 @@ Complete the following steps to increase the network bandwidth on the LXD host:
 
 You must also change the `txqueuelen` value for all Ethernet interfaces in your instances, in the same way as described for the LXD host.
 
-Since LXD version 5.10 you can set the `queue.tx.length` property the network device or configure this value via a profile.
+Since LXD version 5.10 you can set the `queue.tx.length` property of the network device or configure this value via a profile.

--- a/doc/howto/network_increase_bandwidth.md
+++ b/doc/howto/network_increase_bandwidth.md
@@ -43,4 +43,4 @@ Complete the following steps to increase the network bandwidth on the LXD host:
 
 You must also change the `txqueuelen` value for all Ethernet interfaces in your instances, in the same way as described for the LXD host.
 
-Since LXD version 5.10 you can set the `queue.tx.length` value on the profile for network devices.
+Since LXD version 5.10 you can set the `queue.tx.length` property the network device or configure this value via a profile.

--- a/doc/reference/network_bridge.md
+++ b/doc/reference/network_bridge.md
@@ -106,6 +106,7 @@ Key                                  | Type      | Condition             | Defau
 `ipv6.routing`                       | bool      | IPv6 address          | `true`                    | Whether to route traffic in and out of the bridge
 `maas.subnet.ipv4`                   | string    | IPv4 address          | -                         | MAAS IPv4 subnet to register instances in (when using `network` property on NIC)
 `maas.subnet.ipv6`                   | string    | IPv6 address          | -                         | MAAS IPv6 subnet to register instances in (when using `network` property on NIC)
+`queue.tx.length`                    | integer   | -                     | -                         | Sets the `txqueuelength` of the network device to the specified value.
 `raw.dnsmasq`                        | string    | -                     | -                         | Additional `dnsmasq` configuration to append to the configuration file
 `security.acls`                      | string    | -                     | -                         | Comma-separated list of Network ACLs to apply to NICs connected to this network (see {ref}`network-acls-bridge-limitations`)
 `security.acls.default.egress.action`| string    | `security.acls`       | `reject`                  | Action to use for egress traffic that doesn't match any ACL rule


### PR DESCRIPTION
feature added in #11243, which closes #11198 is not documented yet.

Updated `network_bridge.md`, not sure about the other `network_*.md` files. Do any of these need to be changed as well?