### PR TITLE
Gofmt/swagger compatibility for go version > 1.18

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -26,41 +26,41 @@ import (
 
 // swagger:operation GET / server api_get
 //
-// Get the supported API endpoints
+//	Get the supported API endpoints
 //
-// Returns a list of supported API versions (URLs).
+//	Returns a list of supported API versions (URLs).
 //
-// Internal API endpoints are not reported as those aren't versioned and
-// should only be used by LXD itself.
+//	Internal API endpoints are not reported as those aren't versioned and
+//	should only be used by LXD itself.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: ["/1.0"]
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of endpoints
+//	          items:
+//	            type: string
+//	          example: ["/1.0"]
 func restServer(d *Daemon) *http.Server {
 	/* Setup the web server */
 	mux := mux.NewRouter()

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -121,84 +121,84 @@ var api10 = []APIEndpoint{
 
 // swagger:operation GET /1.0?public server server_get_untrusted
 //
-// Get the server environment
+//  Get the server environment
 //
-// Shows a small subset of the server environment and configuration
-// which is required by untrusted clients to reach a server.
+//  Shows a small subset of the server environment and configuration
+//  which is required by untrusted clients to reach a server.
 //
-// The `?public` part of the URL isn't required, it's simply used to
-// separate the two behaviors of this endpoint.
+//  The `?public` part of the URL isn't required, it's simply used to
+//  separate the two behaviors of this endpoint.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Server environment and configuration
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ServerUntrusted"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  responses:
+//    "200":
+//      description: Server environment and configuration
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            $ref: "#/definitions/ServerUntrusted"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0 server server_get
 //
-// Get the server environment and configuration
+//	Get the server environment and configuration
 //
-// Shows the full server environment and configuration.
+//	Shows the full server environment and configuration.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Server environment and configuration
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Server"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Server environment and configuration
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Server"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func api10Get(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -373,38 +373,38 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0 server server_put
 //
-// Update the server configuration
+//	Update the server configuration
 //
-// Updates the entire server configuration.
+//	Updates the entire server configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: server
-//     description: Server configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ServerPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: server
+//	    description: Server configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ServerPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func api10Put(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -472,38 +472,38 @@ func api10Put(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0 server server_patch
 //
-// Partially update the server configuration
+//	Partially update the server configuration
 //
-// Updates a subset of the server configuration.
+//	Updates a subset of the server configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: server
-//     description: Server configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ServerPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: server
+//	    description: Server configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ServerPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func api10Patch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -134,38 +134,38 @@ var internalClusterRaftNodeCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/cluster cluster cluster_get
 //
-// Get the cluster configuration
+//	Get the cluster configuration
 //
-// Gets the current cluster configuration.
+//	Gets the current cluster configuration.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Cluster configuration
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Cluster"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Cluster configuration
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Cluster"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 	serverName := s.ServerName
@@ -265,33 +265,33 @@ func clusterGetMemberConfig(cluster *db.Cluster) ([]api.ClusterMemberConfigKey, 
 
 // swagger:operation PUT /1.0/cluster cluster cluster_put
 //
-// Update the cluster configuration
+//	Update the cluster configuration
 //
-// Updates the entire cluster configuration.
+//	Updates the entire cluster configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterPut(d *Daemon, r *http.Request) response.Response {
 	req := api.ClusterPut{}
 
@@ -1048,84 +1048,84 @@ func clusterAcceptMember(client lxd.InstanceServer, name string, address string,
 
 // swagger:operation GET /1.0/cluster/members cluster cluster_members_get
 //
-// Get the cluster members
+//  Get the cluster members
 //
-// Returns a list of cluster members (URLs).
+//  Returns a list of cluster members (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/cluster/members/lxd01",
-//               "/1.0/cluster/members/lxd02"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/cluster/members/lxd01",
+//                "/1.0/cluster/members/lxd02"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/cluster/members?recursion=1 cluster cluster_members_get_recursion1
 //
-// Get the cluster members
+//	Get the cluster members
 //
-// Returns a list of cluster members (structs).
+//	Returns a list of cluster members (structs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of cluster members
-//           items:
-//             $ref: "#/definitions/ClusterMember"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of cluster members
+//	          items:
+//	            $ref: "#/definitions/ClusterMember"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodesGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 	s := d.State()
@@ -1215,31 +1215,31 @@ var clusterNodesPostMu sync.Mutex // Used to prevent races when creating cluster
 
 // swagger:operation POST /1.0/cluster/members cluster cluster_members_post
 //
-// Request a join token
+//	Request a join token
 //
-// Requests a join token to add a cluster member.
+//	Requests a join token to add a cluster member.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster member add request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterMembersPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster member add request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterMembersPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1368,38 +1368,38 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/cluster/members/{name} cluster cluster_member_get
 //
-// Get the cluster member
+//	Get the cluster member
 //
-// Gets a specific cluster member.
+//	Gets a specific cluster member.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Cluster member
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ClusterMember"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Cluster member
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ClusterMember"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodeGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1473,66 +1473,66 @@ func clusterNodeGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/cluster/members/{name} cluster cluster_member_patch
 //
-// Partially update the cluster member
+//	Partially update the cluster member
 //
-// Updates a subset of the cluster member configuration.
+//	Updates a subset of the cluster member configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster member configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterMemberPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster member configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterMemberPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodePatch(d *Daemon, r *http.Request) response.Response {
 	return updateClusterNode(d, r, true)
 }
 
 // swagger:operation PUT /1.0/cluster/members/{name} cluster cluster_member_put
 //
-// Update the cluster member
+//	Update the cluster member
 //
-// Updates the entire cluster member configuration.
+//	Updates the entire cluster member configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster member configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterMemberPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster member configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterMemberPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodePut(d *Daemon, r *http.Request) response.Response {
 	return updateClusterNode(d, r, false)
 }
@@ -1771,31 +1771,31 @@ func clusterValidateConfig(config map[string]string) error {
 
 // swagger:operation POST /1.0/cluster/members/{name} cluster cluster_member_post
 //
-// Rename the cluster member
+//	Rename the cluster member
 //
-// Renames an existing cluster member.
+//	Renames an existing cluster member.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster member rename request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterMemberPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster member rename request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterMemberPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodePost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1827,22 +1827,22 @@ func clusterNodePost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/cluster/members/{name} cluster cluster_member_delete
 //
-// Delete the cluster member
+//	Delete the cluster member
 //
-// Removes the member from the cluster.
+//	Removes the member from the cluster.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -2085,32 +2085,32 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/cluster/certificate cluster clustering_update_cert
 //
-// Update the certificate for the cluster
+//	Update the certificate for the cluster
 //
-// Replaces existing cluster certificate and reloads LXD on each cluster
-// member.
+//	Replaces existing cluster certificate and reloads LXD on each cluster
+//	member.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster certificate replace request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterCertificatePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster certificate replace request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterCertificatePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterCertificatePut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -2808,38 +2808,38 @@ func internalClusterRaftNodeDelete(d *Daemon, r *http.Request) response.Response
 
 // swagger:operation GET /1.0/cluster/members/{name}/state cluster cluster_member_state_get
 //
-// Get state of the cluster member
+//	Get state of the cluster member
 //
-// Gets state of a specific cluster member.
+//	Gets state of a specific cluster member.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Cluster member state
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ClusterMemberState"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Cluster member state
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ClusterMemberState"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodeStateGet(d *Daemon, r *http.Request) response.Response {
 	memberName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -2864,31 +2864,31 @@ func clusterNodeStateGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/cluster/members/{name}/state cluster cluster_member_state_post
 //
-// Evacuate or restore a cluster member
+//	Evacuate or restore a cluster member
 //
-// Evacuates or restores a cluster member.
+//	Evacuates or restores a cluster member.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster member state
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterMemberStatePost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster member state
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterMemberStatePost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterNodeStatePost(d *Daemon, r *http.Request) response.Response {
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -3442,31 +3442,31 @@ func restoreClusterMember(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/cluster/groups cluster cluster_groups_post
 //
-// Create a cluster group.
+//	Create a cluster group.
 //
-// Creates a new cluster group.
+//	Creates a new cluster group.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster
-//     description: Cluster group to create
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterGroupsPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster
+//	    description: Cluster group to create
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterGroupsPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGroupsPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -3527,84 +3527,84 @@ func clusterGroupsPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/cluster/groups cluster-groups cluster_groups_get
 //
-// Get the cluster groups
+//  Get the cluster groups
 //
-// Returns a list of cluster groups (URLs).
+//  Returns a list of cluster groups (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/cluster/groups/lxd01",
-//               "/1.0/cluster/groups/lxd02"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/cluster/groups/lxd01",
+//                "/1.0/cluster/groups/lxd02"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/cluster/groups?recursion=1 cluster-groups cluster_groups_get_recursion1
 //
-// Get the cluster groups
+//	Get the cluster groups
 //
-// Returns a list of cluster groups (structs).
+//	Returns a list of cluster groups (structs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of cluster groups
-//           items:
-//             $ref: "#/definitions/ClusterGroup"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of cluster groups
+//	          items:
+//	            $ref: "#/definitions/ClusterGroup"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 	clustered, err := cluster.Enabled(d.db.Node)
 	if err != nil {
@@ -3664,38 +3664,38 @@ func clusterGroupsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/cluster/groups/{name} cluster-groups cluster_group_get
 //
-// Get the cluster group
+//	Get the cluster group
 //
-// Gets a specific cluster group.
+//	Gets a specific cluster group.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Cluster group
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ClusterGroup"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Cluster group
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ClusterGroup"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGroupGet(d *Daemon, r *http.Request) response.Response {
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -3746,31 +3746,31 @@ func clusterGroupGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/cluster/groups/{name} cluster-groups cluster_group_post
 //
-// Rename the cluster group
+//	Rename the cluster group
 //
-// Renames an existing cluster group.
+//	Renames an existing cluster group.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: name
-//     description: Cluster group rename request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterGroupPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: name
+//	    description: Cluster group rename request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterGroupPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -3832,33 +3832,33 @@ func clusterGroupPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/cluster/groups/{name} cluster-groups cluster_group_put
 //
-// Update the cluster group
+//	Update the cluster group
 //
-// Updates the entire cluster group configuration.
+//	Updates the entire cluster group configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster group
-//     description: cluster group configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterGroupPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster group
+//	    description: cluster group configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterGroupPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -3974,33 +3974,33 @@ func clusterGroupPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/cluster/groups/{name} cluster-groups cluster_group_patch
 //
-// Update the cluster group
+//	Update the cluster group
 //
-// Updates the cluster group configuration.
+//	Updates the cluster group configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: cluster group
-//     description: cluster group configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ClusterGroupPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: cluster group
+//	    description: cluster group configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ClusterGroupPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -4153,22 +4153,22 @@ func clusterGroupPatch(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/cluster/groups/{name} cluster-groups cluster_group_delete
 //
-// Delete the cluster group.
+//	Delete the cluster group.
 //
-// Removes the cluster group.
+//	Removes the cluster group.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func clusterGroupDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/api_metrics.go
+++ b/lxd/api_metrics.go
@@ -49,34 +49,34 @@ func allowMetrics(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/metrics metrics metrics_get
 //
-// Get metrics
+//	Get metrics
 //
-// Gets metrics of instances.
+//	Gets metrics of instances.
 //
-// ---
-// produces:
-//   - text/plain
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Metrics
-//     schema:
-//       type: string
-//       description: Instance metrics
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - text/plain
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Metrics
+//	    schema:
+//	      type: string
+//	      description: Instance metrics
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func metricsGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -57,84 +57,84 @@ var projectStateCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/projects projects projects_get
 //
-// Get the projects
+//  Get the projects
 //
-// Returns a list of projects (URLs).
+//  Returns a list of projects (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/projects/default",
-//               "/1.0/projects/foo"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/projects/default",
+//                "/1.0/projects/foo"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/projects?recursion=1 projects projects_get_recursion1
 //
-// Get the projects
+//	Get the projects
 //
-// Returns a list of projects (structs).
+//	Returns a list of projects (structs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of projects
-//           items:
-//             $ref: "#/definitions/Project"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of projects
+//	          items:
+//	            $ref: "#/definitions/Project"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectsGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
@@ -242,31 +242,31 @@ func projectUsedBy(ctx context.Context, tx *db.ClusterTx, project *cluster.Proje
 
 // swagger:operation POST /1.0/projects projects projects_post
 //
-// Add a project
+//	Add a project
 //
-// Creates a new project.
+//	Creates a new project.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: project
-//     description: Project
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProjectsPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: project
+//	    description: Project
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProjectsPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectsPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -366,38 +366,38 @@ func projectCreateDefaultProfile(tx *db.ClusterTx, project string) error {
 
 // swagger:operation GET /1.0/projects/{name} projects project_get
 //
-// Get the project
+//	Get the project
 //
-// Gets a specific project.
+//	Gets a specific project.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Project
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Project"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Project
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Project"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectGet(d *Daemon, r *http.Request) response.Response {
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -439,33 +439,33 @@ func projectGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/projects/{name} projects project_put
 //
-// Update the project
+//	Update the project
 //
-// Updates the entire project configuration.
+//	Updates the entire project configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: project
-//     description: Project configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProjectPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: project
+//	    description: Project configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProjectPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -530,33 +530,33 @@ func projectPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/projects/{name} projects project_patch
 //
-// Partially update the project
+//	Partially update the project
 //
-// Updates a subset of the project configuration.
+//	Updates a subset of the project configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: project
-//     description: Project configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProjectPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: project
+//	    description: Project configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProjectPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectPatch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -756,31 +756,31 @@ func projectChange(d *Daemon, project *api.Project, req api.ProjectPut) response
 
 // swagger:operation POST /1.0/projects/{name} projects project_post
 //
-// Rename the project
+//	Rename the project
 //
-// Renames an existing project.
+//	Renames an existing project.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: project
-//     description: Project rename request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProjectPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: project
+//	    description: Project rename request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProjectPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -868,22 +868,22 @@ func projectPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/projects/{name} projects project_delete
 //
-// Delete the project
+//	Delete the project
 //
-// Removes the project.
+//	Removes the project.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -940,38 +940,38 @@ func projectDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/projects/{name}/state projects project_state_get
 //
-// Get the project state
+//	Get the project state
 //
-// Gets a specific project resource consumption information.
+//	Gets a specific project resource consumption information.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Project state
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ProjectState"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Project state
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ProjectState"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func projectStateGet(d *Daemon, r *http.Request) response.Response {
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -60,84 +60,84 @@ var certificateCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/certificates certificates certificates_get
 //
-// Get the trusted certificates
+//  Get the trusted certificates
 //
-// Returns a list of trusted certificates (URLs).
+//  Returns a list of trusted certificates (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/certificates/390fdd27ed5dc2408edc11fe602eafceb6c025ddbad9341dfdcb1056a8dd98b1",
-//               "/1.0/certificates/22aee3f051f96abe6d7756892eecabf4b4b22e2ba877840a4ca981e9ea54030a"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/certificates/390fdd27ed5dc2408edc11fe602eafceb6c025ddbad9341dfdcb1056a8dd98b1",
+//                "/1.0/certificates/22aee3f051f96abe6d7756892eecabf4b4b22e2ba877840a4ca981e9ea54030a"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/certificates?recursion=1 certificates certificates_get_recursion1
 //
-// Get the trusted certificates
+//	Get the trusted certificates
 //
-// Returns a list of trusted certificates (structs).
+//	Returns a list of trusted certificates (structs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of certificates
-//           items:
-//             $ref: "#/definitions/Certificate"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of certificates
+//	          items:
+//	            $ref: "#/definitions/Certificate"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func certificatesGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
@@ -420,68 +420,68 @@ func certificateTokenValid(d *Daemon, r *http.Request, addToken *api.Certificate
 
 // swagger:operation POST /1.0/certificates?public certificates certificates_post_untrusted
 //
-// Add a trusted certificate
+//  Add a trusted certificate
 //
-// Adds a certificate to the trust store as an untrusted user.
-// In this mode, the `password` property must be set to the correct value.
+//  Adds a certificate to the trust store as an untrusted user.
+//  In this mode, the `password` property must be set to the correct value.
 //
-// The `certificate` field can be omitted in which case the TLS client
-// certificate in use for the connection will be retrieved and added to the
-// trust store.
+//  The `certificate` field can be omitted in which case the TLS client
+//  certificate in use for the connection will be retrieved and added to the
+//  trust store.
 //
-// The `?public` part of the URL isn't required, it's simply used to
-// separate the two behaviors of this endpoint.
+//  The `?public` part of the URL isn't required, it's simply used to
+//  separate the two behaviors of this endpoint.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: certificate
-//     description: Certificate
-//     required: true
-//     schema:
-//       $ref: "#/definitions/CertificatesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: body
+//      name: certificate
+//      description: Certificate
+//      required: true
+//      schema:
+//        $ref: "#/definitions/CertificatesPost"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation POST /1.0/certificates certificates certificates_post
 //
-// Add a trusted certificate
+//	Add a trusted certificate
 //
-// Adds a certificate to the trust store.
-// In this mode, the `password` property is always ignored.
+//	Adds a certificate to the trust store.
+//	In this mode, the `password` property is always ignored.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: certificate
-//     description: Certificate
-//     required: true
-//     schema:
-//       $ref: "#/definitions/CertificatesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: certificate
+//	    description: Certificate
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/CertificatesPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func certificatesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -766,38 +766,38 @@ func certificatesPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/certificates/{fingerprint} certificates certificate_get
 //
-// Get the trusted certificate
+//	Get the trusted certificate
 //
-// Gets a specific certificate entry from the trust store.
+//	Gets a specific certificate entry from the trust store.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Certificate
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Certificate"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Certificate
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Certificate"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func certificateGet(d *Daemon, r *http.Request) response.Response {
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
 	if err != nil {
@@ -823,33 +823,33 @@ func certificateGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/certificates/{fingerprint} certificates certificate_put
 //
-// Update the trusted certificate
+//	Update the trusted certificate
 //
-// Updates the entire certificate configuration.
+//	Updates the entire certificate configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: certificate
-//     description: Certificate configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/CertificatePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: certificate
+//	    description: Certificate configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/CertificatePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func certificatePut(d *Daemon, r *http.Request) response.Response {
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
 	if err != nil {
@@ -892,33 +892,33 @@ func certificatePut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/certificates/{fingerprint} certificates certificate_patch
 //
-// Partially update the trusted certificate
+//	Partially update the trusted certificate
 //
-// Updates a subset of the certificate configuration.
+//	Updates a subset of the certificate configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: certificate
-//     description: Certificate configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/CertificatePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: certificate
+//	    description: Certificate configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/CertificatePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func certificatePatch(d *Daemon, r *http.Request) response.Response {
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
 	if err != nil {
@@ -1084,22 +1084,22 @@ func doCertificateUpdate(d *Daemon, dbInfo api.Certificate, req api.CertificateP
 
 // swagger:operation DELETE /1.0/certificates/{fingerprint} certificates certificate_delete
 //
-// Delete the trusted certificate
+//	Delete the trusted certificate
 //
-// Removes the certificate from the trust store.
+//	Removes the certificate from the trust store.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func certificateDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/db/cluster.go
+++ b/lxd/db/cluster.go
@@ -70,7 +70,7 @@ WHERE cluster_groups.name = ? ORDER BY cluster_groups.name
 	return uris, nil
 }
 
-//AddNodeToClusterGroup adds a given node to the given cluster group.
+// AddNodeToClusterGroup adds a given node to the given cluster group.
 func (c *ClusterTx) AddNodeToClusterGroup(ctx context.Context, groupName string, nodeName string) error {
 	groupID, err := cluster.GetClusterGroupID(ctx, c.tx, groupName)
 	if err != nil {
@@ -110,7 +110,7 @@ func (c *ClusterTx) RemoveNodeFromClusterGroup(ctx context.Context, groupName st
 	return nil
 }
 
-//GetClusterGroupsWithNode returns a list of cluster group names the given node belongs to.
+// GetClusterGroupsWithNode returns a list of cluster group names the given node belongs to.
 func (c *ClusterTx) GetClusterGroupsWithNode(ctx context.Context, nodeName string) ([]string, error) {
 	q := `SELECT cluster_groups.name FROM nodes_cluster_groups
 JOIN cluster_groups ON cluster_groups.id = nodes_cluster_groups.group_id

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -82,8 +82,8 @@ func DirectAccess(db *sql.DB) *Node {
 // DB returns the low level database handle to the node-local SQLite
 // database.
 //
-// FIXME: this is used for compatibility with some legacy code, and should be
-//        dropped once there are no call sites left.
+//	FIXME: this is used for compatibility with some legacy code, and should be
+//		dropped once there are no call sites left.
 func (n *Node) DB() *sql.DB {
 	return n.db
 }
@@ -411,8 +411,8 @@ func (c *Cluster) Close() error {
 
 // DB returns the low level database handle to the cluster database.
 //
-// FIXME: this is used for compatibility with some legacy code, and should be
-//        dropped once there are no call sites left.
+//	FIXME: this is used for compatibility with some legacy code, and should be
+//		dropped once there are no call sites left.
 func (c *Cluster) DB() *sql.DB {
 	return c.db
 }

--- a/lxd/db/operationtype/operation_type.go
+++ b/lxd/db/operationtype/operation_type.go
@@ -6,8 +6,8 @@ type Type int64
 // Possible values for Type
 //
 // WARNING: The type codes are stored in the database, so this list of
-//          definitions should be normally append-only. Any other change
-//          requires a database update.
+// definitions should be normally append-only. Any other change
+// requires a database update.
 const (
 	Unknown Type = iota
 	ClusterBootstrap

--- a/lxd/db/schema/schema.go
+++ b/lxd/db/schema/schema.go
@@ -50,8 +50,8 @@ func New(updates []Update) *Schema {
 // (i.e. there are no missing versions).
 //
 // NOTE: the regular New() constructor would be formally enough, but for extra
-//       clarity we also support a map that indicates the version explicitly,
-//       see also PR #3704.
+// clarity we also support a map that indicates the version explicitly,
+// see also PR #3704.
 func NewFromMap(versionsToUpdates map[int]Update) *Schema {
 	// Collect all version keys.
 	versions := []int{}
@@ -117,8 +117,8 @@ func (s *Schema) Fresh(statement string) {
 // will be executed transactionally at the very start of Ensure(), before
 // anything else is done.
 //
-//If a schema hook was set with Hook(), it will be run before running the
-//queries in the file and it will be passed a patch version equals to -1.
+// If a schema hook was set with Hook(), it will be run before running the
+// queries in the file and it will be passed a patch version equals to -1.
 func (s *Schema) File(path string) {
 	s.path = path
 }

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -561,7 +561,7 @@ func (c *Cluster) GetStoragePoolNodeVolumeID(projectName string, volumeName stri
 }
 
 // XXX: this was extracted from lxd/storage_volume_utils.go, we find a way to
-//      factor it independently from both the db and main packages.
+// factor it independently from both the db and main packages.
 const (
 	StoragePoolVolumeTypeContainer = iota
 	StoragePoolVolumeTypeImage

--- a/lxd/endpoints/socket.go
+++ b/lxd/endpoints/socket.go
@@ -32,10 +32,10 @@ func socketUnixListen(path string) (*net.UnixListener, error) {
 // CheckAlreadyRunning checks if the socket at the given path is already
 // bound to a running LXD process, and return an error if so.
 //
-// FIXME: We should probably rather just try a regular unix socket
-//        connection without using the client. However this is the way
-//        this logic has historically behaved, so let's keep it like it
-//        was.
+//	FIXME: We should probably rather just try a regular unix socket
+//		connection without using the client. However this is the way
+//		this logic has historically behaved, so let's keep it like it
+//		was.
 func CheckAlreadyRunning(path string) error {
 	// If socket activated, nothing to do
 	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -154,37 +154,37 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 
 // swagger:operation GET /1.0/events server events_get
 //
-// Get the event stream
+//	Get the event stream
 //
-// Connects to the event API using websocket.
+//	Connects to the event API using websocket.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: type
-//     description: Event type(s), comma separated (valid types are logging, operation or lifecycle)
-//     type: string
-//     example: logging,lifecycle
-//   - in: query
-//     name: all-projects
-//     description: Retrieve instances from all projects
-//     type: boolean
-// responses:
-//   "200":
-//     description: Websocket message (JSON)
-//     schema:
-//       $ref: "#/definitions/Event"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: type
+//	    description: Event type(s), comma separated (valid types are logging, operation or lifecycle)
+//	    type: string
+//	    example: logging,lifecycle
+//	  - in: query
+//	    name: all-projects
+//	    description: Retrieve instances from all projects
+//	    type: boolean
+//	responses:
+//	  "200":
+//	    description: Websocket message (JSON)
+//	    schema:
+//	      $ref: "#/definitions/Event"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func eventsGet(d *Daemon, r *http.Request) response.Response {
 	return &eventsServe{req: r, d: d}
 }

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -384,7 +384,7 @@ func (d Nftables) NetworkClear(networkName string, _ bool, _ []uint) error {
 	return nil
 }
 
-//instanceDeviceLabel returns the unique label used for instance device chains.
+// instanceDeviceLabel returns the unique label used for instance device chains.
 func (d Nftables) instanceDeviceLabel(projectName, instanceName, deviceName string) string {
 	return fmt.Sprintf("%s%s%s", project.Instance(projectName, instanceName), nftablesChainSeparator, deviceName)
 }

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -799,7 +799,7 @@ func (d Xtables) NetworkClear(networkName string, delete bool, ipVersions []uint
 	return nil
 }
 
-//instanceDeviceIPTablesComment returns the iptables comment that is added to each instance device related rule.
+// instanceDeviceIPTablesComment returns the iptables comment that is added to each instance device related rule.
 func (d Xtables) instanceDeviceIPTablesComment(projectName string, instanceName string, deviceName string) string {
 	return fmt.Sprintf("LXD container %s (%s)", project.Instance(projectName, instanceName), deviceName)
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -105,13 +105,16 @@ var imageAliasCmd = APIEndpoint{
 	Put:    APIEndpointAction{Handler: imageAliasPut, AccessHandler: allowProjectPermission("images", "manage-images")},
 }
 
-/* We only want a single publish running at any one time.
-   The CPU and I/O load of publish is such that running multiple ones in
-   parallel takes longer than running them serially.
+/*
+We only want a single publish running at any one time.
 
-   Additionally, publishing the same container or container snapshot
-   twice would lead to storage problem, not to mention a conflict at the
-   end for whichever finishes last. */
+	The CPU and I/O load of publish is such that running multiple ones in
+	parallel takes longer than running them serially.
+
+	Additionally, publishing the same container or container snapshot
+	twice would lead to storage problem, not to mention a conflict at the
+	end for whichever finishes last.
+*/
 var imagePublishLock sync.Mutex
 
 // imageTaskMu prevents image related tasks from being scheduled at the same time as each other to prevent them
@@ -810,111 +813,111 @@ func imageCreateInPool(s *state.State, info *api.Image, storagePool string) erro
 
 // swagger:operation POST /1.0/images?public images images_post_untrusted
 //
-// Add an image
+//  Add an image
 //
-// Pushes the data to the target image server.
-// This is meant for LXD to LXD communication where a new image entry is
-// prepared on the target server and the source server is provided that URL
-// and a secret token to push the image content over.
+//  Pushes the data to the target image server.
+//  This is meant for LXD to LXD communication where a new image entry is
+//  prepared on the target server and the source server is provided that URL
+//  and a secret token to push the image content over.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image
-//     description: Image
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImagesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: body
+//      name: image
+//      description: Image
+//      required: true
+//      schema:
+//        $ref: "#/definitions/ImagesPost"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation POST /1.0/images images images_post
 //
-// Add an image
+//	Add an image
 //
-// Adds a new image to the image store.
+//	Adds a new image to the image store.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image
-//     description: Image
-//     required: false
-//     schema:
-//       $ref: "#/definitions/ImagesPost"
-//   - in: body
-//     name: raw_image
-//     description: Raw image file
-//     required: false
-//   - in: header
-//     name: X-LXD-secret
-//     description: Push secret for server to server communication
-//     schema:
-//       type: string
-//     example: RANDOM-STRING
-//   - in: header
-//     name: X-LXD-fingerprint
-//     description: Expected fingerprint when pushing a raw image
-//     schema:
-//       type: string
-//   - in: header
-//     name: X-LXD-properties
-//     description: Descriptive properties
-//     schema:
-//       type: object
-//       additionalProperties:
-//         type: string
-//   - in: header
-//     name: X-LXD-public
-//     description: Whether the image is available to unauthenticated users
-//     schema:
-//       type: boolean
-//   - in: header
-//     name: X-LXD-filename
-//     description: Original filename of the image
-//     schema:
-//       type: string
-//   - in: header
-//     name: X-LXD-profiles
-//     description: List of profiles to use
-//     schema:
-//       type: array
-//       items:
-//         type: string
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image
+//	    description: Image
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/ImagesPost"
+//	  - in: body
+//	    name: raw_image
+//	    description: Raw image file
+//	    required: false
+//	  - in: header
+//	    name: X-LXD-secret
+//	    description: Push secret for server to server communication
+//	    schema:
+//	      type: string
+//	    example: RANDOM-STRING
+//	  - in: header
+//	    name: X-LXD-fingerprint
+//	    description: Expected fingerprint when pushing a raw image
+//	    schema:
+//	      type: string
+//	  - in: header
+//	    name: X-LXD-properties
+//	    description: Descriptive properties
+//	    schema:
+//	      type: object
+//	      additionalProperties:
+//	        type: string
+//	  - in: header
+//	    name: X-LXD-public
+//	    description: Whether the image is available to unauthenticated users
+//	    schema:
+//	      type: boolean
+//	  - in: header
+//	    name: X-LXD-filename
+//	    description: Original filename of the image
+//	    schema:
+//	      type: string
+//	  - in: header
+//	    name: X-LXD-profiles
+//	    description: List of profiles to use
+//	    schema:
+//	      type: array
+//	      items:
+//	        type: string
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imagesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1326,209 +1329,209 @@ func doImagesGet(ctx context.Context, tx *db.ClusterTx, recursion bool, projectN
 
 // swagger:operation GET /1.0/images?public images images_get_untrusted
 //
-// Get the public images
+//  Get the public images
 //
-// Returns a list of publicly available images (URLs).
+//  Returns a list of publicly available images (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/images/06b86454720d36b20f94e31c6812e05ec51c1b568cf3a8abd273769d213394bb",
-//               "/1.0/images/084dd79dd1360fd25a2479eb46674c2a5ef3022a40fe03c91ab3603e3402b8e1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/images/06b86454720d36b20f94e31c6812e05ec51c1b568cf3a8abd273769d213394bb",
+//                "/1.0/images/084dd79dd1360fd25a2479eb46674c2a5ef3022a40fe03c91ab3603e3402b8e1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/images?public&recursion=1 images images_get_recursion1_untrusted
 //
-// Get the public images
+//  Get the public images
 //
-// Returns a list of publicly available images (structs).
+//  Returns a list of publicly available images (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of images
-//           items:
-//             $ref: "#/definitions/Image"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of images
+//            items:
+//              $ref: "#/definitions/Image"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/images images images_get
 //
-// Get the images
+//  Get the images
 //
-// Returns a list of images (URLs).
+//  Returns a list of images (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/images/06b86454720d36b20f94e31c6812e05ec51c1b568cf3a8abd273769d213394bb",
-//               "/1.0/images/084dd79dd1360fd25a2479eb46674c2a5ef3022a40fe03c91ab3603e3402b8e1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/images/06b86454720d36b20f94e31c6812e05ec51c1b568cf3a8abd273769d213394bb",
+//                "/1.0/images/084dd79dd1360fd25a2479eb46674c2a5ef3022a40fe03c91ab3603e3402b8e1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/images?recursion=1 images images_get_recursion1
 //
-// Get the images
+//	Get the images
 //
-// Returns a list of images (structs).
+//	Returns a list of images (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of images
-//           items:
-//             $ref: "#/definitions/Image"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: filter
+//	    description: Collection filter
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of images
+//	          items:
+//	            $ref: "#/definitions/Image"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imagesGet(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	filterStr := r.FormValue("filter")
@@ -2412,28 +2415,28 @@ func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Oper
 
 // swagger:operation DELETE /1.0/images/{fingerprint} images image_delete
 //
-// Delete the image
+//	Delete the image
 //
-// Removes the image from the image store.
+//	Removes the image from the image store.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageDelete(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 
@@ -2641,90 +2644,90 @@ func imageValidSecret(d *Daemon, r *http.Request, projectName string, fingerprin
 
 // swagger:operation GET /1.0/images/{fingerprint}?public images image_get_untrusted
 //
-// Get the public image
+//  Get the public image
 //
-// Gets a specific public image.
+//  Gets a specific public image.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: secret
-//     description: Secret token to retrieve a private image
-//     type: string
-//     example: RANDOM-STRING
-// responses:
-//   "200":
-//     description: Image
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Image"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: secret
+//      description: Secret token to retrieve a private image
+//      type: string
+//      example: RANDOM-STRING
+//  responses:
+//    "200":
+//      description: Image
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            $ref: "#/definitions/Image"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/images/{fingerprint} images image_get
 //
-// Get the image
+//	Get the image
 //
-// Gets a specific image.
+//	Gets a specific image.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Image
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Image"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Image
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Image"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageGet(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
@@ -2763,38 +2766,38 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/images/{fingerprint} images image_put
 //
-// Update the image
+//	Update the image
 //
-// Updates the entire image definition.
+//	Updates the entire image definition.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image
-//     description: Image configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImagePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image
+//	    description: Image configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImagePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imagePut(d *Daemon, r *http.Request) response.Response {
 	// Get current value
 	projectName := projectParam(r)
@@ -2856,38 +2859,38 @@ func imagePut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/images/{fingerprint} images image_patch
 //
-// Partially update the image
+//	Partially update the image
 //
-// Updates a subset of the image definition.
+//	Updates a subset of the image definition.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image
-//     description: Image configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImagePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image
+//	    description: Image configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImagePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imagePatch(d *Daemon, r *http.Request) response.Response {
 	// Get current value
 	projectName := projectParam(r)
@@ -2966,36 +2969,36 @@ func imagePatch(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/images/aliases images images_aliases_post
 //
-// Add an image alias
+//	Add an image alias
 //
-// Creates a new image alias.
+//	Creates a new image alias.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image alias
-//     description: Image alias
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImageAliasesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image alias
+//	    description: Image alias
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImageAliasesPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageAliasesPost(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	req := api.ImageAliasesPost{}
@@ -3044,96 +3047,96 @@ func imageAliasesPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/images/aliases images images_aliases_get
 //
-// Get the image aliases
+//  Get the image aliases
 //
-// Returns a list of image aliases (URLs).
+//  Returns a list of image aliases (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/images/aliases/foo",
-//               "/1.0/images/aliases/bar1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/images/aliases/foo",
+//                "/1.0/images/aliases/bar1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/images/aliases?recursion=1 images images_aliases_get_recursion1
 //
-// Get the image aliases
+//	Get the image aliases
 //
-// Returns a list of image aliases (structs).
+//	Returns a list of image aliases (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of image aliases
-//           items:
-//             $ref: "#/definitions/ImageAliasesEntry"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of image aliases
+//	          items:
+//	            $ref: "#/definitions/ImageAliasesEntry"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	recursion := util.IsRecursionRequest(r)
@@ -3181,86 +3184,86 @@ func imageAliasesGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/images/aliases/{name}?public images image_alias_get_untrusted
 //
-// Get the public image alias
+//  Get the public image alias
 //
-// Gets a specific public image alias.
-// This untrusted endpoint only works for aliases pointing to public images.
+//  Gets a specific public image alias.
+//  This untrusted endpoint only works for aliases pointing to public images.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Image alias
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ImageAliasesEntry"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: Image alias
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            $ref: "#/definitions/ImageAliasesEntry"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/images/aliases/{name} images image_alias_get
 //
-// Get the image alias
+//	Get the image alias
 //
-// Gets a specific image alias.
+//	Gets a specific image alias.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Image alias
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ImageAliasesEntry"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Image alias
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ImageAliasesEntry"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
@@ -3285,28 +3288,28 @@ func imageAliasGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/images/aliases/{name} images image_alias_delete
 //
-// Delete the image alias
+//	Delete the image alias
 //
-// Deletes a specific image alias.
+//	Deletes a specific image alias.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageAliasDelete(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
@@ -3339,38 +3342,38 @@ func imageAliasDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/images/aliases/{name} images images_aliases_put
 //
-// Update the image alias
+//	Update the image alias
 //
-// Updates the entire image alias configuration.
+//	Updates the entire image alias configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image alias
-//     description: Image alias configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImageAliasesEntryPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image alias
+//	    description: Image alias configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImageAliasesEntryPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageAliasPut(d *Daemon, r *http.Request) response.Response {
 	// Get current value
 	projectName := projectParam(r)
@@ -3428,38 +3431,38 @@ func imageAliasPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/images/aliases/{name} images images_alias_patch
 //
-// Partially update the image alias
+//	Partially update the image alias
 //
-// Updates a subset of the image alias configuration.
+//	Updates a subset of the image alias configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image alias
-//     description: Image alias configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImageAliasesEntryPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image alias
+//	    description: Image alias configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImageAliasesEntryPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageAliasPatch(d *Daemon, r *http.Request) response.Response {
 	// Get current value
 	projectName := projectParam(r)
@@ -3532,36 +3535,36 @@ func imageAliasPatch(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/images/aliases/{name} images images_alias_post
 //
-// Rename the image alias
+//	Rename the image alias
 //
-// Renames an existing image alias.
+//	Renames an existing image alias.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image alias
-//     description: Image alias rename request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImageAliasesEntryPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image alias
+//	    description: Image alias rename request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImageAliasesEntryPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
@@ -3611,58 +3614,58 @@ func imageAliasPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/images/{fingerprint}/export?public images image_export_get_untrusted
 //
-// Get the raw image file(s)
+//  Get the raw image file(s)
 //
-// Download the raw image file(s) of a public image from the server.
-// If the image is in split format, a multipart http transfer occurs.
+//  Download the raw image file(s) of a public image from the server.
+//  If the image is in split format, a multipart http transfer occurs.
 //
-// ---
-// produces:
-//   - application/octet-stream
-//   - multipart/form-data
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: secret
-//     description: Secret token to retrieve a private image
-//     type: string
-//     example: RANDOM-STRING
-// responses:
-//   "200":
-//     description: Raw image data
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/octet-stream
+//    - multipart/form-data
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: secret
+//      description: Secret token to retrieve a private image
+//      type: string
+//      example: RANDOM-STRING
+//  responses:
+//    "200":
+//      description: Raw image data
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/images/{fingerprint}/export images image_export_get
 //
-// Get the raw image file(s)
+//	Get the raw image file(s)
 //
-// Download the raw image file(s) from the server.
-// If the image is in split format, a multipart http transfer occurs.
+//	Download the raw image file(s) from the server.
+//	If the image is in split format, a multipart http transfer occurs.
 //
-// ---
-// produces:
-//   - application/octet-stream
-//   - multipart/form-data
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Raw image data
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/octet-stream
+//	  - multipart/form-data
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Raw image data
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageExport(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
@@ -3767,32 +3770,32 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/images/{fingerprint}/export images images_export_post
 //
-// Make LXD push the image to a remote server
+//	Make LXD push the image to a remote server
 //
-// Gets LXD to connect to a remote server and push the image to it.
+//	Gets LXD to connect to a remote server and push the image to it.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: image
-//     description: Image push request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImageExportPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: image
+//	    description: Image push request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImageExportPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageExportPost(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
@@ -3911,28 +3914,28 @@ func imageExportPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/images/{fingerprint}/secret images images_secret_post
 //
-// Generate secret for retrieval of the image by an untrusted client
+//	Generate secret for retrieval of the image by an untrusted client
 //
-// This generates a background operation including a secret one time key
-// in its metadata which can be used to fetch this image from an untrusted
-// client.
+//	This generates a background operation including a secret one time key
+//	in its metadata which can be used to fetch this image from an untrusted
+//	client.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageSecret(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])
@@ -4022,28 +4025,28 @@ func imageImportFromNode(imagesDir string, client lxd.InstanceServer, fingerprin
 
 // swagger:operation POST /1.0/images/{fingerprint}/refresh images images_refresh_post
 //
-// Refresh an image
+//	Refresh an image
 //
-// This causes LXD to check the image source server for an updated
-// version of the image and if available to refresh the local copy with the
-// new version.
+//	This causes LXD to check the image source server for an updated
+//	version of the image and if available to refresh the local copy with the
+//	new version.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func imageRefresh(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	fingerprint, err := url.PathUnescape(mux.Vars(r)["fingerprint"])

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -27,96 +27,96 @@ import (
 
 // swagger:operation GET /1.0/instances/{name}/backups instances instance_backups_get
 //
-// Get the backups
+//  Get the backups
 //
-// Returns a list of instance backups (URLs).
+//  Returns a list of instance backups (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/instances/foo/backups/backup0",
-//               "/1.0/instances/foo/backups/backup1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/instances/foo/backups/backup0",
+//                "/1.0/instances/foo/backups/backup1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/instances/{name}/backups?recursion=1 instances instance_backups_get_recursion1
 //
-// Get the backups
+//	Get the backups
 //
-// Returns a list of instance backups (structs).
+//	Returns a list of instance backups (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of instance backups
-//           items:
-//             $ref: "#/definitions/InstanceBackup"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of instance backups
+//	          items:
+//	            $ref: "#/definitions/InstanceBackup"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceBackupsGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -178,36 +178,36 @@ func instanceBackupsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/instances/{name}/backups instances instance_backups_post
 //
-// Create a backup
+//	Create a backup
 //
-// Creates a new backup.
+//	Creates a new backup.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: backup
-//     description: Backup request
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstanceBackupsPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: backup
+//	    description: Backup request
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstanceBackupsPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -351,44 +351,44 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/instances/{name}/backups/{backup} instances instance_backup_get
 //
-// Get the backup
+//	Get the backup
 //
-// Gets a specific instance backup.
+//	Gets a specific instance backup.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Instance backup
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/InstanceBackup"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Instance backup
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/InstanceBackup"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceBackupGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -431,36 +431,36 @@ func instanceBackupGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/instances/{name}/backups/{backup} instances instance_backup_post
 //
-// Rename a backup
+//	Rename a backup
 //
-// Renames an instance backup.
+//	Renames an instance backup.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: backup
-//     description: Backup rename
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstanceBackupPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: backup
+//	    description: Backup rename
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstanceBackupPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -535,30 +535,30 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/instances/{name}/backups/{backup} instances instance_backup_delete
 //
-// Delete a backup
+//	Delete a backup
 //
-// Deletes the instance backup.
+//	Deletes the instance backup.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -619,26 +619,26 @@ func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/instances/{name}/backups/{backup}/export instances instance_backup_export
 //
-// Get the raw backup file(s)
+//	Get the raw backup file(s)
 //
-// Download the raw backup file(s) from the server.
+//	Download the raw backup file(s) from the server.
 //
-// ---
-// produces:
-//   - application/octet-stream
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Raw image data
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/octet-stream
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Raw image data
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -369,37 +369,37 @@ func (s *consoleWs) doVGA(op *operations.Operation) error {
 
 // swagger:operation POST /1.0/instances/{name}/console instances instance_console_post
 //
-// Connect to console
+//	Connect to console
 //
-// Connects to the console of an instance.
+//	Connects to the console of an instance.
 //
-// The returned operation metadata will contain two websockets, one for data and one for control.
+//	The returned operation metadata will contain two websockets, one for data and one for control.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: console
-//     description: Console request
-//     schema:
-//       $ref: "#/definitions/InstanceConsolePost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: console
+//	    description: Console request
+//	    schema:
+//	      $ref: "#/definitions/InstanceConsolePost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -511,35 +511,35 @@ func instanceConsolePost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/instances/{name}/console instances instance_console_get
 //
-// Get console log
+//	Get console log
 //
-// Gets the console log for the instance.
+//	Gets the console log for the instance.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//      description: Raw console log
-//      content:
-//        application/octet-stream:
-//          schema:
-//            type: string
-//            example: some-text
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	     description: Raw console log
+//	     content:
+//	       application/octet-stream:
+//	         schema:
+//	           type: string
+//	           example: some-text
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -621,30 +621,30 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/instances/{name}/console instances instance_console_delete
 //
-// Clear the console log
+//	Clear the console log
 //
-// Clears the console log buffer.
+//	Clears the console log buffer.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceConsoleLogDelete(d *Daemon, r *http.Request) response.Response {
 	if !liblxc.RuntimeLiblxcVersionAtLeast(liblxc.Version(), 3, 0, 0) {
 		return response.BadRequest(fmt.Errorf("Clearing the console buffer requires liblxc >= 3.0"))

--- a/lxd/instance_delete.go
+++ b/lxd/instance_delete.go
@@ -17,30 +17,30 @@ import (
 
 // swagger:operation DELETE /1.0/instances/{name} instances instance_delete
 //
-// Delete an instance
+//	Delete an instance
 //
-// Deletes a specific instance.
+//	Deletes a specific instance.
 //
-// This also deletes anything owned by the instance such as snapshots and backups.
+//	This also deletes anything owned by the instance such as snapshots and backups.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceDelete(d *Daemon, r *http.Request) response.Response {
 	// Don't mess with instance while in setup mode.
 	<-d.waitReady.Done()

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -478,42 +478,42 @@ func (s *execWs) Do(op *operations.Operation) error {
 
 // swagger:operation POST /1.0/instances/{name}/exec instances instance_exec_post
 //
-// Run a command
+//	Run a command
 //
-// Executes a command inside an instance.
+//	Executes a command inside an instance.
 //
-// The returned operation metadata will contain either 2 or 4 websockets.
-// In non-interactive mode, you'll get one websocket for each of stdin, stdout and stderr.
-// In interactive mode, a single bi-directional websocket is used for stdin and stdout/stderr.
+//	The returned operation metadata will contain either 2 or 4 websockets.
+//	In non-interactive mode, you'll get one websocket for each of stdin, stdout and stderr.
+//	In interactive mode, a single bi-directional websocket is used for stdin and stdout/stderr.
 //
-// An additional "control" socket is always added on top which can be used for out of band communication with LXD.
-// This allows sending signals and window sizing information through.
+//	An additional "control" socket is always added on top which can be used for out of band communication with LXD.
+//	This allows sending signals and window sizing information through.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: exec
-//     description: Exec request
-//     schema:
-//       $ref: "#/definitions/InstanceExecPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: exec
+//	    description: Exec request
+//	    schema:
+//	      $ref: "#/definitions/InstanceExecPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceExecPost(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -82,72 +82,72 @@ func instanceFileHandler(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/instances/{name}/files instances instance_files_get
 //
-// Get a file
+//	Get a file
 //
-// Gets the file content. If it's a directory, a json list of files will be returned instead.
+//	Gets the file content. If it's a directory, a json list of files will be returned instead.
 //
-// ---
-// produces:
-//   - application/json
-//   - application/octet-stream
-// parameters:
-//   - in: query
-//     name: path
-//     description: Path to the file
-//     type: string
-//     example: default
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//      description: Raw file or directory listing
-//      headers:
-//        X-LXD-uid:
-//          description: File owner UID
-//          schema:
-//            type: integer
-//        X-LXD-gid:
-//          description: File owner GID
-//          schema:
-//            type: integer
-//        X-LXD-mode:
-//          description: Mode mask
-//          schema:
-//            type: integer
-//        X-LXD-modified:
-//          description: Last modified date
-//          schema:
-//            type: string
-//        X-LXD-type:
-//          description: Type of file (file, symlink or directory)
-//          schema:
-//            type: string
-//      content:
-//        application/octet-stream:
-//          schema:
-//            type: string
-//            example: some-text
-//        application/json:
-//          schema:
-//            type: array
-//            items:
-//              type: string
-//            example: |-
-//              [
-//                "/etc",
-//                "/home"
-//              ]
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	  - application/octet-stream
+//	parameters:
+//	  - in: query
+//	    name: path
+//	    description: Path to the file
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	     description: Raw file or directory listing
+//	     headers:
+//	       X-LXD-uid:
+//	         description: File owner UID
+//	         schema:
+//	           type: integer
+//	       X-LXD-gid:
+//	         description: File owner GID
+//	         schema:
+//	           type: integer
+//	       X-LXD-mode:
+//	         description: Mode mask
+//	         schema:
+//	           type: integer
+//	       X-LXD-modified:
+//	         description: Last modified date
+//	         schema:
+//	           type: string
+//	       X-LXD-type:
+//	         description: Type of file (file, symlink or directory)
+//	         schema:
+//	           type: string
+//	     content:
+//	       application/octet-stream:
+//	         schema:
+//	           type: string
+//	           example: some-text
+//	       application/json:
+//	         schema:
+//	           type: array
+//	           items:
+//	             type: string
+//	           example: |-
+//	             [
+//	               "/etc",
+//	               "/home"
+//	             ]
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceFileGet(s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
@@ -263,54 +263,54 @@ func instanceFileGet(s *state.State, inst instance.Instance, path string, r *htt
 
 // swagger:operation HEAD /1.0/instances/{name}/files instances instance_files_head
 //
-// Get metadata for a file
+//	Get metadata for a file
 //
-// Gets the file or directory metadata.
+//	Gets the file or directory metadata.
 //
-// ---
-// parameters:
-//   - in: query
-//     name: path
-//     description: Path to the file
-//     type: string
-//     example: default
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//      description: Raw file or directory listing
-//      headers:
-//        X-LXD-uid:
-//          description: File owner UID
-//          schema:
-//            type: integer
-//        X-LXD-gid:
-//          description: File owner GID
-//          schema:
-//            type: integer
-//        X-LXD-mode:
-//          description: Mode mask
-//          schema:
-//            type: integer
-//        X-LXD-modified:
-//          description: Last modified date
-//          schema:
-//            type: string
-//        X-LXD-type:
-//          description: Type of file (file, symlink or directory)
-//          schema:
-//            type: string
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	parameters:
+//	  - in: query
+//	    name: path
+//	    description: Path to the file
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	     description: Raw file or directory listing
+//	     headers:
+//	       X-LXD-uid:
+//	         description: File owner UID
+//	         schema:
+//	           type: integer
+//	       X-LXD-gid:
+//	         description: File owner GID
+//	         schema:
+//	           type: integer
+//	       X-LXD-mode:
+//	         description: Mode mask
+//	         schema:
+//	           type: integer
+//	       X-LXD-modified:
+//	         description: Last modified date
+//	         schema:
+//	           type: string
+//	       X-LXD-type:
+//	         description: Type of file (file, symlink or directory)
+//	         schema:
+//	           type: string
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceFileHead(s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
@@ -362,70 +362,70 @@ func instanceFileHead(s *state.State, inst instance.Instance, path string, r *ht
 
 // swagger:operation POST /1.0/instances/{name}/files instances instance_files_post
 //
-// Create or replace a file
+//	Create or replace a file
 //
-// Creates a new file in the instance.
+//	Creates a new file in the instance.
 //
-// ---
-// consumes:
-//   - application/octet-stream
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: path
-//     description: Path to the file
-//     type: string
-//     example: default
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: raw_file
-//     description: Raw file content
-//   - in: header
-//     name: X-LXD-uid
-//     description: File owner UID
-//     schema:
-//       type: integer
-//     example: 1000
-//   - in: header
-//     name: X-LXD-gid
-//     description: File owner GID
-//     schema:
-//       type: integer
-//     example: 1000
-//   - in: header
-//     name: X-LXD-mode
-//     description: File mode
-//     schema:
-//       type: integer
-//     example: 0644
-//   - in: header
-//     name: X-LXD-type
-//     description: Type of file (file, symlink or directory)
-//     schema:
-//       type: string
-//     example: file
-//   - in: header
-//     name: X-LXD-write
-//     description: Write mode (overwrite or append)
-//     schema:
-//       type: string
-//     example: overwrite
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/octet-stream
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: path
+//	    description: Path to the file
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: raw_file
+//	    description: Raw file content
+//	  - in: header
+//	    name: X-LXD-uid
+//	    description: File owner UID
+//	    schema:
+//	      type: integer
+//	    example: 1000
+//	  - in: header
+//	    name: X-LXD-gid
+//	    description: File owner GID
+//	    schema:
+//	      type: integer
+//	    example: 1000
+//	  - in: header
+//	    name: X-LXD-mode
+//	    description: File mode
+//	    schema:
+//	      type: integer
+//	    example: 0644
+//	  - in: header
+//	    name: X-LXD-type
+//	    description: Type of file (file, symlink or directory)
+//	    schema:
+//	      type: string
+//	    example: file
+//	  - in: header
+//	    name: X-LXD-write
+//	    description: Write mode (overwrite or append)
+//	    schema:
+//	      type: string
+//	    example: overwrite
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceFilePost(s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
 	// Get a SFTP client.
 	client, err := inst.FileSFTP()
@@ -554,35 +554,35 @@ func instanceFilePost(s *state.State, inst instance.Instance, path string, r *ht
 
 // swagger:operation DELETE /1.0/instances/{name}/files instances instance_files_delete
 //
-// Delete a file
+//	Delete a file
 //
-// Removes the file.
+//	Removes the file.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: path
-//     description: Path to the file
-//     type: string
-//     example: default
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: path
+//	    description: Path to the file
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceFileDelete(s *state.State, inst instance.Instance, path string, r *http.Request) response.Response {
 	// Get a SFTP client.
 	client, err := inst.FileSFTP()

--- a/lxd/instance_get.go
+++ b/lxd/instance_get.go
@@ -16,87 +16,87 @@ import (
 
 // swagger:operation GET /1.0/instances/{name} instances instance_get
 //
-// Get the instance
+//  Get the instance
 //
-// Gets a specific instance (basic struct).
+//  Gets a specific instance (basic struct).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Instance
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Instance"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: Instance
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            $ref: "#/definitions/Instance"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/instances/{name}?recursion=1 instances instance_get_recursion1
 //
-// Get the instance
+//	Get the instance
 //
-// Gets a specific instance (full struct).
+//	Gets a specific instance (full struct).
 //
-// recursion=1 also includes information about state, snapshots and backups.
+//	recursion=1 also includes information about state, snapshots and backups.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Instance
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Instance"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Instance
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Instance"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -43,54 +43,54 @@ var instanceLogsCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/instances/{name}/logs instances instance_logs_get
 //
-// Get the log files
+//	Get the log files
 //
-// Returns a list of log files (URLs).
+//	Returns a list of log files (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/instances/foo/logs/lxc.conf",
-//               "/1.0/instances/foo/logs/lxc.log"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of endpoints
+//	          items:
+//	            type: string
+//	          example: |-
+//	            [
+//	              "/1.0/instances/foo/logs/lxc.conf",
+//	              "/1.0/instances/foo/logs/lxc.log"
+//	            ]
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceLogsGet(d *Daemon, r *http.Request) response.Response {
 	/* Let's explicitly *not* try to do a containerLoadByName here. In some
 	 * cases (e.g. when container creation failed), the container won't
@@ -163,36 +163,36 @@ func validLogFileName(fname string) bool {
 
 // swagger:operation GET /1.0/instances/{name}/logs/{filename} instances instance_log_get
 //
-// Get the log file
+//	Get the log file
 //
-// Gets the log file.
+//	Gets the log file.
 //
-// ---
-// produces:
-//   - application/json
-//   - application/octet-stream
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//      description: Raw file
-//      content:
-//        application/octet-stream:
-//          schema:
-//            type: string
-//            example: some-text
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	  - application/octet-stream
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	     description: Raw file
+//	     content:
+//	       application/octet-stream:
+//	         schema:
+//	           type: string
+//	           example: some-text
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -251,30 +251,30 @@ func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/instances/{name}/logs/{filename} instances instance_log_delete
 //
-// Delete the log file
+//	Delete the log file
 //
-// Removes the log file.
+//	Removes the log file.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceLogDelete(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -26,44 +26,44 @@ import (
 
 // swagger:operation GET /1.0/instances/{name}/metadata instances instance_metadata_get
 //
-// Get the instance image metadata
+//	Get the instance image metadata
 //
-// Gets the image metadata for the instance.
+//	Gets the image metadata for the instance.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Image metadata
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ImageMetadata"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Image metadata
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ImageMetadata"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceMetadataGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -142,38 +142,38 @@ func instanceMetadataGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/instances/{name}/metadata instances instance_metadata_patch
 //
-// Partially update the image metadata
+//	Partially update the image metadata
 //
-// Updates a subset of the instance image metadata.
+//	Updates a subset of the instance image metadata.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: metadata
-//     description: Image metadata
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImageMetadata"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: metadata
+//	    description: Image metadata
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImageMetadata"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceMetadataPatch(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -260,38 +260,38 @@ func instanceMetadataPatch(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/instances/{name}/metadata instances instance_metadata_put
 //
-// Update the image metadata
+//	Update the image metadata
 //
-// Updates the instance image metadata.
+//	Updates the instance image metadata.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: metadata
-//     description: Image metadata
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ImageMetadata"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: metadata
+//	    description: Image metadata
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ImageMetadata"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceMetadataPut(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -368,52 +368,52 @@ func doInstanceMetadataUpdate(d *Daemon, inst instance.Instance, metadata api.Im
 
 // swagger:operation GET /1.0/instances/{name}/metadata/templates instances instance_metadata_templates_get
 //
-// Get the template file names or a specific
+//	Get the template file names or a specific
 //
-// If no path specified, returns a list of template file names.
-// If a path is specified, returns the file content.
+//	If no path specified, returns a list of template file names.
+//	If a path is specified, returns the file content.
 //
-// ---
-// produces:
-//   - application/json
-//   - application/octet-stream
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: path
-//     description: Template name
-//     type: string
-//     example: hostname.tpl
-// responses:
-//   "200":
-//      description: Raw template file or file listing
-//      content:
-//        application/octet-stream:
-//          schema:
-//            type: string
-//            example: some-text
-//        application/json:
-//          schema:
-//            type: array
-//            items:
-//              type: string
-//            example: |-
-//              [
-//                "hostname.tpl",
-//                "hosts.tpl"
-//              ]
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	  - application/octet-stream
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: path
+//	    description: Template name
+//	    type: string
+//	    example: hostname.tpl
+//	responses:
+//	  "200":
+//	     description: Raw template file or file listing
+//	     content:
+//	       application/octet-stream:
+//	         schema:
+//	           type: string
+//	           example: some-text
+//	       application/json:
+//	         schema:
+//	           type: array
+//	           items:
+//	             type: string
+//	           example: |-
+//	             [
+//	               "hostname.tpl",
+//	               "hosts.tpl"
+//	             ]
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -530,40 +530,40 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 
 // swagger:operation POST /1.0/instances/{name}/metadata/templates instances instance_metadata_templates_post
 //
-// Create or replace a template file
+//	Create or replace a template file
 //
-// Creates a new image template file for the instance.
+//	Creates a new image template file for the instance.
 //
-// ---
-// consumes:
-//   - application/octet-stream
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: path
-//     description: Template name
-//     type: string
-//     example: default
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: raw_file
-//     description: Raw file content
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/octet-stream
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: path
+//	    description: Template name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: raw_file
+//	    description: Raw file content
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -651,35 +651,35 @@ func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response
 
 // swagger:operation DELETE /1.0/instances/{name}/metadata/templates instances instance_metadata_templates_delete
 //
-// Delete a template file
+//	Delete a template file
 //
-// Removes the template file.
+//	Removes the template file.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: path
-//     description: Template name
-//     type: string
-//     example: default
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: path
+//	    description: Template name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceMetadataTemplatesDelete(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -25,35 +25,35 @@ import (
 
 // swagger:operation PATCH /1.0/instances/{name} instances instance_patch
 //
-// Partially update the instance
+//	Partially update the instance
 //
-// Updates a subset of the instance configuration
+//	Updates a subset of the instance configuration
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: instance
-//     description: Update request
-//     schema:
-//       $ref: "#/definitions/InstancePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: instance
+//	    description: Update request
+//	    schema:
+//	      $ref: "#/definitions/InstancePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instancePatch(d *Daemon, r *http.Request) response.Response {
 	// Don't mess with instance while in setup mode.
 	<-d.waitReady.Done()

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -36,41 +36,41 @@ var internalClusterInstanceMovedCmd = APIEndpoint{
 
 // swagger:operation POST /1.0/instances/{name} instances instance_post
 //
-// Rename or move/migrate an instance
+//	Rename or move/migrate an instance
 //
-// Renames, moves an instance between pools or migrates an instance to another server.
+//	Renames, moves an instance between pools or migrates an instance to another server.
 //
-// The returned operation metadata will vary based on what's requested.
-// For rename or move within the same server, this is a simple background operation with progress data.
-// For migration, in the push case, this will similarly be a background
-// operation with progress data, for the pull case, it will be a websocket
-// operation with a number of secrets to be passed to the target server.
+//	The returned operation metadata will vary based on what's requested.
+//	For rename or move within the same server, this is a simple background operation with progress data.
+//	For migration, in the push case, this will similarly be a background
+//	operation with progress data, for the pull case, it will be a websocket
+//	operation with a number of secrets to be passed to the target server.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: migration
-//     description: Migration request
-//     schema:
-//       $ref: "#/definitions/InstancePost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: migration
+//	    description: Migration request
+//	    schema:
+//	      $ref: "#/definitions/InstancePost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instancePost(d *Daemon, r *http.Request) response.Response {
 	// Don't mess with instance while in setup mode.
 	<-d.waitReady.Done()

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -27,35 +27,35 @@ import (
 
 // swagger:operation PUT /1.0/instances/{name} instances instance_put
 //
-// Update the instance
+//	Update the instance
 //
-// Updates the instance configuration or trigger a snapshot restore.
+//	Updates the instance configuration or trigger a snapshot restore.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: instance
-//     description: Update request
-//     schema:
-//       $ref: "#/definitions/InstancePut"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: instance
+//	    description: Update request
+//	    schema:
+//	      $ref: "#/definitions/InstancePut"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instancePut(d *Daemon, r *http.Request) response.Response {
 	// Don't mess with instance while in setup mode.
 	<-d.waitReady.Done()

--- a/lxd/instance_sftp.go
+++ b/lxd/instance_sftp.go
@@ -22,25 +22,25 @@ import (
 
 // swagger:operation GET /1.0/instances/{name}/sftp instances instance_sftp
 //
-// Get the instance SFTP connection
+//	Get the instance SFTP connection
 //
-// Upgrades the request to an SFTP connection of the instance's filesystem.
+//	Upgrades the request to an SFTP connection of the instance's filesystem.
 //
-// ---
-// produces:
-//   - application/json
-//   - application/octet-stream
-// responses:
-//   "101":
-//     description: Switching protocols to SFTP
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	  - application/octet-stream
+//	responses:
+//	  "101":
+//	    description: Switching protocols to SFTP
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceSFTPHandler(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	instName, err := url.PathUnescape(mux.Vars(r)["name"])

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -31,96 +31,96 @@ import (
 
 // swagger:operation GET /1.0/instances/{name}/snapshots instances instance_snapshots_get
 //
-// Get the snapshots
+//  Get the snapshots
 //
-// Returns a list of instance snapshots (URLs).
+//  Returns a list of instance snapshots (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/instances/foo/snapshots/snap0",
-//               "/1.0/instances/foo/snapshots/snap1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/instances/foo/snapshots/snap0",
+//                "/1.0/instances/foo/snapshots/snap1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/instances/{name}/snapshots?recursion=1 instances instance_snapshots_get_recursion1
 //
-// Get the snapshots
+//	Get the snapshots
 //
-// Returns a list of instance snapshots (structs).
+//	Returns a list of instance snapshots (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of instance snapshots
-//           items:
-//             $ref: "#/definitions/InstanceSnapshot"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of instance snapshots
+//	          items:
+//	            $ref: "#/definitions/InstanceSnapshot"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -197,36 +197,36 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/instances/{name}/snapshots instances instance_snapshots_post
 //
-// Create a snapshot
+//	Create a snapshot
 //
-// Creates a new snapshot.
+//	Creates a new snapshot.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: snapshot
-//     description: Snapshot request
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstanceSnapshotsPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: snapshot
+//	    description: Snapshot request
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstanceSnapshotsPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -389,36 +389,36 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/instances/{name}/snapshots/{snapshot} instances instance_snapshot_patch
 //
-// Partially update snapshot
+//	Partially update snapshot
 //
-// Updates a subset of the snapshot config.
+//	Updates a subset of the snapshot config.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: snapshot
-//     description: Snapshot update
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstanceSnapshotPut"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: snapshot
+//	    description: Snapshot update
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstanceSnapshotPut"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func snapshotPatch(d *Daemon, r *http.Request, snapInst instance.Instance, name string) response.Response {
 	// Only expires_at is currently editable, so PATCH is equivalent to PUT.
 	return snapshotPut(d, r, snapInst, name)
@@ -426,36 +426,36 @@ func snapshotPatch(d *Daemon, r *http.Request, snapInst instance.Instance, name 
 
 // swagger:operation PUT /1.0/instances/{name}/snapshots/{snapshot} instances instance_snapshot_put
 //
-// Update snapshot
+//	Update snapshot
 //
-// Updates the snapshot config.
+//	Updates the snapshot config.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: snapshot
-//     description: Snapshot update
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstanceSnapshotPut"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: snapshot
+//	    description: Snapshot update
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstanceSnapshotPut"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name string) response.Response {
 	// Validate the ETag
 	etag := []any{snapInst.ExpiryDate()}
@@ -535,44 +535,44 @@ func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name st
 
 // swagger:operation GET /1.0/instances/{name}/snapshots/{snapshot} instances instance_snapshot_get
 //
-// Get the snapshot
+//	Get the snapshot
 //
-// Gets a specific instance snapshot.
+//	Gets a specific instance snapshot.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Instance snapshot
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/InstanceSnapshot"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Instance snapshot
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/InstanceSnapshot"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func snapshotGet(s *state.State, snapInst instance.Instance, name string) response.Response {
 	render, _, err := snapInst.Render(storagePools.RenderSnapshotUsage(s, snapInst))
 	if err != nil {
@@ -585,42 +585,42 @@ func snapshotGet(s *state.State, snapInst instance.Instance, name string) respon
 
 // swagger:operation POST /1.0/instances/{name}/snapshots/{snapshot} instances instance_snapshot_post
 //
-// Rename or move/migrate a snapshot
+//	Rename or move/migrate a snapshot
 //
-// Renames or migrates an instance snapshot to another server.
+//	Renames or migrates an instance snapshot to another server.
 //
-// The returned operation metadata will vary based on what's requested.
-// For rename or move within the same server, this is a simple background operation with progress data.
-// For migration, in the push case, this will similarly be a background
-// operation with progress data, for the pull case, it will be a websocket
-// operation with a number of secrets to be passed to the target server.
+//	The returned operation metadata will vary based on what's requested.
+//	For rename or move within the same server, this is a simple background operation with progress data.
+//	For migration, in the push case, this will similarly be a background
+//	operation with progress data, for the pull case, it will be a websocket
+//	operation with a number of secrets to be passed to the target server.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: snapshot
-//     description: Snapshot migration
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstanceSnapshotPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: snapshot
+//	    description: Snapshot migration
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstanceSnapshotPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, containerName string) response.Response {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
@@ -743,30 +743,30 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 
 // swagger:operation DELETE /1.0/instances/{name}/snapshots/{snapshot} instances instance_snapshot_delete
 //
-// Delete a snapshot
+//	Delete a snapshot
 //
-// Deletes the instance snapshot.
+//	Deletes the instance snapshot.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func snapshotDelete(s *state.State, r *http.Request, snapInst instance.Instance, name string) response.Response {
 	remove := func(op *operations.Operation) error {
 		return snapInst.Delete(false)

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -20,49 +20,49 @@ import (
 
 // swagger:operation GET /1.0/instances/{name}/state instances instance_state_get
 //
-// Get the runtime state
+//	Get the runtime state
 //
-// Gets the runtime state of the instance.
+//	Gets the runtime state of the instance.
 //
-// This is a reasonably expensive call as it causes code to be run
-// inside of the instance to retrieve the resource usage and network
-// information.
+//	This is a reasonably expensive call as it causes code to be run
+//	inside of the instance to retrieve the resource usage and network
+//	information.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-// responses:
-//   "200":
-//     description: State
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/InstanceState"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	responses:
+//	  "200":
+//	    description: State
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/InstanceState"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceState(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {
@@ -105,36 +105,36 @@ func instanceState(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/instances/{name}/state instances instance_state_put
 //
-// Change the state
+//	Change the state
 //
-// Changes the running state of the instance.
+//	Changes the running state of the instance.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: state
-//     description: State
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstanceStatePut"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: state
+//	    description: State
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstanceStatePut"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	instanceType, err := urlInstanceTypeDetect(r)
 	if err != nil {

--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -52,171 +52,171 @@ func urlInstanceTypeDetect(r *http.Request) (instancetype.Type, error) {
 
 // swagger:operation GET /1.0/instances instances instances_get
 //
-// Get the instances
+//  Get the instances
 //
-// Returns a list of instances (URLs).
+//  Returns a list of instances (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-//   - in: query
-//     name: all-projects
-//     description: Retrieve instances from all projects
-//     type: boolean
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/instances/foo",
-//               "/1.0/instances/bar"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//    - in: query
+//      name: all-projects
+//      description: Retrieve instances from all projects
+//      type: boolean
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/instances/foo",
+//                "/1.0/instances/bar"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/instances?recursion=1 instances instances_get_recursion1
 //
-// Get the instances
+//  Get the instances
 //
-// Returns a list of instances (basic structs).
+//  Returns a list of instances (basic structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-//   - in: query
-//     name: all-projects
-//     description: Retrieve instances from all projects
-//     type: boolean
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of instances
-//           items:
-//             $ref: "#/definitions/Instance"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//    - in: query
+//      name: all-projects
+//      description: Retrieve instances from all projects
+//      type: boolean
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of instances
+//            items:
+//              $ref: "#/definitions/Instance"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/instances?recursion=2 instances instances_get_recursion2
 //
-// Get the instances
+//  Get the instances
 //
-// Returns a list of instances (full structs).
+//  Returns a list of instances (full structs).
 //
-// The main difference between recursion=1 and recursion=2 is that the
-// latter also includes state and snapshot information allowing for a
-// single API call to return everything needed by most clients.
+//  The main difference between recursion=1 and recursion=2 is that the
+//  latter also includes state and snapshot information allowing for a
+//  single API call to return everything needed by most clients.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-//   - in: query
-//     name: all-projects
-//     description: Retrieve instances from all projects
-//     type: boolean
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of instances
-//           items:
-//             $ref: "#/definitions/InstanceFull"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//    - in: query
+//      name: all-projects
+//      description: Retrieve instances from all projects
+//      type: boolean
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of instances
+//            items:
+//              $ref: "#/definitions/InstanceFull"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 func instancesGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -736,48 +736,48 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 
 // swagger:operation POST /1.0/instances instances instances_post
 //
-// Create a new instance
+//	Create a new instance
 //
-// Creates a new instance on LXD.
-// Depending on the source, this can create an instance from an existing
-// local image, remote image, existing local instance or snapshot, remote
-// migration stream or backup file.
+//	Creates a new instance on LXD.
+//	Depending on the source, this can create an instance from an existing
+//	local image, remote image, existing local instance or snapshot, remote
+//	migration stream or backup file.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member
-//     type: string
-//     example: default
-//   - in: body
-//     name: instance
-//     description: Instance request
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstancesPost"
-//   - in: body
-//     name: raw_backup
-//     description: Raw backup file
-//     required: false
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: instance
+//	    description: Instance request
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstancesPost"
+//	  - in: body
+//	    name: raw_backup
+//	    description: Raw backup file
+//	    required: false
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instancesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/instances_put.go
+++ b/lxd/instances_put.go
@@ -41,36 +41,36 @@ func coalesceErrors(local bool, errors map[string]error) error {
 
 // swagger:operation PUT /1.0/instances instances instances_put
 //
-// Bulk instance state update
+//	Bulk instance state update
 //
-// Changes the running state of all instances.
+//	Changes the running state of all instances.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: state
-//     description: State
-//     required: false
-//     schema:
-//       $ref: "#/definitions/InstancesPut"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: state
+//	    description: State
+//	    required: false
+//	    schema:
+//	      $ref: "#/definitions/InstancesPut"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func instancesPut(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 

--- a/lxd/network_acls.go
+++ b/lxd/network_acls.go
@@ -49,96 +49,96 @@ var networkACLLogCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/network-acls network-acls network_acls_get
 //
-// Get the network ACLs
+//  Get the network ACLs
 //
-// Returns a list of network ACLs (URLs).
+//  Returns a list of network ACLs (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/network-acls/foo",
-//               "/1.0/network-acls/bar"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/network-acls/foo",
+//                "/1.0/network-acls/bar"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/network-acls?recursion=1 network-acls network_acls_get_recursion1
 //
-// Get the network ACLs
+//	Get the network ACLs
 //
-// Returns a list of network ACLs (structs).
+//	Returns a list of network ACLs (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of network ACLs
-//           items:
-//             $ref: "#/definitions/NetworkACL"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of network ACLs
+//	          items:
+//	            $ref: "#/definitions/NetworkACL"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -180,36 +180,36 @@ func networkACLsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/network-acls network-acls network_acls_post
 //
-// Add a network ACL
+//	Add a network ACL
 //
-// Creates a new network ACL.
+//	Creates a new network ACL.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: acl
-//     description: ACL
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkACLsPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: acl
+//	    description: ACL
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkACLsPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkACLsPost(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -247,28 +247,28 @@ func networkACLsPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/network-acls/{name} network-acls network_acl_delete
 //
-// Delete the network ACL
+//	Delete the network ACL
 //
-// Removes the network ACL.
+//	Removes the network ACL.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkACLDelete(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -297,44 +297,44 @@ func networkACLDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/network-acls/{name} network-acls network_acl_get
 //
-// Get the network ACL
+//	Get the network ACL
 //
-// Gets a specific network ACL.
+//	Gets a specific network ACL.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: ACL
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/NetworkACL"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: ACL
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkACL"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkACLGet(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -362,73 +362,73 @@ func networkACLGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/network-acls/{name} network-acls network_acl_patch
 //
-// Partially update the network ACL
+//  Partially update the network ACL
 //
-// Updates a subset of the network ACL configuration.
+//  Updates a subset of the network ACL configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: acl
-//     description: ACL configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkACLPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: body
+//      name: acl
+//      description: ACL configuration
+//      required: true
+//      schema:
+//        $ref: "#/definitions/NetworkACLPut"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "412":
+//      $ref: "#/responses/PreconditionFailed"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation PUT /1.0/network-acls/{name} network-acls network_acl_put
 //
-// Update the network ACL
+//	Update the network ACL
 //
-// Updates the entire network ACL configuration.
+//	Updates the entire network ACL configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: acl
-//     description: ACL configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkACLPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: acl
+//	    description: ACL configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkACLPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkACLPut(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -485,36 +485,36 @@ func networkACLPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/network-acls/{name} network-acls network_acl_post
 //
-// Rename the network ACL
+//	Rename the network ACL
 //
-// Renames an existing network ACL.
+//	Renames an existing network ACL.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: acl
-//     description: ACL rename request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkACLPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: acl
+//	    description: ACL rename request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkACLPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkACLPost(d *Daemon, r *http.Request) response.Response {
 	aclName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
@@ -553,31 +553,31 @@ func networkACLPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/network-acls/{name}/log network-acls network_acl_log_get
 //
-// Get the network ACL log
+//	Get the network ACL log
 //
-// Gets a specific network ACL log entries.
+//	Gets a specific network ACL log entries.
 //
-// ---
-// produces:
-//   - application/octet-stream
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//      description: Raw log file
-//      content:
-//        application/octet-stream:
-//          schema:
-//            type: string
-//            example: LOG-ENTRY
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/octet-stream
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	     description: Raw log file
+//	     content:
+//	       application/octet-stream:
+//	         schema:
+//	           type: string
+//	           example: LOG-ENTRY
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkACLLogGet(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {

--- a/lxd/network_forwards.go
+++ b/lxd/network_forwards.go
@@ -39,96 +39,96 @@ var networkForwardCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/networks/{networkName}/forwards network-forwards network_forwards_get
 //
-// Get the network address forwards
+//  Get the network address forwards
 //
-// Returns a list of network address forwards (URLs).
+//  Returns a list of network address forwards (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/networks/lxdbr0/forwards/192.0.2.1",
-//               "/1.0/networks/lxdbr0/forwards/192.0.2.2"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/networks/lxdbr0/forwards/192.0.2.1",
+//                "/1.0/networks/lxdbr0/forwards/192.0.2.2"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/networks/{networkName}/forwards?recursion=1 network-forwards network_forward_get_recursion1
 //
-// Get the network address forwards
+//	Get the network address forwards
 //
-// Returns a list of network address forwards (structs).
+//	Returns a list of network address forwards (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of network address forwards
-//           items:
-//             $ref: "#/definitions/NetworkForward"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of network address forwards
+//	          items:
+//	            $ref: "#/definitions/NetworkForward"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkForwardsGet(d *Daemon, r *http.Request) response.Response {
 	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -185,36 +185,36 @@ func networkForwardsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/networks/{networkName}/forwards network-forwards network_forwards_post
 //
-// Add a network address forward
+//	Add a network address forward
 //
-// Creates a new network address forward.
+//	Creates a new network address forward.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: forward
-//     description: Forward
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkForwardsPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: forward
+//	    description: Forward
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkForwardsPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -271,28 +271,28 @@ func networkForwardsPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/networks/{networkName}/forwards/{listenAddress} network-forwards network_forward_delete
 //
-// Delete the network address forward
+//	Delete the network address forward
 //
-// Removes the network address forward.
+//	Removes the network address forward.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -344,44 +344,44 @@ func networkForwardDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/networks/{networkName}/forwards/{listenAddress} network-forwards network_forward_get
 //
-// Get the network address forward
+//	Get the network address forward
 //
-// Gets a specific network address forward.
+//	Gets a specific network address forward.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Address forward
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/NetworkForward"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Address forward
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkForward"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkForwardGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -432,73 +432,73 @@ func networkForwardGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/networks/{networkName}/forwards/{listenAddress} network-forwards network_forward_patch
 //
-// Partially update the network address forward
+//  Partially update the network address forward
 //
-// Updates a subset of the network address forward configuration.
+//  Updates a subset of the network address forward configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: forward
-//     description: Address forward configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkForwardPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: body
+//      name: forward
+//      description: Address forward configuration
+//      required: true
+//      schema:
+//        $ref: "#/definitions/NetworkForwardPut"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "412":
+//      $ref: "#/responses/PreconditionFailed"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation PUT /1.0/networks/{networkName}/forwards/{listenAddress} network-forwards network_forward_put
 //
-// Update the network address forward
+//	Update the network address forward
 //
-// Updates the entire network address forward configuration.
+//	Updates the entire network address forward configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: forward
-//     description: Address forward configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkForwardPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: forward
+//	    description: Address forward configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkForwardPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkForwardPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/network_load_balancers.go
+++ b/lxd/network_load_balancers.go
@@ -39,96 +39,96 @@ var networkLoadBalancerCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/networks/{networkName}/load-balancers network-load-balancers network_load_balancers_get
 //
-// Get the network address of load balancers
+//  Get the network address of load balancers
 //
-// Returns a list of network address load balancers (URLs).
+//  Returns a list of network address load balancers (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/networks/lxdbr0/load-balancers/192.0.2.1",
-//               "/1.0/networks/lxdbr0/load-balancers/192.0.2.2"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/networks/lxdbr0/load-balancers/192.0.2.1",
+//                "/1.0/networks/lxdbr0/load-balancers/192.0.2.2"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/networks/{networkName}/load-balancers?recursion=1 network-load-balancers network_load_balancer_get_recursion1
 //
-// Get the network address load balancers
+//	Get the network address load balancers
 //
-// Returns a list of network address load balancers (structs).
+//	Returns a list of network address load balancers (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of network address load balancers
-//           items:
-//             $ref: "#/definitions/NetworkLoadBalancer"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of network address load balancers
+//	          items:
+//	            $ref: "#/definitions/NetworkLoadBalancer"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkLoadBalancersGet(d *Daemon, r *http.Request) response.Response {
 	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -186,36 +186,36 @@ func networkLoadBalancersGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/networks/{networkName}/load-balancers network-load-balancers network_load_balancers_post
 //
-// Add a network load balancer
+//	Add a network load balancer
 //
-// Creates a new network load balancer.
+//	Creates a new network load balancer.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: load-balancer
-//     description: Load Balancer
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkLoadBalancersPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: load-balancer
+//	    description: Load Balancer
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkLoadBalancersPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkLoadBalancersPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -272,28 +272,28 @@ func networkLoadBalancersPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/networks/{networkName}/load-balancers/{listenAddress} network-load-balancers network_load_balancer_delete
 //
-// Delete the network address load balancer
+//	Delete the network address load balancer
 //
-// Removes the network address load balancer.
+//	Removes the network address load balancer.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -345,44 +345,44 @@ func networkLoadBalancerDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/networks/{networkName}/load-balancers/{listenAddress} network-load-balancers network_load_balancer_get
 //
-// Get the network address load balancer
+//	Get the network address load balancer
 //
-// Gets a specific network address load balancer.
+//	Gets a specific network address load balancer.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Load Balancer
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/NetworkLoadBalancer"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Load Balancer
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkLoadBalancer"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkLoadBalancerGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -433,73 +433,73 @@ func networkLoadBalancerGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/networks/{networkName}/load-balancers/{listenAddress} network-load-balancers network_load_balancer_patch
 //
-// Partially update the network address load balancer
+//  Partially update the network address load balancer
 //
-// Updates a subset of the network address load balancer configuration.
+//  Updates a subset of the network address load balancer configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: load-balancer
-//     description: Address load balancer configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkLoadBalancerPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: body
+//      name: load-balancer
+//      description: Address load balancer configuration
+//      required: true
+//      schema:
+//        $ref: "#/definitions/NetworkLoadBalancerPut"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "412":
+//      $ref: "#/responses/PreconditionFailed"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation PUT /1.0/networks/{networkName}/load-balancers/{listenAddress} network-load-balancers network_load_balancer_put
 //
-// Update the network address load balancer
+//	Update the network address load balancer
 //
-// Updates the entire network address load balancer configuration.
+//	Updates the entire network address load balancer configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: load-balancer
-//     description: Address load balancer configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkLoadBalancerPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: load-balancer
+//	    description: Address load balancer configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkLoadBalancerPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkLoadBalancerPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/network_peer.go
+++ b/lxd/network_peer.go
@@ -38,96 +38,96 @@ var networkPeerCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/networks/{networkName}/peers network-peers network_peers_get
 //
-// Get the network peers
+//  Get the network peers
 //
-// Returns a list of network peers (URLs).
+//  Returns a list of network peers (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/networks/lxdbr0/peers/my-peer-1",
-//               "/1.0/networks/lxdbr0/peers/my-peer-2"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/networks/lxdbr0/peers/my-peer-1",
+//                "/1.0/networks/lxdbr0/peers/my-peer-2"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/networks/{networkName}/peers?recursion=1 network-peers network_peer_get_recursion1
 //
-// Get the network peers
+//	Get the network peers
 //
-// Returns a list of network peers (structs).
+//	Returns a list of network peers (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of network peers
-//           items:
-//             $ref: "#/definitions/NetworkPeer"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of network peers
+//	          items:
+//	            $ref: "#/definitions/NetworkPeer"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -183,38 +183,38 @@ func networkPeersGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/networks/{networkName}/peers network-peers network_peers_post
 //
-// Add a network peer
+//	Add a network peer
 //
-// Initiates/creates a new network peering.
+//	Initiates/creates a new network peering.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: peer
-//     description: Peer
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkPeersPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "202":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: peer
+//	    description: Peer
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkPeersPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -267,28 +267,28 @@ func networkPeersPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/networks/{networkName}/peers/{peerName} network-peers network_peer_delete
 //
-// Delete the network peer
+//	Delete the network peer
 //
-// Removes the network peering.
+//	Removes the network peering.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -338,44 +338,44 @@ func networkPeerDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/networks/{networkName}/peers/{peerName} network-peers network_peer_get
 //
-// Get the network peer
+//	Get the network peer
 //
-// Gets a specific network peering.
+//	Gets a specific network peering.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Peer
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/NetworkPeer"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Peer
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkPeer"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -425,73 +425,73 @@ func networkPeerGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/networks/{networkName}/peers/{peerName} network-peers network_peer_patch
 //
-// Partially update the network peer
+//  Partially update the network peer
 //
-// Updates a subset of the network peering configuration.
+//  Updates a subset of the network peering configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: Peer
-//     description: Peer configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkPeerPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: body
+//      name: Peer
+//      description: Peer configuration
+//      required: true
+//      schema:
+//        $ref: "#/definitions/NetworkPeerPut"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "412":
+//      $ref: "#/responses/PreconditionFailed"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation PUT /1.0/networks/{networkName}/peers/{peerName} network-peers network_peer_put
 //
-// Update the network peer
+//	Update the network peer
 //
-// Updates the entire network peering configuration.
+//	Updates the entire network peering configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: peer
-//     description: Peer configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkPeerPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: peer
+//	    description: Peer configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkPeerPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPeerPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/network_zones.go
+++ b/lxd/network_zones.go
@@ -39,96 +39,96 @@ var networkZoneCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/network-zones network-zones network_zones_get
 //
-// Get the network zones
+//  Get the network zones
 //
-// Returns a list of network zones (URLs).
+//  Returns a list of network zones (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/network-zones/example.net",
-//               "/1.0/network-zones/example.com"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/network-zones/example.net",
+//                "/1.0/network-zones/example.com"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/network-zones?recursion=1 network-zones network_zones_get_recursion1
 //
-// Get the network zones
+//	Get the network zones
 //
-// Returns a list of network zones (structs).
+//	Returns a list of network zones (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of network zones
-//           items:
-//             $ref: "#/definitions/NetworkZone"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of network zones
+//	          items:
+//	            $ref: "#/definitions/NetworkZone"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -170,36 +170,36 @@ func networkZonesGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/network-zones network-zones network_zones_post
 //
-// Add a network zone
+//	Add a network zone
 //
-// Creates a new network zone.
+//	Creates a new network zone.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: zone
-//     description: zone
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkZonesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: zone
+//	    description: zone
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkZonesPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZonesPost(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -238,28 +238,28 @@ func networkZonesPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/network-zones/{name} network-zones network_zone_delete
 //
-// Delete the network zone
+//	Delete the network zone
 //
-// Removes the network zone.
+//	Removes the network zone.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -288,44 +288,44 @@ func networkZoneDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/network-zones/{name} network-zones network_zone_get
 //
-// Get the network zone
+//	Get the network zone
 //
-// Gets a specific network zone.
+//	Gets a specific network zone.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: zone
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/NetworkZone"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: zone
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkZone"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -353,73 +353,73 @@ func networkZoneGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/network-zones/{name} network-zones network_zone_patch
 //
-// Partially update the network zone
+//  Partially update the network zone
 //
-// Updates a subset of the network zone configuration.
+//  Updates a subset of the network zone configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: zone
-//     description: zone configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkZonePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: body
+//      name: zone
+//      description: zone configuration
+//      required: true
+//      schema:
+//        $ref: "#/definitions/NetworkZonePut"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "412":
+//      $ref: "#/responses/PreconditionFailed"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation PUT /1.0/network-zones/{name} network-zones network_zone_put
 //
-// Update the network zone
+//	Update the network zone
 //
-// Updates the entire network zone configuration.
+//	Updates the entire network zone configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: zone
-//     description: zone configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkZonePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: zone
+//	    description: zone configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkZonePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZonePut(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {

--- a/lxd/network_zones_records.go
+++ b/lxd/network_zones_records.go
@@ -38,96 +38,96 @@ var networkZoneRecordCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/network-zones/{zone}/records network-zones network_zone_records_get
 //
-// Get the network zone records
+//  Get the network zone records
 //
-// Returns a list of network zone records (URLs).
+//  Returns a list of network zone records (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/network-zones/example.net/records/foo",
-//               "/1.0/network-zones/example.net/records/bar"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/network-zones/example.net/records/foo",
+//                "/1.0/network-zones/example.net/records/bar"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/network-zones/{zone}/records?recursion=1 network-zones network_zone_records_get_recursion1
 //
-// Get the network zone records
+//	Get the network zone records
 //
-// Returns a list of network zone records (structs).
+//	Returns a list of network zone records (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of network zone records
-//           items:
-//             $ref: "#/definitions/NetworkZoneRecord"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of network zone records
+//	          items:
+//	            $ref: "#/definitions/NetworkZoneRecord"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZoneRecordsGet(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -172,36 +172,36 @@ func networkZoneRecordsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/network-zones/{zone}/records network-zones network_zone_records_post
 //
-// Add a network zone record
+//	Add a network zone record
 //
-// Creates a new network zone record.
+//	Creates a new network zone record.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: zone
-//     description: zone
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkZoneRecordsPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: zone
+//	    description: zone
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkZoneRecordsPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZoneRecordsPost(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -240,28 +240,28 @@ func networkZoneRecordsPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/network-zones/{zone}/records/{name} network-zones network_zone_record_delete
 //
-// Delete the network zone record
+//	Delete the network zone record
 //
-// Removes the network zone record.
+//	Removes the network zone record.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZoneRecordDelete(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -297,44 +297,44 @@ func networkZoneRecordDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/network-zones/{zone}/records/{name} network-zones network_zone_record_get
 //
-// Get the network zone record
+//	Get the network zone record
 //
-// Gets a specific network zone record.
+//	Gets a specific network zone record.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: zone
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/NetworkZoneRecord"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: zone
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkZoneRecord"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZoneRecordGet(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -368,73 +368,73 @@ func networkZoneRecordGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/network-zones/{zone}/records/{name} network-zones network_zone_record_patch
 //
-// Partially update the network zone record
+//  Partially update the network zone record
 //
-// Updates a subset of the network zone record configuration.
+//  Updates a subset of the network zone record configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: zone
-//     description: zone record configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkZoneRecordPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: body
+//      name: zone
+//      description: zone record configuration
+//      required: true
+//      schema:
+//        $ref: "#/definitions/NetworkZoneRecordPut"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "412":
+//      $ref: "#/responses/PreconditionFailed"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation PUT /1.0/network-zones/{zone}/records/{name} network-zones network_zone_record_put
 //
-// Update the network zone record
+//	Update the network zone record
 //
-// Updates the entire network zone record configuration.
+//	Updates the entire network zone record configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: zone
-//     description: zone record configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkZoneRecordPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: zone
+//	    description: zone record configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkZoneRecordPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkZoneRecordPut(d *Daemon, r *http.Request) response.Response {
 	projectName, _, err := project.NetworkZoneProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -77,96 +77,96 @@ var networkStateCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/networks networks networks_get
 //
-// Get the networks
+//  Get the networks
 //
-// Returns a list of networks (URLs).
+//  Returns a list of networks (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/networks/lxdbr0",
-//               "/1.0/networks/lxdbr1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/networks/lxdbr0",
+//                "/1.0/networks/lxdbr1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/networks?recursion=1 networks networks_get_recursion1
 //
-// Get the networks
+//	Get the networks
 //
-// Returns a list of networks (structs).
+//	Returns a list of networks (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of networks
-//           items:
-//             $ref: "#/definitions/Network"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of networks
+//	          items:
+//	            $ref: "#/definitions/Network"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networksGet(d *Daemon, r *http.Request) response.Response {
 	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -230,42 +230,42 @@ func networksGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/networks networks networks_post
 //
-// Add a network
+//	Add a network
 //
-// Creates a new network.
-// When clustered, most network types require individual POST for each cluster member prior to a global POST.
+//	Creates a new network.
+//	When clustered, most network types require individual POST for each cluster member prior to a global POST.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: network
-//     description: Network
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworksPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: network
+//	    description: Network
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworksPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networksPost(d *Daemon, r *http.Request) response.Response {
 	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -706,49 +706,49 @@ func doNetworksCreate(d *Daemon, n network.Network, clientType clusterRequest.Cl
 
 // swagger:operation GET /1.0/networks/{name} networks network_get
 //
-// Get the network
+//	Get the network
 //
-// Gets a specific network.
+//	Gets a specific network.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Network
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Network"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Network
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Network"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -893,28 +893,28 @@ func doNetworkGet(d *Daemon, r *http.Request, allNodes bool, projectName string,
 
 // swagger:operation DELETE /1.0/networks/{name} networks network_delete
 //
-// Delete the network
+//	Delete the network
 //
-// Removes the network.
+//	Removes the network.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkDelete(d *Daemon, r *http.Request) response.Response {
 	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -1001,36 +1001,36 @@ func networkDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/networks/{name} networks network_post
 //
-// Rename the network
+//	Rename the network
 //
-// Renames an existing network.
+//	Renames an existing network.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: network
-//     description: Network rename request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: network
+//	    description: Network rename request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPost(d *Daemon, r *http.Request) response.Response {
 	// FIXME: renaming a network is currently not supported in clustering
 	//        mode. The difficulty is that network.Start() depends on the
@@ -1127,43 +1127,43 @@ func networkPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/networks/{name} networks network_put
 //
-// Update the network
+//	Update the network
 //
-// Updates the entire network configuration.
+//	Updates the entire network configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: network
-//     description: Network configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: network
+//	    description: Network configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1264,43 +1264,43 @@ func networkPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/networks/{name} networks network_patch
 //
-// Partially update the network
+//	Partially update the network
 //
-// Updates a subset of the network configuration.
+//	Updates a subset of the network configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: network
-//     description: Network configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/NetworkPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: network
+//	    description: Network configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/NetworkPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkPatch(d *Daemon, r *http.Request) response.Response {
 	return networkPut(d, r)
 }
@@ -1351,52 +1351,52 @@ func doNetworkUpdate(d *Daemon, projectName string, n network.Network, req api.N
 
 // swagger:operation GET /1.0/networks/{name}/leases networks networks_leases_get
 //
-// Get the DHCP leases
+//	Get the DHCP leases
 //
-// Returns a list of DHCP leases for the network.
+//	Returns a list of DHCP leases for the network.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of DHCP leases
-//           items:
-//             $ref: "#/definitions/NetworkLease"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of DHCP leases
+//	          items:
+//	            $ref: "#/definitions/NetworkLease"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkLeasesGet(d *Daemon, r *http.Request) response.Response {
 	projectName, reqProject, err := project.NetworkProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -1716,49 +1716,49 @@ func networkRestartOVN(s *state.State) error {
 
 // swagger:operation GET /1.0/networks/{name}/state networks networks_state_get
 //
-// Get the network state
+//	Get the network state
 //
-// Returns the current network state information.
+//	Returns the current network state information.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/NetworkState"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/NetworkState"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func networkStateGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/node/raft.go
+++ b/lxd/node/raft.go
@@ -16,19 +16,19 @@ import (
 //
 // The following rules are applied:
 //
-// - If no cluster.https_address config key is set, this is a non-clustered node
-//   and the returned RaftNode will have ID 1 but no address, to signal that
-//   the node should setup an in-memory raft cluster where the node itself
-//   is the only member and leader.
+//   - If no cluster.https_address config key is set, this is a non-clustered node
+//     and the returned RaftNode will have ID 1 but no address, to signal that
+//     the node should setup an in-memory raft cluster where the node itself
+//     is the only member and leader.
 //
-// - If cluster.https_address config key is set, but there is no row in the
-//   raft_nodes table, this is a brand new clustered node that is joining a
-//   cluster, and same behavior as the previous case applies.
+//   - If cluster.https_address config key is set, but there is no row in the
+//     raft_nodes table, this is a brand new clustered node that is joining a
+//     cluster, and same behavior as the previous case applies.
 //
-// - If cluster.https_address config key is set and there is at least one row
-//   in the raft_nodes table, then this node is considered a raft node if
-//   cluster.https_address matches one of the rows in raft_nodes. In that case,
-//   the matching db.RaftNode row is returned, otherwise nil.
+//   - If cluster.https_address config key is set and there is at least one row
+//     in the raft_nodes table, then this node is considered a raft node if
+//     cluster.https_address matches one of the rows in raft_nodes. In that case,
+//     the matching db.RaftNode row is returned, otherwise nil.
 func DetermineRaftNode(ctx context.Context, tx *db.NodeTx) (*db.RaftNode, error) {
 	config, err := ConfigLoad(ctx, tx)
 	if err != nil {

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -135,38 +135,38 @@ func waitForOperations(ctx context.Context, cluster *db.Cluster, consoleShutdown
 
 // swagger:operation GET /1.0/operations/{id} operations operation_get
 //
-// Get the operation state
+//	Get the operation state
 //
-// Gets the operation state.
+//	Gets the operation state.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Operation
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Operation"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Operation
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Operation"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func operationGet(d *Daemon, r *http.Request) response.Response {
 	id, err := url.PathUnescape(mux.Vars(r)["id"])
 	if err != nil {
@@ -222,22 +222,22 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/operations/{id} operations operation_delete
 //
-// Cancel the operation
+//	Cancel the operation
 //
-// Cancels the operation if supported.
+//	Cancels the operation if supported.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func operationDelete(d *Daemon, r *http.Request) response.Response {
 	id, err := url.PathUnescape(mux.Vars(r)["id"])
 	if err != nil {
@@ -361,87 +361,87 @@ func operationCancel(d *Daemon, r *http.Request, projectName string, op *api.Ope
 
 // swagger:operation GET /1.0/operations operations operations_get
 //
-// Get the operations
+//  Get the operations
 //
-// Returns a dict of operation type to operation list (URLs).
+//  Returns a dict of operation type to operation list (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: object
-//           additionalProperties:
-//             type: array
-//             items:
-//               type: string
-//           description: Dict of operation types to operation URLs
-//           example: |-
-//             {
-//               "running": [
-//                 "/1.0/operations/6916c8a6-9b7d-4abd-90b3-aedfec7ec7da"
-//               ]
-//             }
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: object
+//            additionalProperties:
+//              type: array
+//              items:
+//                type: string
+//            description: Dict of operation types to operation URLs
+//            example: |-
+//              {
+//                "running": [
+//                  "/1.0/operations/6916c8a6-9b7d-4abd-90b3-aedfec7ec7da"
+//                ]
+//              }
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/operations?recursion=1 operations operations_get_recursion1
 //
-// Get the operations
+//	Get the operations
 //
-// Returns a list of operations (structs).
+//	Returns a list of operations (structs).
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of operations
-//           items:
-//             $ref: "#/definitions/Operation"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of operations
+//	          items:
+//	            $ref: "#/definitions/Operation"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func operationsGet(d *Daemon, r *http.Request) response.Response {
 	projectName := projectParam(r)
 	recursion := util.IsRecursionRequest(r)
@@ -759,92 +759,92 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 
 // swagger:operation GET /1.0/operations/{id}/wait?public operations operation_wait_get_untrusted
 //
-// Wait for the operation
+//  Wait for the operation
 //
-// Waits for the operation to reach a final state (or timeout) and retrieve its final state.
+//  Waits for the operation to reach a final state (or timeout) and retrieve its final state.
 //
-// When accessed by an untrusted user, the secret token must be provided.
+//  When accessed by an untrusted user, the secret token must be provided.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: secret
-//     description: Authentication token
-//     type: string
-//     example: random-string
-//   - in: query
-//     name: timeout
-//     description: Timeout in seconds (-1 means never)
-//     type: integer
-//     example: -1
-// responses:
-//   "200":
-//     description: Operation
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Operation"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: secret
+//      description: Authentication token
+//      type: string
+//      example: random-string
+//    - in: query
+//      name: timeout
+//      description: Timeout in seconds (-1 means never)
+//      type: integer
+//      example: -1
+//  responses:
+//    "200":
+//      description: Operation
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            $ref: "#/definitions/Operation"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/operations/{id}/wait operations operation_wait_get
 //
-// Wait for the operation
+//	Wait for the operation
 //
-// Waits for the operation to reach a final state (or timeout) and retrieve its final state.
+//	Waits for the operation to reach a final state (or timeout) and retrieve its final state.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: timeout
-//     description: Timeout in seconds (-1 means never)
-//     type: integer
-//     example: -1
-// responses:
-//   "200":
-//     description: Operation
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Operation"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: timeout
+//	    description: Timeout in seconds (-1 means never)
+//	    type: integer
+//	    example: -1
+//	responses:
+//	  "200":
+//	    description: Operation
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Operation"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 	id, err := url.PathUnescape(mux.Vars(r)["id"])
 	if err != nil {
@@ -955,58 +955,58 @@ func (r *operationWebSocket) String() string {
 
 // swagger:operation GET /1.0/operations/{id}/websocket?public operations operation_websocket_get_untrusted
 //
-// Get the websocket stream
+//  Get the websocket stream
 //
-// Connects to an associated websocket stream for the operation.
-// This should almost never be done directly by a client, instead it's
-// meant for LXD to LXD communication with the client only relaying the
-// connection information to the servers.
+//  Connects to an associated websocket stream for the operation.
+//  This should almost never be done directly by a client, instead it's
+//  meant for LXD to LXD communication with the client only relaying the
+//  connection information to the servers.
 //
-// The untrusted endpoint is used by the target server to connect to the source server.
-// Authentication is performed through the secret token.
+//  The untrusted endpoint is used by the target server to connect to the source server.
+//  Authentication is performed through the secret token.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: secret
-//     description: Authentication token
-//     type: string
-//     example: random-string
-// responses:
-//   "200":
-//     description: Websocket operation messages (dependent on operation)
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: secret
+//      description: Authentication token
+//      type: string
+//      example: random-string
+//  responses:
+//    "200":
+//      description: Websocket operation messages (dependent on operation)
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/operations/{id}/websocket operations operation_websocket_get
 //
-// Get the websocket stream
+//	Get the websocket stream
 //
-// Connects to an associated websocket stream for the operation.
-// This should almost never be done directly by a client, instead it's
-// meant for LXD to LXD communication with the client only relaying the
-// connection information to the servers.
+//	Connects to an associated websocket stream for the operation.
+//	This should almost never be done directly by a client, instead it's
+//	meant for LXD to LXD communication with the client only relaying the
+//	connection information to the servers.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: secret
-//     description: Authentication token
-//     type: string
-//     example: random-string
-// responses:
-//   "200":
-//     description: Websocket operation messages (dependent on operation)
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: secret
+//	    description: Authentication token
+//	    type: string
+//	    example: random-string
+//	responses:
+//	  "200":
+//	    description: Websocket operation messages (dependent on operation)
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 	id, err := url.PathUnescape(mux.Vars(r)["id"])
 	if err != nil {

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -36,21 +36,23 @@ const (
 	patchPostNetworks
 )
 
-/* Patches are one-time actions that are sometimes needed to update
-   existing container configuration or move things around on the
-   filesystem.
+/*
+Patches are one-time actions that are sometimes needed to update
 
-   Those patches are applied at startup time after the database schema
-   has been fully updated. Patches can therefore assume a working database.
+	existing container configuration or move things around on the
+	filesystem.
 
-   At the time the patches are applied, the containers aren't started
-   yet and the daemon isn't listening to requests.
+	Those patches are applied at startup time after the database schema
+	has been fully updated. Patches can therefore assume a working database.
 
-   DO NOT use this mechanism for database update. Schema updates must be
-   done through the separate schema update mechanism.
+	At the time the patches are applied, the containers aren't started
+	yet and the daemon isn't listening to requests.
+
+	DO NOT use this mechanism for database update. Schema updates must be
+	done through the separate schema update mechanism.
 
 
-   Only append to the patches list, never remove entries and never re-order them.
+	Only append to the patches list, never remove entries and never re-order them.
 */
 var patches = []patch{
 	{name: "storage_lvm_skipactivation", stage: patchPostDaemonStorage, run: patchGenericStorage},

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -50,96 +50,96 @@ var profileCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/profiles profiles profiles_get
 //
-// Get the profiles
+//  Get the profiles
 //
-// Returns a list of profiles (URLs).
+//  Returns a list of profiles (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/profiles/default",
-//               "/1.0/profiles/foo"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/profiles/default",
+//                "/1.0/profiles/foo"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/profiles?recursion=1 profiles profiles_get_recursion1
 //
-// Get the profiles
+//	Get the profiles
 //
-// Returns a list of profiles (structs).
+//	Returns a list of profiles (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of profiles
-//           items:
-//             $ref: "#/definitions/Profile"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of profiles
+//	          items:
+//	            $ref: "#/definitions/Profile"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func profilesGet(d *Daemon, r *http.Request) response.Response {
 	p, err := project.ProfileProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -212,36 +212,36 @@ func profileUsedBy(ctx context.Context, tx *db.ClusterTx, profile dbCluster.Prof
 
 // swagger:operation POST /1.0/profiles profiles profiles_post
 //
-// Add a profile
+//	Add a profile
 //
-// Creates a new profile.
+//	Creates a new profile.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: profile
-//     description: Profile
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProfilesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: profile
+//	    description: Profile
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProfilesPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func profilesPost(d *Daemon, r *http.Request) response.Response {
 	p, err := project.ProfileProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -326,44 +326,44 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/profiles/{name} profiles profile_get
 //
-// Get the profile
+//	Get the profile
 //
-// Gets a specific profile.
+//	Gets a specific profile.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Profile
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Profile"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Profile
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Profile"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func profileGet(d *Daemon, r *http.Request) response.Response {
 	p, err := project.ProfileProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -407,38 +407,38 @@ func profileGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/profiles/{name} profiles profile_put
 //
-// Update the profile
+//	Update the profile
 //
-// Updates the entire profile configuration.
+//	Updates the entire profile configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: profile
-//     description: Profile configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProfilePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: profile
+//	    description: Profile configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProfilePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func profilePut(d *Daemon, r *http.Request) response.Response {
 	p, err := project.ProfileProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -523,38 +523,38 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/profiles/{name} profiles profile_patch
 //
-// Partially update the profile
+//	Partially update the profile
 //
-// Updates a subset of the profile configuration.
+//	Updates a subset of the profile configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: profile
-//     description: Profile configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProfilePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: profile
+//	    description: Profile configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProfilePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func profilePatch(d *Daemon, r *http.Request) response.Response {
 	p, err := project.ProfileProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -653,36 +653,36 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/profiles/{name} profiles profile_post
 //
-// Rename the profile
+//	Rename the profile
 //
-// Renames an existing profile.
+//	Renames an existing profile.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: profile
-//     description: Profile rename request
-//     required: true
-//     schema:
-//       $ref: "#/definitions/ProfilePost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: profile
+//	    description: Profile rename request
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/ProfilePost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func profilePost(d *Daemon, r *http.Request) response.Response {
 	p, err := project.ProfileProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -739,28 +739,28 @@ func profilePost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/profiles/{name} profiles profile_delete
 //
-// Delete the profile
+//	Delete the profile
 //
-// Removes the profile.
+//	Removes the profile.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func profileDelete(d *Daemon, r *http.Request) response.Response {
 	p, err := project.ProfileProject(d.State().DB.Cluster, projectParam(r))
 	if err != nil {

--- a/lxd/resources.go
+++ b/lxd/resources.go
@@ -26,44 +26,44 @@ var storagePoolResourcesCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/resources server resources_get
 //
-// Get system resources information
+//	Get system resources information
 //
-// Gets the hardware information profile of the LXD server.
+//	Gets the hardware information profile of the LXD server.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Hardware resources
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Resources"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Hardware resources
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Resources"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func api10ResourcesGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -84,44 +84,44 @@ func api10ResourcesGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/storage-pools/{name}/resources storage storage_pool_resources
 //
-// Get storage pool resources information
+//	Get storage pool resources information
 //
-// Gets the usage information for the storage pool.
+//	Gets the usage information for the storage pool.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Hardware resources
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/ResourcesStoragePool"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Hardware resources
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/ResourcesStoragePool"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolResourcesGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/storage/drivers/driver_ceph_utils.go
+++ b/lxd/storage/drivers/driver_ceph_utils.go
@@ -58,12 +58,12 @@ func (d *ceph) osdPoolExists() bool {
 }
 
 // osdDeletePool destroys an OSD pool.
-// - A call to osdDeletePool will destroy a pool including any storage
-//   volumes that still exist in the pool.
-// - In case the OSD pool that is supposed to be deleted does not exist this
-//   command will still exit 0. This means that if the caller wants to be sure
-//   that this call actually deleted an OSD pool it needs to check for the
-//   existence of the pool first.
+//   - A call to osdDeletePool will destroy a pool including any storage
+//     volumes that still exist in the pool.
+//   - In case the OSD pool that is supposed to be deleted does not exist this
+//     command will still exit 0. This means that if the caller wants to be sure
+//     that this call actually deleted an OSD pool it needs to check for the
+//     existence of the pool first.
 func (d *ceph) osdDeletePool() error {
 	_, err := shared.RunCommand(
 		"ceph",
@@ -122,10 +122,10 @@ func (d *ceph) rbdCreateVolume(vol Volume, size string) error {
 }
 
 // rbdDeleteVolume deletes an RBD storage volume.
-// - In case the RBD storage volume that is supposed to be deleted does not
-//   exist this command will still exit 0. This means that if the caller wants
-//   to be sure that this call actually deleted an RBD storage volume it needs
-//   to check for the existence of the pool first.
+//   - In case the RBD storage volume that is supposed to be deleted does not
+//     exist this command will still exit 0. This means that if the caller wants
+//     to be sure that this call actually deleted an RBD storage volume it needs
+//     to check for the existence of the pool first.
 func (d *ceph) rbdDeleteVolume(vol Volume) error {
 	_, err := shared.RunCommand(
 		"rbd",
@@ -468,12 +468,12 @@ func (d *ceph) rbdRenameVolumeSnapshot(vol Volume, oldSnapshotName string, newSn
 }
 
 // rbdGetVolumeParent will return the snapshot the RBD clone was created from:
-// - If the RBD storage volume is not a clone then this function will return
-//   db.NoSuchObjectError.
-// - The snapshot will be returned as
-//   <osd-pool-name>/<rbd-volume-name>@<rbd-snapshot-name>
-//   The caller will usually want to parse this according to its needs. This
-//   helper library provides two small functions to do this but see below.
+//   - If the RBD storage volume is not a clone then this function will return
+//     db.NoSuchObjectError.
+//   - The snapshot will be returned as
+//     <osd-pool-name>/<rbd-volume-name>@<rbd-snapshot-name>
+//     The caller will usually want to parse this according to its needs. This
+//     helper library provides two small functions to do this but see below.
 func (d *ceph) rbdGetVolumeParent(vol Volume) (string, error) {
 	msg, err := shared.RunCommand(
 		"rbd",
@@ -623,22 +623,22 @@ func (d *ceph) copyWithSnapshots(sourceVolumeName string, targetVolumeName strin
 }
 
 // deleteVolume deletes the RBD storage volume of a container including any dependencies.
-// - This function takes care to delete any RBD storage entities that are marked
-//   as zombie and whose existence is solely dependent on the RBD storage volume
-//   for the container to be deleted.
-// - This function will mark any storage entities of the container to be deleted
-//   as zombies in case any RBD storage entities in the storage pool have a
-//   dependency relation with it.
-// - This function uses a C-style convention to return error or success simply
-//   because it is more elegant and simple than the go way.
-//   The function will return
-//   -1 on error
-//    0 if the RBD storage volume has been deleted
-//    1 if the RBD storage volume has been marked as a zombie
-// - deleteVolume in conjunction with deleteVolumeSnapshot
-//   recurses through an OSD storage pool to find and delete any storage
-//   entities that were kept around because of dependency relations but are not
-//   deletable.
+//   - This function takes care to delete any RBD storage entities that are marked
+//     as zombie and whose existence is solely dependent on the RBD storage volume
+//     for the container to be deleted.
+//   - This function will mark any storage entities of the container to be deleted
+//     as zombies in case any RBD storage entities in the storage pool have a
+//     dependency relation with it.
+//   - This function uses a C-style convention to return error or success simply
+//     because it is more elegant and simple than the go way.
+//     The function will return
+//     -1 on error
+//     0 if the RBD storage volume has been deleted
+//     1 if the RBD storage volume has been marked as a zombie
+//   - deleteVolume in conjunction with deleteVolumeSnapshot
+//     recurses through an OSD storage pool to find and delete any storage
+//     entities that were kept around because of dependency relations but are not
+//     deletable.
 func (d *ceph) deleteVolume(vol Volume) (int, error) {
 	snaps, err := d.rbdListVolumeSnapshots(vol)
 	if err == nil {
@@ -733,22 +733,22 @@ func (d *ceph) deleteVolume(vol Volume) (int, error) {
 }
 
 // deleteVolumeSnapshot deletes an RBD snapshot of a container including any dependencies.
-// - This function takes care to delete any RBD storage entities that are marked
-//   as zombie and whose existence is solely dependent on the RBD snapshot for
-//   the container to be deleted.
-// - This function will mark any storage entities of the container to be deleted
-//   as zombies in case any RBD storage entities in the storage pool have a
-//   dependency relation with it.
-// - This function uses a C-style convention to return error or success simply
-//   because it is more elegant and simple than the go way.
-//   The function will return
-//   -1 on error
-//    0 if the RBD storage volume has been deleted
-//    1 if the RBD storage volume has been marked as a zombie
-// - deleteVolumeSnapshot in conjunction with deleteVolume
-//   recurses through an OSD storage pool to find and delete any storage
-//   entities that were kept around because of dependency relations but are not
-//   deletable.
+//   - This function takes care to delete any RBD storage entities that are marked
+//     as zombie and whose existence is solely dependent on the RBD snapshot for
+//     the container to be deleted.
+//   - This function will mark any storage entities of the container to be deleted
+//     as zombies in case any RBD storage entities in the storage pool have a
+//     dependency relation with it.
+//   - This function uses a C-style convention to return error or success simply
+//     because it is more elegant and simple than the go way.
+//     The function will return
+//     -1 on error
+//     0 if the RBD storage volume has been deleted
+//     1 if the RBD storage volume has been marked as a zombie
+//   - deleteVolumeSnapshot in conjunction with deleteVolume
+//     recurses through an OSD storage pool to find and delete any storage
+//     entities that were kept around because of dependency relations but are not
+//     deletable.
 func (d *ceph) deleteVolumeSnapshot(vol Volume, snapshotName string) (int, error) {
 	clones, err := d.rbdListSnapshotClones(vol, snapshotName)
 	if err != nil {

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -461,13 +461,15 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 // ImageUnpack unpacks a filesystem image into the destination path.
 // There are several formats that images can come in:
 // Container Format A: Separate metadata tarball and root squashfs file.
-// 	- Unpack metadata tarball into mountPath.
-//	- Unpack root squashfs file into mountPath/rootfs.
+//   - Unpack metadata tarball into mountPath.
+//   - Unpack root squashfs file into mountPath/rootfs.
+//
 // Container Format B: Combined tarball containing metadata files and root squashfs.
-//	- Unpack combined tarball into mountPath.
+//   - Unpack combined tarball into mountPath.
+//
 // VM Format A: Separate metadata tarball and root qcow2 file.
-// 	- Unpack metadata tarball into mountPath.
-//	- Check rootBlockPath is a file and convert qcow2 file into raw format in rootBlockPath.
+//   - Unpack metadata tarball into mountPath.
+//   - Check rootBlockPath is a file and convert qcow2 file into raw format in rootBlockPath.
 func ImageUnpack(imageFile string, vol drivers.Volume, destBlockFile string, blockBackend bool, sysOS *sys.OS, allowUnsafeResize bool, tracker *ioprogress.ProgressTracker) (int64, error) {
 	l := logger.AddContext(logger.Log, logger.Ctx{"imageFile": imageFile, "volName": vol.Name()})
 	l.Info("Image unpack started")

--- a/lxd/storage_buckets.go
+++ b/lxd/storage_buckets.go
@@ -57,96 +57,96 @@ var storagePoolBucketKeyCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/storage-pools/{poolName}/buckets storage storage_pool_buckets_get
 //
-// Get the storage pool buckets
+//  Get the storage pool buckets
 //
-// Returns a list of storage pool buckets (URLs).
+//  Returns a list of storage pool buckets (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/storage-pools/default/buckets/foo",
-//               "/1.0/storage-pools/default/buckets/bar",
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/storage-pools/default/buckets/foo",
+//                "/1.0/storage-pools/default/buckets/bar",
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools/{poolName}/buckets?recursion=1 storage storage_pool_buckets_get_recursion1
 //
-// Get the storage pool buckets
+//	Get the storage pool buckets
 //
-// Returns a list of storage pool buckets (structs).
+//	Returns a list of storage pool buckets (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of storage pool buckets
-//           items:
-//             $ref: "#/definitions/StorageBucket"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of storage pool buckets
+//	          items:
+//	            $ref: "#/definitions/StorageBucket"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 	requestProjectName := projectParam(r)
 	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, requestProjectName)
@@ -223,44 +223,44 @@ func storagePoolBucketsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/storage-pools/{poolName}/buckets/{bucketName} storage storage_pool_bucket_get
 //
-// Get the storage pool bucket
+//	Get the storage pool bucket
 //
-// Gets a specific storage pool bucket.
+//	Gets a specific storage pool bucket.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Storage pool bucket
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/StorageBucket"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Storage pool bucket
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StorageBucket"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -315,36 +315,36 @@ func storagePoolBucketGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/storage-pools/{poolName}/buckets storage storage_pool_bucket_post
 //
-// Add a storage pool bucket.
+//	Add a storage pool bucket.
 //
-// Creates a new storage pool bucket.
+//	Creates a new storage pool bucket.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: bucket
-//     description: Bucket
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageBucketsPost"
-// responses:
-//   "200":
-//     $ref: '#/definitions/StorageBucketKey'
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: bucket
+//	    description: Bucket
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageBucketsPost"
+//	responses:
+//	  "200":
+//	    $ref: '#/definitions/StorageBucketKey'
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -409,83 +409,83 @@ func storagePoolBucketsPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/storage-pools/{name}/buckets/{bucketName} storage storage_pool_bucket_patch
 //
-// Partially update the storage bucket.
+//  Partially update the storage bucket.
 //
-// Updates a subset of the storage bucket configuration.
+//  Updates a subset of the storage bucket configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage bucket
-//     description: Storage bucket configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageBucketPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  consumes:
+//    - application/json
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: target
+//      description: Cluster member name
+//      type: string
+//      example: lxd01
+//    - in: body
+//      name: storage bucket
+//      description: Storage bucket configuration
+//      required: true
+//      schema:
+//        $ref: "#/definitions/StorageBucketPut"
+//  responses:
+//    "200":
+//      $ref: "#/responses/EmptySyncResponse"
+//    "400":
+//      $ref: "#/responses/BadRequest"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "412":
+//      $ref: "#/responses/PreconditionFailed"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation PUT /1.0/storage-pools/{name}/buckets/{bucketName} storage storage_pool_bucket_put
 //
-// Update the storage bucket
+//	Update the storage bucket
 //
-// Updates the entire storage bucket configuration.
+//	Updates the entire storage bucket configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage bucket
-//     description: Storage bucket configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageBucketPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage bucket
+//	    description: Storage bucket configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageBucketPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -556,33 +556,33 @@ func storagePoolBucketPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/storage-pools/{name}/buckets/{bucketName} storage storage_pool_bucket_delete
 //
-// Delete the storage bucket
+//	Delete the storage bucket
 //
-// Removes the storage bucket.
+//	Removes the storage bucket.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -625,96 +625,96 @@ func storagePoolBucketDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/storage-pools/{poolName}/buckets/{bucketName}/keys storage storage_pool_bucket_keys_get
 //
-// Get the storage pool bucket keys
+//  Get the storage pool bucket keys
 //
-// Returns a list of storage pool bucket keys (URLs).
+//  Returns a list of storage pool bucket keys (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/storage-pools/default/buckets/foo/keys/my-read-only-key",
-//               "/1.0/storage-pools/default/buckets/bar/keys/admin",
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/storage-pools/default/buckets/foo/keys/my-read-only-key",
+//                "/1.0/storage-pools/default/buckets/bar/keys/admin",
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools/{poolName}/buckets/{bucketName}/keys?recursion=1 storage storage_pool_bucket_keys_get_recursion1
 //
-// Get the storage pool bucket keys
+//	Get the storage pool bucket keys
 //
-// Returns a list of storage pool bucket keys (structs).
+//	Returns a list of storage pool bucket keys (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of storage pool bucket keys
-//           items:
-//             $ref: "#/definitions/StorageBucketKey"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of storage pool bucket keys
+//	          items:
+//	            $ref: "#/definitions/StorageBucketKey"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeysGet(d *Daemon, r *http.Request) response.Response {
 	bucketProjectName, err := project.StorageBucketProject(r.Context(), d.State().DB.Cluster, projectParam(r))
 	if err != nil {
@@ -785,36 +785,36 @@ func storagePoolBucketKeysGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/storage-pools/{poolName}/buckets/{bucketName}/keys storage storage_pool_bucket_key_post
 //
-// Add a storage pool bucket key.
+//	Add a storage pool bucket key.
 //
-// Creates a new storage pool bucket key.
+//	Creates a new storage pool bucket key.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: body
-//     name: bucket
-//     description: Bucket
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageBucketKeysPost"
-// responses:
-//   "200":
-//     $ref: '#/definitions/StorageBucketKey'
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: body
+//	    name: bucket
+//	    description: Bucket
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageBucketKeysPost"
+//	responses:
+//	  "200":
+//	    $ref: '#/definitions/StorageBucketKey'
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -863,33 +863,33 @@ func storagePoolBucketKeysPost(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/storage-pools/{name}/buckets/{bucketName}/keys/{keyName} storage storage_pool_bucket_key_delete
 //
-// Delete the storage bucket key
+//	Delete the storage bucket key
 //
-// Removes the storage bucket key.
+//	Removes the storage bucket key.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -935,44 +935,44 @@ func storagePoolBucketKeyDelete(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/storage-pools/{poolName}/buckets/{bucketName}/keys/{keyName} storage storage_pool_bucket_key_get
 //
-// Get the storage pool bucket key
+//	Get the storage pool bucket key
 //
-// Gets a specific storage pool bucket key.
+//	Gets a specific storage pool bucket key.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Storage pool bucket key
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/StorageBucketKey"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: Storage pool bucket key
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StorageBucketKey"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1036,43 +1036,43 @@ func storagePoolBucketKeyGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/storage-pools/{name}/buckets/{bucketName}/keys/{keyName} storage storage_pool_bucket_key_put
 //
-// Update the storage bucket key
+//	Update the storage bucket key
 //
-// Updates the entire storage bucket key configuration.
+//	Updates the entire storage bucket key configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage bucket
-//     description: Storage bucket key configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageBucketKeyPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage bucket
+//	    description: Storage bucket key configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageBucketKeyPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolBucketKeyPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -49,96 +49,96 @@ var storagePoolCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/storage-pools storage storage_pools_get
 //
-// Get the storage pools
+//  Get the storage pools
 //
-// Returns a list of storage pools (URLs).
+//  Returns a list of storage pools (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/storage-pools/local",
-//               "/1.0/storage-pools/remote"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/storage-pools/local",
+//                "/1.0/storage-pools/remote"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools?recursion=1 storage storage_pools_get_recursion1
 //
-// Get the storage pools
+//	Get the storage pools
 //
-// Returns a list of storage pools (structs).
+//	Returns a list of storage pools (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of storage pools
-//           items:
-//             $ref: "#/definitions/StoragePool"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of storage pools
+//	          items:
+//	            $ref: "#/definitions/StoragePool"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 	recursion := util.IsRecursionRequest(r)
 
@@ -200,42 +200,42 @@ func storagePoolsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation POST /1.0/storage-pools storage storage_pools_post
 //
-// Add a storage pool
+//	Add a storage pool
 //
-// Creates a new storage pool.
-// When clustered, storage pools require individual POST for each cluster member prior to a global POST.
+//	Creates a new storage pool.
+//	When clustered, storage pools require individual POST for each cluster member prior to a global POST.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage
-//     description: Storage pool
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StoragePoolsPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage
+//	    description: Storage pool
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StoragePoolsPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolsPost(d *Daemon, r *http.Request) response.Response {
 	storagePoolCreateLock.Lock()
 	defer storagePoolCreateLock.Unlock()
@@ -525,49 +525,49 @@ func storagePoolsPostCluster(d *Daemon, pool *api.StoragePool, req api.StoragePo
 
 // swagger:operation GET /1.0/storage-pools/{name} storage storage_pool_get
 //
-// Get the storage pool
+//	Get the storage pool
 //
-// Gets a specific storage pool.
+//	Gets a specific storage pool.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Storage pool
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/StoragePool"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Storage pool
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StoragePool"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -629,43 +629,43 @@ func storagePoolGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/storage-pools/{name} storage storage_pool_put
 //
-// Update the storage pool
+//	Update the storage pool
 //
-// Updates the entire storage pool configuration.
+//	Updates the entire storage pool configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage pool
-//     description: Storage pool configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StoragePoolPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage pool
+//	    description: Storage pool configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StoragePoolPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolPut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -763,43 +763,43 @@ func storagePoolPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/storage-pools/{name} storage storage_pool_patch
 //
-// Partially update the storage pool
+//	Partially update the storage pool
 //
-// Updates a subset of the storage pool configuration.
+//	Updates a subset of the storage pool configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage pool
-//     description: Storage pool configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StoragePoolPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage pool
+//	    description: Storage pool configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StoragePoolPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolPatch(d *Daemon, r *http.Request) response.Response {
 	return storagePoolPut(d, r)
 }
@@ -875,28 +875,28 @@ func doStoragePoolUpdate(d *Daemon, pool storagePools.Pool, req api.StoragePoolP
 
 // swagger:operation DELETE /1.0/storage-pools/{name} storage storage_pools_delete
 //
-// Delete the storage pool
+//	Delete the storage pool
 //
-// Removes the storage pool.
+//	Removes the storage pool.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 	poolName, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -67,221 +67,221 @@ var storagePoolVolumeTypeCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes storage storage_pool_volumes_get
 //
-// Get the storage volumes
+//  Get the storage volumes
 //
-// Returns a list of storage volumes (URLs).
+//  Returns a list of storage volumes (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/storage-pools/local/volumes/container/a1",
-//               "/1.0/storage-pools/local/volumes/container/a2",
-//               "/1.0/storage-pools/local/volumes/custom/backups",
-//               "/1.0/storage-pools/local/volumes/custom/images"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: target
+//      description: Cluster member name
+//      type: string
+//      example: lxd01
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/storage-pools/local/volumes/container/a1",
+//                "/1.0/storage-pools/local/volumes/container/a2",
+//                "/1.0/storage-pools/local/volumes/custom/backups",
+//                "/1.0/storage-pools/local/volumes/custom/images"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes?recursion=1 storage storage_pool_volumes_get_recursion1
 //
-// Get the storage volumes
+//  Get the storage volumes
 //
-// Returns a list of storage volumes (structs).
+//  Returns a list of storage volumes (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: query
-//     name: filter
-//     description: Collection filter
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of storage volumes
-//           items:
-//             $ref: "#/definitions/StorageVolume"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: target
+//      description: Cluster member name
+//      type: string
+//      example: lxd01
+//    - in: query
+//      name: filter
+//      description: Collection filter
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of storage volumes
+//            items:
+//              $ref: "#/definitions/StorageVolume"
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type} storage storage_pool_volumes_type_get
 //
-// Get the storage volumes
+//  Get the storage volumes
 //
-// Returns a list of storage volumes (URLs) (type specific endpoint).
+//  Returns a list of storage volumes (URLs) (type specific endpoint).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/storage-pools/local/volumes/custom/backups",
-//               "/1.0/storage-pools/local/volumes/custom/images"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: target
+//      description: Cluster member name
+//      type: string
+//      example: lxd01
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/storage-pools/local/volumes/custom/backups",
+//                "/1.0/storage-pools/local/volumes/custom/images"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}?recursion=1 storage storage_pool_volumes_type_get_recursion1
 //
-// Get the storage volumes
+//	Get the storage volumes
 //
-// Returns a list of storage volumes (structs) (type specific endpoint).
+//	Returns a list of storage volumes (structs) (type specific endpoint).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of storage volumes
-//           items:
-//             $ref: "#/definitions/StorageVolume"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of storage volumes
+//	          items:
+//	            $ref: "#/definitions/StorageVolume"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumesGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -491,44 +491,44 @@ func filterVolumes(volumes []*db.StorageVolume, clauses []filter.Clause, allProj
 
 // swagger:operation POST /1.0/storage-pools/{name}/volumes/{type} storage storage_pool_volumes_type_post
 //
-// Add a storage volume
+//	Add a storage volume
 //
-// Creates a new storage volume (type specific endpoint).
-// Will return an empty sync response on simple volume creation but an operation on copy or migration.
+//	Creates a new storage volume (type specific endpoint).
+//	Will return an empty sync response on simple volume creation but an operation on copy or migration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: volume
-//     description: Storage volume
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: volume
+//	    description: Storage volume
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumesPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -715,44 +715,44 @@ func doVolumeCreateOrCopy(d *Daemon, r *http.Request, requestProjectName string,
 
 // swagger:operation POST /1.0/storage-pools/{name}/volumes storage storage_pool_volumes_post
 //
-// Add a storage volume
+//	Add a storage volume
 //
-// Creates a new storage volume.
-// Will return an empty sync response on simple volume creation but an operation on copy or migration.
+//	Creates a new storage volume.
+//	Will return an empty sync response on simple volume creation but an operation on copy or migration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: volume
-//     description: Storage volume
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumesPost"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: volume
+//	    description: Storage volume
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumesPost"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -921,46 +921,46 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 
 // swagger:operation POST /1.0/storage-pools/{name}/volumes/{type}/{volume} storage storage_pool_volume_type_post
 //
-// Rename or move/migrate a storage volume
+//	Rename or move/migrate a storage volume
 //
-// Renames, moves a storage volume between pools or migrates an instance to another server.
+//	Renames, moves a storage volume between pools or migrates an instance to another server.
 //
-// The returned operation metadata will vary based on what's requested.
-// For rename or move within the same server, this is a simple background operation with progress data.
-// For migration, in the push case, this will similarly be a background
-// operation with progress data, for the pull case, it will be a websocket
-// operation with a number of secrets to be passed to the target server.
+//	The returned operation metadata will vary based on what's requested.
+//	For rename or move within the same server, this is a simple background operation with progress data.
+//	For migration, in the push case, this will similarly be a background
+//	operation with progress data, for the pull case, it will be a websocket
+//	operation with a number of secrets to be passed to the target server.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: migration
-//     description: Migration request
-//     schema:
-//       $ref: "#/definitions/StorageVolumePost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: migration
+//	    description: Migration request
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumePost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1285,49 +1285,49 @@ func storageGetVolumeNameFromURL(r *http.Request) (string, error) {
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume} storage storage_pool_volume_type_get
 //
-// Get the storage volume
+//	Get the storage volume
 //
-// Gets a specific storage volume.
+//	Gets a specific storage volume.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Storage volume
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/StorageVolume"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Storage volume
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StorageVolume"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1405,43 +1405,43 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PUT /1.0/storage-pools/{name}/volumes/{type}/{volume} storage storage_pool_volume_type_put
 //
-// Update the storage volume
+//	Update the storage volume
 //
-// Updates the entire storage volume configuration.
+//	Updates the entire storage volume configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage volume
-//     description: Storage volume configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage volume
+//	    description: Storage volume configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1576,43 +1576,43 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/storage-pools/{name}/volumes/{type}/{volume} storage storage_pool_volume_type_patch
 //
-// Partially update the storage volume
+//	Partially update the storage volume
 //
-// Updates a subset of the storage volume configuration.
+//	Updates a subset of the storage volume configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage volume
-//     description: Storage volume configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumePut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage volume
+//	    description: Storage volume configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumePut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -1718,33 +1718,33 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/storage-pools/{name}/volumes/{type}/{volume} storage storage_pool_volume_type_delete
 //
-// Delete the storage volume
+//	Delete the storage volume
 //
-// Removes the storage volume.
+//	Removes the storage volume.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -50,106 +50,106 @@ var storagePoolVolumeTypeCustomBackupExportCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/backups storage storage_pool_volumes_type_backups_get
 //
-// Get the storage volume backups
+//  Get the storage volume backups
 //
-// Returns a list of storage volume backups (URLs).
+//  Returns a list of storage volume backups (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/storage-pools/local/volumes/custom/foo/backups/backup0",
-//               "/1.0/storage-pools/local/volumes/custom/foo/backups/backup1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: target
+//      description: Cluster member name
+//      type: string
+//      example: lxd01
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/storage-pools/local/volumes/custom/foo/backups/backup0",
+//                "/1.0/storage-pools/local/volumes/custom/foo/backups/backup1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/backups?recursion=1 storage storage_pool_volumes_type_backups_get_recursion1
 //
-// Get the storage volume backups
+//	Get the storage volume backups
 //
-// Returns a list of storage volume backups (structs).
+//	Returns a list of storage volume backups (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of storage volume backups
-//           items:
-//             $ref: "#/definitions/StoragePoolVolumeBackup"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of storage volume backups
+//	          items:
+//	            $ref: "#/definitions/StoragePoolVolumeBackup"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.Response {
 	projectName, err := project.StorageVolumeProject(d.State().DB.Cluster, projectParam(r), db.StoragePoolVolumeTypeCustom)
 	if err != nil {
@@ -232,41 +232,41 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 
 // swagger:operation POST /1.0/storage-pools/{name}/volumes/{type}/{volume}/backups storage storage_pool_volumes_type_backups_post
 //
-// Create a storage volume backup
+//	Create a storage volume backup
 //
-// Creates a new storage volume backup.
+//	Creates a new storage volume backup.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: volume
-//     description: Storage volume backup
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StoragePoolVolumeBackupsPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: volume
+//	    description: Storage volume backup
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StoragePoolVolumeBackupsPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -436,49 +436,49 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/backups/{backup} storage storage_pool_volumes_type_backup_get
 //
-// Get the storage volume backup
+//	Get the storage volume backup
 //
-// Gets a specific storage volume backup.
+//	Gets a specific storage volume backup.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Storage volume backup
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/StoragePoolVolumeBackup"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Storage volume backup
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StoragePoolVolumeBackup"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -544,41 +544,41 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 
 // swagger:operation POST /1.0/storage-pools/{name}/volumes/{type}/{volume}/backups/{backup} storage storage_pool_volumes_type_backup_post
 //
-// Rename a storage volume backup
+//	Rename a storage volume backup
 //
-// Renames a storage volume backup.
+//	Renames a storage volume backup.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: volume rename
-//     description: Storage volume backup
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumeSnapshotPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: volume rename
+//	    description: Storage volume backup
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumeSnapshotPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -676,35 +676,35 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 
 // swagger:operation DELETE /1.0/storage-pools/{name}/volumes/{type}/{volume}/backups/{backup} storage storage_pool_volumes_type_backup_delete
 //
-// Delete a storage volume backup
+//	Delete a storage volume backup
 //
-// Deletes a new storage volume backup.
+//	Deletes a new storage volume backup.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -789,31 +789,31 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/backups/{backup}/export storage storage_pool_volumes_type_backup_export_get
 //
-// Get the raw backup file
+//	Get the raw backup file
 //
-// Download the raw backup file from the server.
+//	Download the raw backup file from the server.
 //
-// ---
-// produces:
-//   - application/octet-stream
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Raw backup data
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/octet-stream
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Raw backup data
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -49,41 +49,41 @@ var storagePoolVolumeSnapshotTypeCmd = APIEndpoint{
 
 // swagger:operation POST /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots storage storage_pool_volumes_type_snapshots_post
 //
-// Create a storage volume snapshot
+//	Create a storage volume snapshot
 //
-// Creates a new storage volume snapshot.
+//	Creates a new storage volume snapshot.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: volume
-//     description: Storage volume snapshot
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumeSnapshotsPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: volume
+//	    description: Storage volume snapshot
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumeSnapshotsPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -241,106 +241,106 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots storage storage_pool_volumes_type_snapshots_get
 //
-// Get the storage volume snapshots
+//  Get the storage volume snapshots
 //
-// Returns a list of storage volume snapshots (URLs).
+//  Returns a list of storage volume snapshots (URLs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/storage-pools/local/volumes/custom/foo/snapshots/snap0",
-//               "/1.0/storage-pools/local/volumes/custom/foo/snapshots/snap1"
-//             ]
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//    - in: query
+//      name: target
+//      description: Cluster member name
+//      type: string
+//      example: lxd01
+//  responses:
+//    "200":
+//      description: API endpoints
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/storage-pools/local/volumes/custom/foo/snapshots/snap0",
+//                "/1.0/storage-pools/local/volumes/custom/foo/snapshots/snap1"
+//              ]
+//    "403":
+//      $ref: "#/responses/Forbidden"
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots?recursion=1 storage storage_pool_volumes_type_snapshots_get_recursion1
 //
-// Get the storage volume snapshots
+//	Get the storage volume snapshots
 //
-// Returns a list of storage volume snapshots (structs).
+//	Returns a list of storage volume snapshots (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of storage volume snapshots
-//           items:
-//             $ref: "#/definitions/StorageVolumeSnapshot"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of storage volume snapshots
+//	          items:
+//	            $ref: "#/definitions/StorageVolumeSnapshot"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Response {
 	// Get the name of the pool the storage volume is supposed to be attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])
@@ -439,41 +439,41 @@ func storagePoolVolumeSnapshotsTypeGet(d *Daemon, r *http.Request) response.Resp
 
 // swagger:operation POST /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots/{snapshot} storage storage_pool_volumes_type_snapshot_post
 //
-// Rename a storage volume snapshot
+//	Rename a storage volume snapshot
 //
-// Renames a storage volume snapshot.
+//	Renames a storage volume snapshot.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: volume rename
-//     description: Storage volume snapshot
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumeSnapshotPost"
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: volume rename
+//	    description: Storage volume snapshot
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumeSnapshotPost"
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -569,49 +569,49 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots/{snapshot} storage storage_pool_volumes_type_snapshot_get
 //
-// Get the storage volume snapshot
+//	Get the storage volume snapshot
 //
-// Gets a specific storage volume snapshot.
+//	Gets a specific storage volume snapshot.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Storage volume snapshot
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/StorageVolumeSnapshot"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Storage volume snapshot
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StorageVolumeSnapshot"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -698,43 +698,43 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 
 // swagger:operation PUT /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots/{snapshot} storage storage_pool_volumes_type_snapshot_put
 //
-// Update the storage volume snapshot
+//	Update the storage volume snapshot
 //
-// Updates the entire storage volume snapshot configuration.
+//	Updates the entire storage volume snapshot configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage volume snapshot
-//     description: Storage volume snapshot configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumeSnapshotPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage volume snapshot
+//	    description: Storage volume snapshot configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumeSnapshotPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -826,43 +826,43 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 
 // swagger:operation PATCH /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots/{snapshot} storage storage_pool_volumes_type_snapshot_patch
 //
-// Partially update the storage volume snapshot
+//	Partially update the storage volume snapshot
 //
-// Updates a subset of the storage volume snapshot configuration.
+//	Updates a subset of the storage volume snapshot configuration.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-//   - in: body
-//     name: storage volume snapshot
-//     description: Storage volume snapshot configuration
-//     required: true
-//     schema:
-//       $ref: "#/definitions/StorageVolumeSnapshotPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "412":
-//     $ref: "#/responses/PreconditionFailed"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	  - in: body
+//	    name: storage volume snapshot
+//	    description: Storage volume snapshot configuration
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/StorageVolumeSnapshotPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "412":
+//	    $ref: "#/responses/PreconditionFailed"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 
@@ -990,35 +990,35 @@ func doStoragePoolVolumeSnapshotUpdate(d *Daemon, r *http.Request, poolName stri
 
 // swagger:operation DELETE /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots/{snapshot} storage storage_pool_volumes_type_snapshot_delete
 //
-// Delete a storage volume snapshot
+//	Delete a storage volume snapshot
 //
-// Deletes a new storage volume snapshot.
+//	Deletes a new storage volume snapshot.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "202":
-//     $ref: "#/responses/Operation"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "202":
+//	    $ref: "#/responses/Operation"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Response {
 	s := d.State()
 

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -27,49 +27,49 @@ var storagePoolVolumeTypeStateCmd = APIEndpoint{
 
 // swagger:operation GET /1.0/storage-pools/{name}/volumes/{type}/{volume}/state storage storage_pool_volume_type_state_get
 //
-// Get the storage volume state
+//	Get the storage volume state
 //
-// Gets a specific storage volume state (usage data).
+//	Gets a specific storage volume state (usage data).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-//   - in: query
-//     name: target
-//     description: Cluster member name
-//     type: string
-//     example: lxd01
-// responses:
-//   "200":
-//     description: Storage pool
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/StorageVolumeState"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	  - in: query
+//	    name: target
+//	    description: Cluster member name
+//	    type: string
+//	    example: lxd01
+//	responses:
+//	  "200":
+//	    description: Storage pool
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/StorageVolumeState"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response {
 	// Get the name of the pool the storage volume is supposed to be attached to.
 	poolName, err := url.PathUnescape(mux.Vars(r)["pool"])

--- a/lxd/swagger.go
+++ b/lxd/swagger.go
@@ -9,9 +9,9 @@
 // certificates with a macaroon based (candid) authentication method also
 // supported.
 //
-//     Version: 1.0
-//     License: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0
-//     Contact: LXD upstream <lxc-devel@lists.linuxcontainers.org> https://github.com/lxc/lxd
+//	Version: 1.0
+//	License: Apache-2.0 https://www.apache.org/licenses/LICENSE-2.0
+//	Contact: LXD upstream <lxc-devel@lists.linuxcontainers.org> https://github.com/lxc/lxd
 //
 // swagger:meta
 package main

--- a/lxd/sys/testing.go
+++ b/lxd/sys/testing.go
@@ -43,9 +43,9 @@ func NewTestOS(t *testing.T) (*OS, func()) {
 // Since generating certificates is CPU intensive, they will be simply
 // symlink'ed from the test/deps/ directory.
 //
-// FIXME: this function is exported because some tests use it
-//        directly. Eventually we should rework those tests to use NewTestOS
-//        instead.
+//	FIXME: this function is exported because some tests use it
+//		directly. Eventually we should rework those tests to use NewTestOS
+//		instead.
 func SetupTestCerts(dir string) error {
 	_, filename, _, _ := runtime.Caller(0)
 	deps := filepath.Join(filepath.Dir(filename), "..", "..", "test", "deps")

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -59,92 +59,92 @@ func filterWarnings(warnings []api.Warning, clauses []filter.Clause) []api.Warni
 
 // swagger:operation GET /1.0/warnings warnings warnings_get
 //
-// List the warnings
+//  List the warnings
 //
-// Returns a list of warnings.
+//  Returns a list of warnings.
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: Sync response
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of endpoints
-//           items:
-//             type: string
-//           example: |-
-//             [
-//               "/1.0/warnings/39c61a48-cc17-40ae-8248-4f7b4cadedf4",
-//               "/1.0/warnings/951779a5-2820-4d96-b01e-88fe820e5310"
-//             ]
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//  ---
+//  produces:
+//    - application/json
+//  parameters:
+//    - in: query
+//      name: project
+//      description: Project name
+//      type: string
+//      example: default
+//  responses:
+//    "200":
+//      description: Sync response
+//      schema:
+//        type: object
+//        description: Sync response
+//        properties:
+//          type:
+//            type: string
+//            description: Response type
+//            example: sync
+//          status:
+//            type: string
+//            description: Status description
+//            example: Success
+//          status_code:
+//            type: integer
+//            description: Status code
+//            example: 200
+//          metadata:
+//            type: array
+//            description: List of endpoints
+//            items:
+//              type: string
+//            example: |-
+//              [
+//                "/1.0/warnings/39c61a48-cc17-40ae-8248-4f7b4cadedf4",
+//                "/1.0/warnings/951779a5-2820-4d96-b01e-88fe820e5310"
+//              ]
+//    "500":
+//      $ref: "#/responses/InternalServerError"
 
 // swagger:operation GET /1.0/warnings?recursion=1 warnings warnings_get_recursion1
 //
-// Get the warnings
+//	Get the warnings
 //
-// Returns a list of warnings (structs).
+//	Returns a list of warnings (structs).
 //
-// ---
-// produces:
-//   - application/json
-// parameters:
-//   - in: query
-//     name: project
-//     description: Project name
-//     type: string
-//     example: default
-// responses:
-//   "200":
-//     description: API endpoints
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           type: array
-//           description: List of warnings
-//           items:
-//             $ref: "#/definitions/Warning"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: query
+//	    name: project
+//	    description: Project name
+//	    type: string
+//	    example: default
+//	responses:
+//	  "200":
+//	    description: API endpoints
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          type: array
+//	          description: List of warnings
+//	          items:
+//	            $ref: "#/definitions/Warning"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func warningsGet(d *Daemon, r *http.Request) response.Response {
 	// Parse the recursion field
 	recursionStr := r.FormValue("recursion")
@@ -215,38 +215,38 @@ func warningsGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation GET /1.0/warnings/{uuid} warnings warning_get
 //
-// Get the warning
+//	Get the warning
 //
-// Gets a specific warning.
+//	Gets a specific warning.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     description: Warning
-//     schema:
-//       type: object
-//       description: Sync response
-//       properties:
-//         type:
-//           type: string
-//           description: Response type
-//           example: sync
-//         status:
-//           type: string
-//           description: Status description
-//           example: Success
-//         status_code:
-//           type: integer
-//           description: Status code
-//           example: 200
-//         metadata:
-//           $ref: "#/definitions/Warning"
-//   "404":
-//     $ref: "#/responses/NotFound"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    description: Warning
+//	    schema:
+//	      type: object
+//	      description: Sync response
+//	      properties:
+//	        type:
+//	          type: string
+//	          description: Response type
+//	          example: sync
+//	        status:
+//	          type: string
+//	          description: Status description
+//	          example: Success
+//	        status_code:
+//	          type: integer
+//	          description: Status code
+//	          example: 200
+//	        metadata:
+//	          $ref: "#/definitions/Warning"
+//	  "404":
+//	    $ref: "#/responses/NotFound"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func warningGet(d *Daemon, r *http.Request) response.Response {
 	id, err := url.PathUnescape(mux.Vars(r)["id"])
 	if err != nil {
@@ -278,62 +278,62 @@ func warningGet(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation PATCH /1.0/warnings/{uuid} warnings warning_patch
 //
-// Partially update the warning
+//	Partially update the warning
 //
-// Updates a subset of the warning status.
+//	Updates a subset of the warning status.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: warning
-//     description: Warning status
-//     required: true
-//     schema:
-//       $ref: "#/definitions/WarningPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: warning
+//	    description: Warning status
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/WarningPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func warningPatch(d *Daemon, r *http.Request) response.Response {
 	return warningPut(d, r)
 }
 
 // swagger:operation PUT /1.0/warnings/{uuid} warnings warning_put
 //
-// Update the warning
+//	Update the warning
 //
-// Updates the warning status.
+//	Updates the warning status.
 //
-// ---
-// consumes:
-//   - application/json
-// produces:
-//   - application/json
-// parameters:
-//   - in: body
-//     name: warning
-//     description: Warning status
-//     required: true
-//     schema:
-//       $ref: "#/definitions/WarningPut"
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "400":
-//     $ref: "#/responses/BadRequest"
-//   "403":
-//     $ref: "#/responses/Forbidden"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	consumes:
+//	  - application/json
+//	produces:
+//	  - application/json
+//	parameters:
+//	  - in: body
+//	    name: warning
+//	    description: Warning status
+//	    required: true
+//	    schema:
+//	      $ref: "#/definitions/WarningPut"
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "400":
+//	    $ref: "#/responses/BadRequest"
+//	  "403":
+//	    $ref: "#/responses/Forbidden"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func warningPut(d *Daemon, r *http.Request) response.Response {
 	id, err := url.PathUnescape(mux.Vars(r)["id"])
 	if err != nil {
@@ -381,18 +381,18 @@ func warningPut(d *Daemon, r *http.Request) response.Response {
 
 // swagger:operation DELETE /1.0/warnings/{uuid} warnings warning_delete
 //
-// Delete the warning
+//	Delete the warning
 //
-// Removes the warning.
+//	Removes the warning.
 //
-// ---
-// produces:
-//   - application/json
-// responses:
-//   "200":
-//     $ref: "#/responses/EmptySyncResponse"
-//   "500":
-//     $ref: "#/responses/InternalServerError"
+//	---
+//	produces:
+//	  - application/json
+//	responses:
+//	  "200":
+//	    $ref: "#/responses/EmptySyncResponse"
+//	  "500":
+//	    $ref: "#/responses/InternalServerError"
 func warningDelete(d *Daemon, r *http.Request) response.Response {
 	id, err := url.PathUnescape(mux.Vars(r)["id"])
 	if err != nil {


### PR DESCRIPTION
Changes to gofmt in go 1.19 break swagger documentation generation (see https://github.com/go-swagger/go-swagger/issues/2759), the solution is to indent the swagger documentation so that gofmt treats it as a preformatted block.

Additionally I have edited some remaining comments to ensure they are not modified when we run gofmt.