### PR TITLE
lxd/storage/drivers/zfs: don't force atime to on

### DIFF
--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -27,7 +27,6 @@ var zfsTrim bool
 var zfsRaw bool
 
 var zfsDefaultSettings = map[string]string{
-	"atime":      "off",
 	"relatime":   "on",
 	"mountpoint": "legacy",
 	"setuid":     "on",


### PR DESCRIPTION
zfs defaults to using `atime=on` and `relatime=off` and man 7 zfsprops:

> relatime=on|off
>   Controls the manner in which the access time is updated when atime=on is set.

To align with other FSes, we want `relatime=on`. By not forcing `atime` to on, we
get the `relatime` behavior and we also allow an admin to disable the feature by
setting `atime=off` on the dataset itself or on a parent.

This also fixes commit d3e3b3df775f989a6f