### PR TITLE
Storage: Only activate & mount VM config volume when updating backup.yaml

### DIFF
--- a/lxd/device/none.go
+++ b/lxd/device/none.go
@@ -14,6 +14,11 @@ func (d *none) CanMigrate() bool {
 	return true
 }
 
+// CanHotPlug returns whether the device can be managed whilst the instance is running.
+func (d *none) CanHotPlug() bool {
+	return true
+}
+
 // validateConfig checks the supplied config for correctness.
 // validateConfig checks the supplied config for correctness.
 func (d *none) validateConfig(instConf instance.ConfigReader) error {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5474,6 +5474,11 @@ func (b *lxdBackend) UpdateInstanceBackupFile(inst instance.Instance, op *operat
 	contentType := InstanceContentType(inst)
 	vol := b.GetVolume(volType, contentType, volStorageName, config.Volume.Config)
 
+	// Only need to activate and mount the VM's config volume.
+	if inst.Type() == instancetype.VM {
+		vol = vol.NewVMBlockFilesystemVolume()
+	}
+
 	// Update pool information in the backup.yaml file.
 	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
 		// Write the YAML


### PR DESCRIPTION
Also allow the `none` device type to be "hot plugged" into a running VM.