### PR TITLE
Network: Update ip.Link to support applying settings atomically when adding interfaces

### DIFF
--- a/lxd-agent/network.go
+++ b/lxd-agent/network.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"encoding/json"
-	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -120,7 +119,7 @@ func reconfigureNetworkInterfaces() {
 
 		link := ip.Link{
 			Name: currentNIC.Name,
-			MTU:  fmt.Sprintf("%d", currentNIC.MTU),
+			MTU:  uint32(currentNIC.MTU),
 		}
 
 		err := link.SetDown()
@@ -153,23 +152,21 @@ func reconfigureNetworkInterfaces() {
 
 		// Apply the MTU from the NIC config if needed.
 		if changeMTU {
-			newMTU := fmt.Sprintf("%d", nic.MTU)
-			err = link.SetMTU(newMTU)
+			err = link.SetMTU(nic.MTU)
 			if err != nil {
 				return err
 			}
 
+			link.MTU = nic.MTU
+
 			revert.Add(func() {
-				currentMTU := fmt.Sprintf("%d", currentNIC.MTU)
-				err := link.SetMTU(currentMTU)
+				err := link.SetMTU(uint32(currentNIC.MTU))
 				if err != nil {
 					return
 				}
 
-				link.MTU = currentMTU
+				link.MTU = uint32(currentNIC.MTU)
 			})
-
-			link.MTU = newMTU
 		}
 
 		err = link.SetUp()

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -42,7 +42,7 @@ func NetworkSetDevMTU(devName string, mtu uint32) error {
 	// Only try and change the MTU if the requested mac is different to current one.
 	if curMTU != mtu {
 		link := &ip.Link{Name: devName}
-		err := link.SetMTU(fmt.Sprintf("%d", mtu))
+		err := link.SetMTU(mtu)
 		if err != nil {
 			return err
 		}

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -70,8 +70,13 @@ func NetworkSetDevMAC(devName string, mac string) error {
 
 	// Only try and change the MAC if the requested mac is different to current one.
 	if curMac != mac {
+		hwaddr, err := net.ParseMAC(mac)
+		if err != nil {
+			return fmt.Errorf("Failed parsing MAC address %q: %w", mac, err)
+		}
+
 		link := &ip.Link{Name: devName}
-		err := link.SetAddress(mac)
+		err = link.SetAddress(hwaddr)
 		if err != nil {
 			return err
 		}
@@ -881,8 +886,13 @@ func networkSRIOVRestoreVF(d deviceCommon, useSpoofCheck bool, volatile map[stri
 func networkSRIOVSetupContainerVFNIC(hostName string, config map[string]string) error {
 	// Set the MAC address.
 	if config["hwaddr"] != "" {
+		hwaddr, err := net.ParseMAC(config["hwaddr"])
+		if err != nil {
+			return fmt.Errorf("Failed parsing MAC address %q: %w", config["hwaddr"], err)
+		}
+
 		link := &ip.Link{Name: hostName}
-		err := link.SetAddress(config["hwaddr"])
+		err = link.SetAddress(hwaddr)
 		if err != nil {
 			return fmt.Errorf("Failed setting MAC address %q on %q: %w", config["hwaddr"], hostName, err)
 		}
@@ -931,8 +941,13 @@ func networkSRIOVSetupContainerVFNIC(hostName string, config map[string]string) 
 			return fmt.Errorf("Failed generating random MAC for VF %q: %w", hostName, err)
 		}
 
+		hwaddr, err := net.ParseMAC(randMAC)
+		if err != nil {
+			return fmt.Errorf("Failed parsing MAC address %q: %w", randMAC, err)
+		}
+
 		link := &ip.Link{Name: hostName}
-		err = link.SetAddress(randMAC)
+		err = link.SetAddress(hwaddr)
 		if err != nil {
 			return fmt.Errorf("Failed to set random MAC address %q on %q: %w", randMAC, hostName, err)
 		}

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -891,8 +891,13 @@ func networkSRIOVSetupContainerVFNIC(hostName string, config map[string]string) 
 
 	// Set the MTU.
 	if config["mtu"] != "" {
+		mtu, err := strconv.ParseUint(config["mtu"], 10, 32)
+		if err != nil {
+			return fmt.Errorf("Invalid VF MTU specified %q: %w", config["mtu"], err)
+		}
+
 		link := &ip.Link{Name: hostName}
-		err := link.SetMTU(config["mtu"])
+		err = link.SetMTU(uint32(mtu))
 		if err != nil {
 			return fmt.Errorf("Failed setting MTU %q on %q: %w", config["mtu"], hostName, err)
 		}

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -206,96 +206,72 @@ func networkRestorePhysicalNIC(hostName string, volatile map[string]string) erro
 // is supplied in config, then the MTU of the new peer interface will inherit the parent MTU.
 // Accepts the name of the host side interface as a parameter and returns the peer interface name and MTU used.
 func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, uint32, error) {
-	peerName := network.RandomDevName("veth")
+	var err error
 
 	veth := &ip.Veth{
 		Link: ip.Link{
 			Name: hostName,
+			Up:   true,
 		},
-		PeerName: peerName,
+		Peer: ip.Link{
+			Name: network.RandomDevName("veth"),
+		},
 	}
 
-	err := veth.Add()
-	if err != nil {
-		return "", 0, fmt.Errorf("Failed to create the veth interfaces %q and %q: %w", hostName, peerName, err)
-	}
-
-	err = veth.SetUp()
-	if err != nil {
-		_ = network.InterfaceRemove(hostName)
-		return "", 0, fmt.Errorf("Failed to bring up the veth interface %q: %w", hostName, err)
-	}
-
-	// Set the MAC address on peer.
-	if m["hwaddr"] != "" {
-		link := &ip.Link{Name: peerName}
-		err := link.SetAddress(m["hwaddr"])
-		if err != nil {
-			_ = network.InterfaceRemove(peerName)
-			return "", 0, fmt.Errorf("Failed to set the MAC address: %w", err)
-		}
-	}
-
-	// Set the MTU on peer. If not specified and has parent, will inherit MTU from parent.
-	var mtu uint32
+	// Set the MTU on both ends. If not specified and has parent, will inherit MTU from parent.
 	if m["mtu"] != "" {
-		nicMTU, err := strconv.ParseUint(m["mtu"], 10, 32)
+		mtu, err := strconv.ParseUint(m["mtu"], 10, 32)
 		if err != nil {
 			return "", 0, fmt.Errorf("Invalid MTU specified: %w", err)
 		}
 
-		mtu = uint32(nicMTU)
+		veth.MTU = uint32(mtu)
 	} else if m["parent"] != "" {
-		mtu, err = network.GetDevMTU(m["parent"])
+		mtu, err := network.GetDevMTU(m["parent"])
 		if err != nil {
 			return "", 0, fmt.Errorf("Failed to get the parent MTU: %w", err)
 		}
+
+		veth.MTU = mtu
 	}
 
-	if mtu > 0 {
-		err = NetworkSetDevMTU(peerName, mtu)
+	veth.Peer.MTU = veth.MTU
+
+	// Set the MAC address on peer.
+	if m["hwaddr"] != "" {
+		hwaddr, err := net.ParseMAC(m["hwaddr"])
 		if err != nil {
-			_ = network.InterfaceRemove(peerName)
-			return "", 0, fmt.Errorf("Failed to set the MTU %d: %w", mtu, err)
+			return "", 0, fmt.Errorf("Failed parsing MAC address %q: %w", m["hwaddr"], err)
 		}
 
-		err = NetworkSetDevMTU(hostName, mtu)
-		if err != nil {
-			_ = network.InterfaceRemove(peerName)
-			return "", 0, fmt.Errorf("Failed to set the MTU %d: %w", mtu, err)
-		}
+		veth.Peer.Address = hwaddr
 	}
 
-	var txqlen uint32
+	// Set TX queue length on both ends.
 	if m["queue.tx.length"] != "" {
 		nicTXqlen, err := strconv.ParseUint(m["queue.tx.length"], 10, 32)
 		if err != nil {
 			return "", 0, fmt.Errorf("Invalid txqueuelen specified: %w", err)
 		}
 
-		txqlen = uint32(nicTXqlen)
+		veth.TXQueueLength = uint32(nicTXqlen)
 	} else if m["parent"] != "" {
-		txqlen, err = network.GetTXQueueLength(m["parent"])
+		veth.TXQueueLength, err = network.GetTXQueueLength(m["parent"])
 		if err != nil {
 			return "", 0, fmt.Errorf("Failed to get the parent txqueuelen: %w", err)
 		}
 	}
 
-	if txqlen != 0 {
-		link := &ip.Link{Name: peerName}
-		err = link.SetTXQueueLength(txqlen)
-		if err != nil {
-			return "", 0, fmt.Errorf("Failed to set the SetTXQueueLength %d: %w", txqlen, err)
-		}
+	veth.Peer.TXQueueLength = veth.TXQueueLength
 
-		link = &ip.Link{Name: hostName}
-		err = link.SetTXQueueLength(txqlen)
-		if err != nil {
-			return "", 0, fmt.Errorf("Failed to set the SetTXQueueLength %d: %w", txqlen, err)
-		}
+	// Add and configure the interface in one operation to reduce the number of executions and to avoid
+	// systemd-udevd from applying the default MACAddressPolicy=persistent policy.
+	err = veth.Add()
+	if err != nil {
+		return "", 0, fmt.Errorf("Failed to create the veth interfaces %q and %q: %w", hostName, veth.Peer.Name, err)
 	}
 
-	return peerName, mtu, nil
+	return veth.Peer.Name, veth.MTU, nil
 }
 
 // networkCreateTap creates and configures a TAP device.

--- a/lxd/device/infiniband_physical.go
+++ b/lxd/device/infiniband_physical.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"strconv"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	pcidev "github.com/lxc/lxd/lxd/device/pci"
@@ -110,8 +111,13 @@ func (d *infinibandPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 		// Set the MTU.
 		if d.config["mtu"] != "" {
+			mtu, err := strconv.ParseUint(d.config["mtu"], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid MTU specified %q: %w", d.config["mtu"], err)
+			}
+
 			link := &ip.Link{Name: saveData["host_name"]}
-			err := link.SetMTU(d.config["mtu"])
+			err = link.SetMTU(uint32(mtu))
 			if err != nil {
 				return nil, fmt.Errorf("Failed setting MTU %q on %q: %w", d.config["mtu"], saveData["host_name"], err)
 			}

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -118,8 +118,13 @@ func (d *infinibandSRIOV) startContainer() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
+		mtu, err := strconv.ParseUint(d.config["mtu"], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid MTU specified %q: %w", d.config["mtu"], err)
+		}
+
 		link := &ip.Link{Name: saveData["host_name"]}
-		err := link.SetMTU(d.config["mtu"])
+		err = link.SetMTU(uint32(mtu))
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting MTU %q on %q: %w", d.config["mtu"], saveData["host_name"], err)
 		}

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance"
@@ -232,8 +233,13 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	// Set the MTU.
 	if d.config["mtu"] != "" {
+		mtu, err := strconv.ParseUint(d.config["mtu"], 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid MTU specified %q: %w", d.config["mtu"], err)
+		}
+
 		link := &ip.Link{Name: saveData["host_name"]}
-		err := link.SetMTU(d.config["mtu"])
+		err = link.SetMTU(uint32(mtu))
 		if err != nil {
 			return nil, fmt.Errorf("Failed setting MTU %q on %q: %w", d.config["mtu"], saveData["host_name"], err)
 		}

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"net"
 	"strconv"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
@@ -172,8 +173,13 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 		// Set the MAC address.
 		if d.config["hwaddr"] != "" {
+			hwaddr, err := net.ParseMAC(d.config["hwaddr"])
+			if err != nil {
+				return nil, fmt.Errorf("Failed parsing MAC address %q: %w", d.config["hwaddr"], err)
+			}
+
 			link := &ip.Link{Name: saveData["host_name"]}
-			err := link.SetAddress(d.config["hwaddr"])
+			err = link.SetAddress(hwaddr)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to set the MAC address: %s", err)
 			}

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -2,6 +2,7 @@ package device
 
 import (
 	"fmt"
+	"strconv"
 
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	pcidev "github.com/lxc/lxd/lxd/device/pci"
@@ -180,8 +181,13 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 		// Set the MTU.
 		if d.config["mtu"] != "" {
+			mtu, err := strconv.ParseUint(d.config["mtu"], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("Invalid MTU specified %q: %w", d.config["mtu"], err)
+			}
+
 			link := &ip.Link{Name: saveData["host_name"]}
-			err := link.SetMTU(d.config["mtu"])
+			err = link.SetMTU(uint32(mtu))
 			if err != nil {
 				return nil, fmt.Errorf("Failed setting MTU %q on %q: %w", d.config["mtu"], saveData["host_name"], err)
 			}

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -119,8 +119,8 @@ func (l *Link) SetTXQueueLength(queueLength uint32) error {
 }
 
 // SetAddress sets the address of the link device.
-func (l *Link) SetAddress(address string) error {
-	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "address", address)
+func (l *Link) SetAddress(address net.HardwareAddr) error {
+	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "address", address.String())
 	if err != nil {
 		return err
 	}

--- a/lxd/ip/link.go
+++ b/lxd/ip/link.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"os/exec"
 	"regexp"
 	"strconv"
@@ -14,34 +15,64 @@ import (
 
 // Link represents base arguments for link device.
 type Link struct {
-	Name   string
-	MTU    string
-	Parent string
+	Name          string
+	MTU           uint32
+	Parent        string
+	Address       net.HardwareAddr
+	TXQueueLength uint32
+	AllMutlicast  bool
+	Master        string
+	Up            bool
 }
 
 // args generate common arguments for the virtual link.
-func (l *Link) args(linkType string) []string {
+func (l *Link) args() []string {
 	var result []string
+
+	if l.Name != "" {
+		result = append(result, "name", l.Name)
+	}
+
 	if l.Parent != "" {
 		result = append(result, "link", l.Parent)
 	}
 
-	if l.MTU != "" {
-		result = append(result, "mtu", l.MTU)
+	if l.MTU > 0 {
+		result = append(result, "mtu", fmt.Sprintf("%d", l.MTU))
 	}
 
-	result = append(result, "type", linkType)
+	if l.Address != nil {
+		result = append(result, "address", l.Address.String())
+	}
+
+	if l.TXQueueLength > 0 {
+		result = append(result, "txqueuelen", fmt.Sprintf("%d", l.TXQueueLength))
+	}
+
+	if l.AllMutlicast {
+		result = append(result, "allmulticast", "on")
+	}
+
+	if l.Master != "" {
+		result = append(result, "master", l.Master)
+	}
+
+	if l.Up {
+		result = append(result, "up")
+	}
+
 	return result
 }
 
 // add adds new virtual link.
 func (l *Link) add(linkType string, additionalArgs []string) error {
-	cmd := []string{"link", "add", l.Name}
-	cmd = append(cmd, l.args(linkType)...)
+	cmd := append([]string{"link", "add"}, l.args()...)
+	cmd = append(cmd, "type", linkType)
 	cmd = append(cmd, additionalArgs...)
+
 	_, err := shared.RunCommand("ip", cmd...)
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed adding link: %w", err)
 	}
 
 	return nil
@@ -68,8 +99,8 @@ func (l *Link) SetDown() error {
 }
 
 // SetMTU sets the MTU of the link device.
-func (l *Link) SetMTU(mtu string) error {
-	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "mtu", mtu)
+func (l *Link) SetMTU(mtu uint32) error {
+	_, err := shared.RunCommand("ip", "link", "set", "dev", l.Name, "mtu", fmt.Sprintf("%d", mtu))
 	if err != nil {
 		return err
 	}

--- a/lxd/ip/link_veth.go
+++ b/lxd/ip/link_veth.go
@@ -3,20 +3,10 @@ package ip
 // Veth represents arguments for link of type veth.
 type Veth struct {
 	Link
-	PeerName string
-}
-
-// additionalArgs generates veth specific arguments.
-func (veth *Veth) additionalArgs() []string {
-	args := []string{}
-	if veth.PeerName != "" {
-		args = append(args, "peer", "name", veth.PeerName)
-	}
-
-	return args
+	Peer Link
 }
 
 // Add adds new virtual link.
 func (veth *Veth) Add() error {
-	return veth.Link.add("veth", veth.additionalArgs())
+	return veth.Link.add("veth", append([]string{"peer"}, veth.Peer.args()...))
 }

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -711,7 +711,7 @@ func (n *bridge) setup(oldConfig map[string]string) error {
 
 		// Set the MAC address on the bridge interface if specified.
 		if bridge.Address != nil {
-			err = bridge.SetAddress(bridge.Address.String())
+			err = bridge.SetAddress(bridge.Address)
 			if err != nil {
 				return err
 			}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1208,14 +1208,19 @@ func (n *ovn) startUplinkPortBridgeNative(uplinkNet Network, bridgeDevice string
 	}
 
 	if uplinkNetMTU != "" {
+		mtu, err := strconv.ParseUint(uplinkNetMTU, 10, 32)
+		if err != nil {
+			return fmt.Errorf("Invalid uplink MTU %q: %w", uplinkNetMTU, err)
+		}
+
 		uplinkEndLink := &ip.Link{Name: vars.uplinkEnd}
-		err := uplinkEndLink.SetMTU(uplinkNetMTU)
+		err = uplinkEndLink.SetMTU(uint32(mtu))
 		if err != nil {
 			return fmt.Errorf("Failed setting MTU %q on %q: %w", uplinkNetMTU, uplinkEndLink.Name, err)
 		}
 
 		ovsEndLink := &ip.Link{Name: vars.ovsEnd}
-		err = ovsEndLink.SetMTU(uplinkNetMTU)
+		err = ovsEndLink.SetMTU(uint32(mtu))
 		if err != nil {
 			return fmt.Errorf("Failed setting MTU %q on %q: %w", uplinkNetMTU, ovsEndLink.Name, err)
 		}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1263,7 +1263,7 @@ func (n *ovn) startUplinkPortBridgeNative(uplinkNet Network, bridgeDevice string
 
 	// Create uplink OVS bridge if needed.
 	ovs := openvswitch.NewOVS()
-	err = ovs.BridgeAdd(vars.ovsBridge, true)
+	err = ovs.BridgeAdd(vars.ovsBridge, true, nil, 0)
 	if err != nil {
 		return fmt.Errorf("Failed to create uplink OVS bridge %q: %w", vars.ovsBridge, err)
 	}
@@ -1386,7 +1386,7 @@ func (n *ovn) startUplinkPortPhysical(uplinkNet Network) error {
 	}
 
 	// Create uplink OVS bridge if needed.
-	err = ovs.BridgeAdd(vars.ovsBridge, true)
+	err = ovs.BridgeAdd(vars.ovsBridge, true, nil, 0)
 	if err != nil {
 		return fmt.Errorf("Failed to create uplink OVS bridge %q: %w", vars.ovsBridge, err)
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -1187,7 +1187,9 @@ func (n *ovn) startUplinkPortBridgeNative(uplinkNet Network, bridgeDevice string
 			Link: ip.Link{
 				Name: vars.uplinkEnd,
 			},
-			PeerName: vars.ovsEnd,
+			Peer: ip.Link{
+				Name: vars.ovsEnd,
+			},
 		}
 
 		err := veth.Add()

--- a/lxd/network/openvswitch/ovs.go
+++ b/lxd/network/openvswitch/ovs.go
@@ -62,7 +62,7 @@ func (o *OVS) BridgeExists(bridgeName string) (bool, error) {
 }
 
 // BridgeAdd adds an OVS bridge.
-func (o *OVS) BridgeAdd(bridgeName string, mayExist bool) error {
+func (o *OVS) BridgeAdd(bridgeName string, mayExist bool, hwaddr net.HardwareAddr, mtu uint32) error {
 	args := []string{}
 
 	if mayExist {
@@ -70,6 +70,14 @@ func (o *OVS) BridgeAdd(bridgeName string, mayExist bool) error {
 	}
 
 	args = append(args, "add-br", bridgeName)
+
+	if hwaddr != nil {
+		args = append(args, "--", "set", "bridge", bridgeName, fmt.Sprintf(`other-config:hwaddr="%s"`, hwaddr.String()))
+	}
+
+	if mtu > 0 {
+		args = append(args, "--", "set", "int", bridgeName, fmt.Sprintf(`mtu_request=%d`, mtu))
+	}
 
 	_, err := shared.RunCommand("ovs-vsctl", args...)
 	if err != nil {


### PR DESCRIPTION
Hopefully fixes https://bugs.launchpad.net/lxd/+bug/1991552

I suspect the problem is the change to systemd-networkd that adds a default link policy of:

`MACAddressPolicy=persistent`

Which would apply to new veth interfaces created.

See:

https://bugzilla.suse.com/show_bug.cgi?id=1136600
https://github.com/systemd/systemd/issues/25555
https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/merge_requests/15#note_162509
https://github.com/moby/libnetwork/pull/2380

Specifically the last one was key:

> We set the address before udev gets to the networking rules, so udev
sees /sys/devices/virtual/net/docker0/addr_assign_type = 3
(NET_ADDR_SET). This means there's no need to assign a different
address and everything is fine.

This got me thinking that if we can set the MAC address at the same time the interface is created (in one operation) then this might prevent systemd-udevd from thinking it needs to generate and apply a persistent MAC address.

This PR updates LXD's use of `ip link add` command to apply the MAC, MTU, and other settings directly in a single execution rather than calling `ip link add` first to create the veth pairs, and then subsequently calling `ip link set` afterwards.

Hopefully this should be sufficient to ensure that systemd-udevd always sees the veth interfaces created by LXD as having a manually set MAC address and will leave them alone.

This change applies to:

* veth
* macvlan/macvtap

Also updated the `bridge` network driver to perform the same type of initialization for its bridge interface to avoid similar races.