### PR TITLE
doc: add sphinx-copybutton extension

### DIFF
--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -21,7 +21,8 @@ extensions = [
     "youtube-links",
     "related-links",
     "custom-rst-roles",
-    "sphinxcontrib.jquery"
+    "sphinxcontrib.jquery",
+    "sphinx_copybutton"
 ]
 
 myst_enable_extensions = [

--- a/.sphinx/requirements.txt
+++ b/.sphinx/requirements.txt
@@ -35,3 +35,4 @@ furo
 sphinxext-opengraph>=0.6.1
 lxd-sphinx-extensions
 pyspelling
+sphinx-copybutton


### PR DESCRIPTION
This extension adds a button to each code block that makes it easy to copy the contents.