### PR TITLE
doc/faq: add a section explaining where lxc stores its config

### DIFF
--- a/doc/authentication.md
+++ b/doc/authentication.md
@@ -118,7 +118,7 @@ To enable PKI mode, complete the following steps:
 
 1. Add the {abbr}`CA (Certificate authority)` certificate to all machines:
 
-   - Place the `client.ca` file in the clients' configuration directories (`~/.config/lxc`).
+   - Place the `client.ca` file in the clients' configuration directories (`~/.config/lxc` or `~/snap/lxd/common/config` for snap users).
    - Place the `server.ca` file in the server's configuration directory (`/var/lib/lxd` or `/var/snap/lxd/common/lxd` for snap users).
 1. Place the certificates issued by the CA on the clients and the server, replacing the automatically generated ones.
 1. Restart the server.

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -40,14 +40,15 @@ See the [RESTful API](rest-api.md) for available API.
 ## REST API through HTTPS
 
 [HTTPS connection to LXD](security.md) requires valid
-client certificate, generated in `~/.config/lxc/client.crt` on
-first `lxc remote add`. This certificate should be passed to
-connection tools for authentication and encryption.
+client certificate that is generated on first `lxc remote add`. This
+certificate should be passed to connection tools for authentication
+and encryption.
 
-Examining certificate. In case you are curious:
+If desired, `openssl` can be used to examine the certificate (`~/.config/lxc/client.crt`
+or `~/snap/lxd/common/config/client.crt` for snap users):
 
 ```bash
-openssl x509 -in client.crt -purpose
+openssl x509 -text -noout -in client.crt
 ```
 
 Among the lines you should see:
@@ -58,7 +59,10 @@ Among the lines you should see:
 ### With command line tools
 
 ```bash
-wget --no-check-certificate https://127.0.0.1:8443/1.0 --certificate=$HOME/.config/lxc/client.crt --private-key=$HOME/.config/lxc/client.key -O - -q
+wget --no-check-certificate --certificate=$HOME/.config/lxc/client.crt --private-key=$HOME/.config/lxc/client.key -qO - https://127.0.0.1:8443/1.0
+
+# or for snap users
+wget --no-check-certificate --certificate=$HOME/snap/lxd/common/config/client.crt --private-key=$HOME/snap/lxd/common/config/client.key -qO - https://127.0.0.1:8443/1.0
 ```
 
 ### With browser

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -90,6 +90,18 @@ We have also received some reports that creating a `/.dockerenv` file in your
 container can help Docker ignore some errors it's getting due to running in a
 nested environment.
 
+### Where does `lxc` store its configuration?
+
+The `lxc` command stores its configuration under `~/.config/lxc` or in `~/snap/lxd/common/config`
+for snap users.
+
+Various configuration files are stored in that directory, among which are:
+
+- `client.crt`: client certificate (generated on demand)
+- `client.key`: client key (generated on demand)
+- `config.yml`: configuration file (info about `remotes`, `aliases`, etc)
+- `servercerts/`: directory with server certificates belonging to `remotes`
+
 ## Networking issues
 
 In a larger [Production Environment](performance-tuning), it is common to have

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -20,7 +20,7 @@ then use the `config set` command on the server:
 
 ```bash
 ip addr
-lxc config set core.https_address 192.168.1.15
+lxc config set core.https_address 192.0.2.1
 ```
 
 Also see {ref}`security_remote_access`.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -38,7 +38,8 @@ lxc config set core.trust_password SECRET
 This will set the remote password that you can then use to do `lxc remote add`.
 
 You can also access the server without setting a password by copying the client
-certificate from `.config/lxc/client.crt` to the server and adding it with:
+certificate (`~/.config/lxc/client.crt` or `~/snap/lxd/common/config/client.crt`
+for snap users) to the server and adding it with:
 
 ```bash
 lxc config trust add client.crt

--- a/doc/howto/initialize.md
+++ b/doc/howto/initialize.md
@@ -89,7 +89,7 @@ For example, starting from a brand new LXD installation, you could configure LXD
 ```bash
     cat <<EOF | lxd init --preseed
 config:
-  core.https_address: 192.168.1.1:9999
+  core.https_address: 192.0.2.1:9999
   images.auto_update_interval: 15
 networks:
 - name: lxdbr0
@@ -100,7 +100,7 @@ networks:
 EOF
 ```
 
-This preseed configuration initializes the LXD daemon to listen for HTTPS connections on port 9999 of the 192.168.1.1 address, to automatically update images every 15 hours and to create a network bridge device named `lxdbr0`, which gets assigned an IPv4 address automatically.
+This preseed configuration initializes the LXD daemon to listen for HTTPS connections on port 9999 of the 192.0.2.1 address, to automatically update images every 15 hours and to create a network bridge device named `lxdbr0`, which gets assigned an IPv4 address automatically.
 
 ### Re-configuring an existing LXD installation
 
@@ -148,7 +148,7 @@ You can use it as a template for your own preseed file and add, change or remove
 
 # Daemon settings
 config:
-  core.https_address: 192.168.1.1:9999
+  core.https_address: 192.0.2.1:9999
   core.trust_password: sekret
   images.auto_update_interval: 6
 

--- a/doc/howto/network_acls.md
+++ b/doc/howto/network_acls.md
@@ -220,6 +220,6 @@ When using network ACLs with a bridge network, be aware of the following limitat
   This means they can only be used to apply network policies for traffic going to or from external networks.
   They cannot be used for to create {spellexception}`intra-bridge` firewalls, thus firewalls that control traffic between instances connected to the same bridge.
 - {ref}`ACL groups and network selectors <network-acls-selectors>` are not supported.
-- When using the `iptables` firewall driver, you cannot use IP range subjects (for example, `192.168.1.1-192.168.1.10`).
+- When using the `iptables` firewall driver, you cannot use IP range subjects (for example, `192.0.2.1-192.0.2.10`).
 - Baseline network service rules are added before ACL rules (in their respective INPUT/OUTPUT chains), because we cannot differentiate between INPUT/OUTPUT and FORWARD traffic once we have jumped into the ACL chain.
   Because of this, ACL rules cannot be used to block baseline service rules.


### PR DESCRIPTION
Also, provide the path to the client config/cert for snap users in other doc files.