### PR TITLE
api: Add zfs_block_mode API extension

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2148,3 +2148,13 @@ The Starlark scriptlet is provided to LXD via the new global configuration optio
 Adds support for a `source.wipe` Boolean on the storage pool, indicating
 that LXD should wipe partition headers off the requested disk rather
 than potentially fail due to pre-existing file systems.
+
+## `zfs_block_mode`
+
+This adds support for using ZFS block {spellexception}`filesystem` volumes allowing the use of different file systems on top of ZFS.
+
+This adds the following new configuration options for ZFS storage pools:
+
+* `volume.zfs.block_mode`
+* `volume.block.mount_options`
+* `volume.block.filesystem`

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -360,6 +360,7 @@ var APIExtensions = []string{
 	"cluster_member_state",
 	"instances_placement_scriptlet",
 	"storage_pool_source_wipe",
+	"zfs_block_mode",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This adds the missing `zfs_block_mode` API extension.
