### PR TITLE
Storage: Sync and freeze in-use ZFS block mode filesystem volumes during consistent copy

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1469,12 +1469,12 @@ func (d *ceph) CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) er
 		// been committed to disk. If we don't then the rbd snapshot of
 		// the underlying filesystem can be inconsistent or - worst case
 		// - empty.
-		unix.Sync()
-
-		_, err := shared.TryRunCommand("fsfreeze", "--freeze", sourcePath)
-		if err == nil {
-			defer func() { _, _ = shared.TryRunCommand("fsfreeze", "--unfreeze", sourcePath) }()
+		unfreezeFS, err := d.filesystemFreeze(sourcePath)
+		if err != nil {
+			return err
 		}
+
+		defer func() { _ = unfreezeFS() }()
 	}
 
 	// Create the parent directory.

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -137,7 +137,7 @@ func (d *lvm) Create() error {
 		}
 
 		if shared.PathExists(d.config["source"]) {
-			return fmt.Errorf("Source file location already exists")
+			return fmt.Errorf("Source file location %q already exists", d.config["source"])
 		}
 
 		err = ensureSparseFile(d.config["source"], size)


### PR DESCRIPTION
This fixes an issue where recent writes to an in-use (mounted) ZFS block mode filesystem volume were not being reflected in the copies made of the volume if the copy was made immediately after a write.

It was initially thought that is only occurred when the instance was stopped and a recent offline file operation (such as `lxc file push`) had been performed, which had left a temporary lingering mount active (by design), and so the recent write had not yet been flushed to the underlying zvol, and thus was not included in the snapshot used for the copy.

However further testing using this script showed that it also affected running instances:

```bash
lxc storage create zfs1 foo1 volume.zfs.block_mode=true volume.block.filesystem=xfs
lxc init images:alpine/3.17 c1 -s foo1

lxc start c1
echo "before" | lxc file push - c1/root/foo
lxc stop c1

lxc start c1
echo "after" | lxc file push - c1/root/foo
lxc exec c1 -- cat /root/foo

lxc copy c1 c2 --instance-only -s foo1
lxc start c2
lxc exec c2 -- cat /root/foo # This outputted "before" when it should have been "after"
lxc delete -f c1 c2

lxc storage delete foo1
```

Initially I suspected that we would need to call `filesystem.SyncFS()` before taking the temporary snapshot used for the copy.
But, at least for XFS filesystems, this was not sufficient. However I have left a call to `filesystem.SyncFS()` in place for good measure.

The fix that I found to work was freezing the filesystem before taking the snapshot. Initially I used `xfs_freeze` command, however I was able to generalise that using the `fsfreeze` command (that is already required by LXD in the Ceph driver) and use it for all filesystems supported ontop of ZFS.

I believe this is important to do for all block mode filesystem volumes ontop of ZFS (not just XFS ones) because the `lxc copy` command already supports an `--allow-inconsistent` flag, and the absence of which indicates that the user is expecting a consistent copy. For ZFS block mode filesystem volumes, unless we sync and freeze the filesystem before taking the snapshot, we cannot say it is a consistent copy.

If the user does not want to incur the short filesystem freeze during copies, then they can use the `--allow-inconsistent` flag, in which case LXD will not freeze the filesystem.

### Other storage drivers:

I have considered whether other storage drivers could benefit from a similar fix.

- Dir and Btrfs cannot have this fix because they use shared filesystem across multiple instances/applications.
- LVM I thought might need this fix, but it appears that the LVM system already handles this as the problem doesn't show up. Indeed I tried adding the fix to the LVM driver and the LVM subsystem actually fails to snapshot a volume that is frozen.
- Ceph could likely do with this fix but I have not tested/implemented it yet.


Closes #11419 - as the `LockExclusive` approach didn't provide a full solution to the issue.








