### PR TITLE
Clean up cloud-init docs

### DIFF
--- a/.sphinx/.wordlist.txt
+++ b/.sphinx/.wordlist.txt
@@ -274,6 +274,7 @@ WebSockets
 XFS
 XHR
 YAML
+YAML's
 Zettabyte
 ZFS
 zpool

--- a/.sphinx/conf.py
+++ b/.sphinx/conf.py
@@ -22,7 +22,8 @@ extensions = [
     "related-links",
     "custom-rst-roles",
     "sphinxcontrib.jquery",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
+    "sphinx.ext.intersphinx"
 ]
 
 myst_enable_extensions = [
@@ -37,6 +38,10 @@ myst_heading_anchors = 7
 if os.path.exists("../doc/substitutions.yaml"):
     with open("../doc/substitutions.yaml", "r") as fd:
         myst_substitutions = yaml.safe_load(fd.read())
+
+intersphinx_mapping = {
+    'cloud-init': ('https://cloudinit.readthedocs.io/en/latest/', None)
+}
 
 # Setup theme.
 templates_path = ["_templates"]

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -9,6 +9,16 @@ relatedlinks: https://cloudinit.readthedocs.org/
 ```{youtube} https://www.youtube.com/watch?v=8OCG15TAldI
 ```
 
+## `cloud-init` support in images
+
+Before trying to use `cloud-init`, however, first determine which image source you are
+about to use as not all images have the `cloud-init` package installed.
+
+The images from the `ubuntu` and `ubuntu-daily` remotes are all `cloud-init` enabled.
+Images from the `images` remote have `cloud-init` enabled variants using the `/cloud` suffix, e.g. `images:ubuntu/22.04/cloud`.
+
+## Configuration keys
+
 LXD supports [cloud-init](https://launchpad.net/cloud-init) via the following instance or profile
 configuration keys:
 
@@ -17,12 +27,6 @@ configuration keys:
 * `cloud-init.network-config`
 
 For more information, see the [`cloud-init` instance options](instance-options-cloud-init), and the documentation for the [LXD data source](https://cloudinit.readthedocs.io/en/latest/reference/datasources/lxd.html) in the `cloud-init` documentation.
-
-Before trying to use `cloud-init`, however, first determine which image source you are
-about to use as not all images have the `cloud-init` package installed.
-
-The images from the `ubuntu` and `ubuntu-daily` remotes are all `cloud-init` enabled.
-Images from the `images` remote have `cloud-init` enabled variants using the `/cloud` suffix, e.g. `images:ubuntu/22.04/cloud`.
 
 Both `vendor-data` and `user-data` follow the same rules, with the following caveats:
 
@@ -41,9 +45,7 @@ In this case, configure how `cloud-init` should merge the provided data.
 See [Merging User-Data Sections](https://cloudinit.readthedocs.io/en/latest/reference/merging.html) in the `cloud-init` documentation for instructions.
 ```
 
-`cloud-config` examples can be found in the [`cloud-init` documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).
-
-## Working with cloud-init
+## How to work with `cloud-init`
 
 For a safe way to test, use a new profile that's copied from the default profile.
 
@@ -90,7 +92,7 @@ config:
   cloud-init.network-config: |
 ```
 
-### Custom user-data configuration
+## How to specify user or vendor data
 
 cloud-init uses the `user-data` (and `vendor-data`) section to do things like upgrade packages, install packages or run arbitrary commands.
 
@@ -100,6 +102,11 @@ An instance's rootfs will contain the following files as a result:
 
 * `/var/lib/cloud/instance/cloud-config.txt`
 * `/var/lib/cloud/instance/user-data.txt`
+
+### Examples for `cloud-init` user data
+
+`cloud-config` examples can be found in the [`cloud-init` documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).
+
 
 #### Upgrade packages on instance creation
 
@@ -160,7 +167,7 @@ config:
       - name: documentation_example
 ```
 
-### Custom network configuration
+## How to specify network configuration data
 
 `cloud-init` uses the `network-config` data to render the relevant network
 configuration on the system using either `ifupdown` or `netplan` depending
@@ -171,6 +178,8 @@ The default behavior is to use a DHCP client on an instance's `eth0` interface.
 In order to change this you need to define your own network configuration
 using `cloud-init.network-config` key in the configuration dictionary which will override
 the default configuration (this is due to how the template is structured).
+
+### Examples for a `cloud-init` network configuration
 
 For example, to configure a specific network interface with a static IPv4
 address and also use a custom name server use

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -4,157 +4,133 @@ relatedlinks: https://cloudinit.readthedocs.org/
 ---
 
 (cloud-init)=
-# cloud-init
+# How to use `cloud-init`
 
 ```{youtube} https://www.youtube.com/watch?v=8OCG15TAldI
 ```
-`cloud-init` is a software for automatic customization of a Linux distribution.
 
-Features include:
+[`cloud-init`](https://cloud-init.io/) is a tool for automatically initializing and customizing an instance of a Linux distribution.
 
-* install packages
-* apply/edit configuration
-* add users
-* and more
+By adding `cloud-init` configuration to your instance, you can instruct `cloud-init` to execute specific actions at the first start of an instance.
+Possible actions include, for example:
 
-See the [Cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/).
+* Updating and installing packages
+* Applying certain configurations
+* Adding users
+* Enabling services
+* Running commands or scripts
+* Automatically growing the file system of a VM to the size of the disk
+
+See the {ref}`cloud-init:index` for detailed information.
+
+```{note}
+The `cloud-init` actions are run only once on the first start of the instance.
+Rebooting the instance does not re-trigger the actions.
+```
 
 ## `cloud-init` support in images
 
-Before trying to use `cloud-init`, however, first determine which image source you are
-about to use as not all images have the `cloud-init` package installed.
+To use `cloud-init`, you must base your instance on an image that has `cloud-init` installed:
 
-The images from the `ubuntu` and `ubuntu-daily` remotes are all `cloud-init` enabled.
-Images from the `images` remote have `cloud-init` enabled variants using the `/cloud` suffix, e.g. `images:ubuntu/22.04/cloud`.
+* All images from the `ubuntu` and `ubuntu-daily` {ref}`image servers <remote-image-servers>` have `cloud-init` support.
+* Images from the [`images` remote](https://images.linuxcontainers.org/) have `cloud-init`-enabled variants, which are usually bigger in size than the default variant.
+  The cloud variants use the `/cloud` suffix, for example, `images:ubuntu/22.04/cloud`.
 
-Requirements:
+## Configuration options
 
-* Images with cloud-init support: For example, official LXD images that contain the term `cloud` in `ALIAS` have implemented cloud-init support.
+LXD supports two different sets of configuration options for configuring `cloud-init`: `cloud-init.*` and `user.*`.
+Which of these sets you must use depends on the `cloud-init` support in the image that you use.
+As a rule of thumb, newer images support the `cloud-init.*` configuration options, while older images support `user.*`.
+However, there might be exceptions to that rule.
 
-## Configuration keys
+The following configuration options are supported:
 
-LXD supports [cloud-init](https://launchpad.net/cloud-init) via the following instance or profile
-configuration keys:
+* `cloud-init.vendor-data` or `user.vendor-data` (see {ref}`cloud-init:vendordata`)
+* `cloud-init.user-data` or `user.user-data` (see {ref}`cloud-init:user_data_formats`)
+* `cloud-init.network-config` or `user.network-config` (see {ref}`cloud-init:network_config`)
 
-* `cloud-init.vendor-data`
-* `cloud-init.user-data`
-* `cloud-init.network-config`
+For more information about the configuration options, see the [`cloud-init` instance options](instance-options-cloud-init), and the documentation for the {ref}`LXD data source <cloud-init:datasource_lxd>` in the `cloud-init` documentation.
 
-- `user.meta-data` - see [cloud-init docs - instance metadata](https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html)
-- `user.vendor-data` - see [cloud-init docs - vendordata](https://cloudinit.readthedocs.io/en/latest/explanation/vendordata.html)
-- `user.network-config` - see [cloud-init docs - network configuration](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html)
+### Vendor data and user data
 
-For more information, see the [`cloud-init` instance options](instance-options-cloud-init), and the documentation for the [LXD data source](https://cloudinit.readthedocs.io/en/latest/reference/datasources/lxd.html) in the `cloud-init` documentation.
+Both `vendor-data` and `user-data` are used to provide {ref}`cloud configuration data <explanation/format:cloud config data>` to `cloud-init`.
 
-Both `vendor-data` and `user-data` follow the same rules, with the following caveats:
+The main idea is that `vendor-data` is used for the general default configuration, while `user-data` is used for instance-specific configuration.
+This means that you should specify `vendor-data` in a profile and `user-data` in the instance configuration.
+LXD does not enforce this method, but allows using both `vendor-data` and `user-data` in profiles and in the instance configuration.
 
-* Users have ultimate control over vendor data. They can disable its execution or disable handling of specific parts of multipart input.
-* By default it only runs on first boot.
-* Vendor data can be disabled by the user. If the use of vendor data is required for the instance to run, then vendor data should not be used.
-* User supplied `cloud-config` is merged over `cloud-config` from vendor data.
-
-For LXD instances, `vendor-data` should be used in profiles rather than the instance configuration.
-
-```{note}
-If both `cloud-init.user-data` and `cloud-init.vendor-data` are supplied, `cloud-init` merges the two configurations.
-
+If both `vendor-data` and `user-data` are supplied for an instance, `cloud-init` merges the two configurations.
 However, if you use the same keys in both configurations, merging might not be possible.
 In this case, configure how `cloud-init` should merge the provided data.
-See [Merging User-Data Sections](https://cloudinit.readthedocs.io/en/latest/reference/merging.html) in the `cloud-init` documentation for instructions.
-```
+See {ref}`cloud-init:merging_user_data` for instructions.
 
-## How to work with `cloud-init`
+## How to configure `cloud-init`
 
-For a safe way to test, use a new profile that's copied from the default profile.
+To configure `cloud-init` for an instance, add the corresponding configuration options to a {ref}`profile <profiles>` that the instance uses or directly to the {ref}`instance configuration <instances-configure>`.
 
-    lxc profile copy default test
+When configuring `cloud-init` directly for an instance, keep in mind that `cloud-init` runs only on the first start of the instance.
+That means that you must configure `cloud-init` before you start the instance.
+To do so, create the instance with `lxc init` instead of `lxc launch`, and then start it after completing the configuration.
 
-Then edit the new `test` profile. You might want to set your `EDITOR` environment variable first.
+### YAML format for `cloud-init` configuration
 
-    lxc profile edit test
+The `cloud-init` options require YAML's [literal style format](https://yaml.org/spec/1.2.2/#812-literal-style).
+You use a pipe symbol (`|`) to indicate that all indented text after the pipe should be passed to `cloud-init` as a single string, with new lines and indentation preserved.
 
-For a new LXD installation, the configuration file should look similar to this example:
+The `vendor-data` and `user-data` options usually start with `#cloud-config`.
 
-```yaml
-config: {}
-description: Default LXD profile
-devices:
-  eth0:
-    name: eth0
-    network: lxdbr0
-    type: nic
-  root:
-    path: /
-    pool: default
-    type: disk
-```
-
-Once you've set up the `cloud-init` configuration, use `lxc launch` with `--profile <profilename>` to apply the profile to the instance.
-
-### Adding cloud-init keys to the configuration
-
-`cloud-init` keys require a specific syntax. You use a pipe symbol (`|`) to indicate that all indented text after the pipe should be passed to `cloud-init` as a single string, with new lines and indentation preserved; this is [literal style format](https://yaml.org/spec/1.2.2/#812-literal-style) used in YAML.
+For example:
 
 ```yaml
 config:
   cloud-init.user-data: |
+    #cloud-config
+    package_upgrade: true
+    packages:
+      - package1
+      - package2
 ```
 
-```yaml
-config:
-  cloud-init.vendor-data: |
+```{tip}
+See {ref}`cloud-init:reference/faq:how can i debug my user data?` for information on how to check whether the syntax is correct.
 ```
 
-```yaml
-config:
-  cloud-init.network-config: |
-```
+## How to check the `cloud-init` status
 
-!!! Tip
-    You can check whether the syntax is correct with: [cloud-init FAQ - debug user-data](https://cloudinit.readthedocs.io/en/latest/reference/faq.html#how-can-i-debug-my-user-data)
+`cloud-init` runs automatically on the first start of an instance.
+Depending on the configured actions, it might take a while until it finishes.
 
-!!! note
-	Cloud-init may take a while until it is finished, depending on your instructions.
+To check the `cloud-init` status, log on to the instance and enter the following command:
 
-#### Cloud-init status
-You can get the status of cloud-init with:
+    cloud-init status
 
-	cloud-init status
+If the result is `status: running`, `cloud-init` is still working. If the result is `status: done`, it has finished.
 
-Reports:
+Alternatively, use the following flag to be notified only when `cloud-init` is finished:
 
-`status: running`: means cloud-init is still working
-
-or
-
-`status: done`: means cloud-init has finished work
-
-<br>
-
-You can also use the following flag, which will only respond when cloud-init is finished:
-
-	cloud-init status --wait
-
+    cloud-init status --wait
 
 ## How to specify user or vendor data
 
-cloud-init uses the `user-data` (and `vendor-data`) section to do things like upgrade packages, install packages or run arbitrary commands.
+The `user-data` and `vendor-data` configuration can be used to, for example, upgrade or install packages, add users, or run commands.
 
-A `cloud-init.user-data` key must have a first line that indicates what type of [data format](https://cloudinit.readthedocs.io/en/latest/topics/format.html) is being passed to `cloud-init`. For activities like upgrading packages or setting up a user, `#cloud-config` is the data format to use.
+The provided values must have a first line that indicates what type of {ref}`user data format <cloud-init:user_data_formats>` is being passed to `cloud-init`.
+For activities like upgrading packages or setting up a user, `#cloud-config` is the data format to use.
 
-An instance's rootfs will contain the following files as a result:
+The configuration data is stored in the following files in the instance's root file system:
 
 * `/var/lib/cloud/instance/cloud-config.txt`
 * `/var/lib/cloud/instance/user-data.txt`
 
-### Examples for `cloud-init` user data
+### Examples
 
-`cloud-config` examples can be found in the [`cloud-init` documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html).
+See the following sections for the user data (or vendor data) configuration for different example use cases.
 
+You can find more advanced {ref}`examples <cloud-init:yaml_examples>` in the `cloud-init` documentation.
 
-#### Upgrade packages on instance creation
+#### Upgrade packages
 
-To trigger a package upgrade from the repositories for the instance, use the `package_upgrade` key:
+To trigger a package upgrade from the repositories for the instance right after the instance is created, use the `package_upgrade` key:
 
 ```yaml
 config:
@@ -163,7 +139,7 @@ config:
     package_upgrade: true
 ```
 
-#### Install packages on instance creation
+#### Install packages
 
 To install specific packages when the instance is set up, use the `packages` key and specify the package names as a list:
 
@@ -176,9 +152,9 @@ config:
       - openssh-server
 ```
 
-#### Set the time zone on instance creation
+#### Set the time zone
 
-To set the time zone for the instance, use the `timezone` key:
+To set the time zone for the instance on instance creation, use the `timezone` key:
 
 ```yaml
 config:
@@ -189,7 +165,7 @@ config:
 
 #### Run commands
 
-To run a command (such as writing a marker file), use the `runcmd` key and specify commands as a list:
+To run a command (such as writing a marker file), use the `runcmd` key and specify the commands as a list:
 
 ```yaml
 config:
@@ -201,7 +177,8 @@ config:
 
 #### Add a user account
 
-To add a user account, use the `user` key. See the [documentation](https://cloudinit.readthedocs.io/en/latest/topics/examples.html#including-users-and-groups) for more details about default users and which keys are supported.
+To add a user account, use the `user` key.
+See the {ref}`cloud-init:reference/examples:including users and groups` example in the `cloud-init` documentation for details about default users and which keys are supported.
 
 ```yaml
 config:
@@ -213,20 +190,20 @@ config:
 
 ## How to specify network configuration data
 
-`cloud-init` uses the `network-config` data to render the relevant network
-configuration on the system using either `ifupdown` or `netplan` depending
-on the Ubuntu release.
+By default, `cloud-init` configures a DHCP client on an instance's `eth0` interface.
+You can define your own network configuration using the `network-config` option to override the default configuration (this is due to how the template is structured).
 
-The default behavior is to use a DHCP client on an instance's `eth0` interface.
+`cloud-init` then renders the relevant network configuration on the system using either `ifupdown` or `netplan`, depending on the Ubuntu release.
 
-In order to change this you need to define your own network configuration
-using `cloud-init.network-config` key in the configuration dictionary which will override
-the default configuration (this is due to how the template is structured).
+The configuration data is stored in the following files in the instance's root file system:
 
-### Examples for a `cloud-init` network configuration
+* `/var/lib/cloud/seed/nocloud-net/network-config`
+* `/etc/network/interfaces.d/50-cloud-init.cfg` (if using `ifupdown`)
+* `/etc/netplan/50-cloud-init.yaml` (if using `netplan`)
 
-For example, to configure a specific network interface with a static IPv4
-address and also use a custom name server use
+### Example
+
+To configure a specific network interface with a static IPv4 address and also use a custom name server, use the following configuration:
 
 ```yaml
 config:
@@ -245,9 +222,3 @@ config:
       - type: nameserver
         address: 10.10.10.254
 ```
-
-An instance's rootfs will contain the following files as a result:
-
-* `/var/lib/cloud/seed/nocloud-net/network-config`
-* `/etc/network/interfaces.d/50-cloud-init.cfg` (if using `ifupdown`)
-* `/etc/netplan/50-cloud-init.yaml` (if using `netplan`)

--- a/doc/cloud-init.md
+++ b/doc/cloud-init.md
@@ -8,6 +8,16 @@ relatedlinks: https://cloudinit.readthedocs.org/
 
 ```{youtube} https://www.youtube.com/watch?v=8OCG15TAldI
 ```
+`cloud-init` is a software for automatic customization of a Linux distribution.
+
+Features include:
+
+* install packages
+* apply/edit configuration
+* add users
+* and more
+
+See the [Cloud-init documentation](https://cloudinit.readthedocs.io/en/latest/).
 
 ## `cloud-init` support in images
 
@@ -17,6 +27,10 @@ about to use as not all images have the `cloud-init` package installed.
 The images from the `ubuntu` and `ubuntu-daily` remotes are all `cloud-init` enabled.
 Images from the `images` remote have `cloud-init` enabled variants using the `/cloud` suffix, e.g. `images:ubuntu/22.04/cloud`.
 
+Requirements:
+
+* Images with cloud-init support: For example, official LXD images that contain the term `cloud` in `ALIAS` have implemented cloud-init support.
+
 ## Configuration keys
 
 LXD supports [cloud-init](https://launchpad.net/cloud-init) via the following instance or profile
@@ -25,6 +39,10 @@ configuration keys:
 * `cloud-init.vendor-data`
 * `cloud-init.user-data`
 * `cloud-init.network-config`
+
+- `user.meta-data` - see [cloud-init docs - instance metadata](https://cloudinit.readthedocs.io/en/latest/explanation/instancedata.html)
+- `user.vendor-data` - see [cloud-init docs - vendordata](https://cloudinit.readthedocs.io/en/latest/explanation/vendordata.html)
+- `user.network-config` - see [cloud-init docs - network configuration](https://cloudinit.readthedocs.io/en/latest/reference/network-config.html)
 
 For more information, see the [`cloud-init` instance options](instance-options-cloud-init), and the documentation for the [LXD data source](https://cloudinit.readthedocs.io/en/latest/reference/datasources/lxd.html) in the `cloud-init` documentation.
 
@@ -91,6 +109,32 @@ config:
 config:
   cloud-init.network-config: |
 ```
+
+!!! Tip
+    You can check whether the syntax is correct with: [cloud-init FAQ - debug user-data](https://cloudinit.readthedocs.io/en/latest/reference/faq.html#how-can-i-debug-my-user-data)
+
+!!! note
+	Cloud-init may take a while until it is finished, depending on your instructions.
+
+#### Cloud-init status
+You can get the status of cloud-init with:
+
+	cloud-init status
+
+Reports:
+
+`status: running`: means cloud-init is still working
+
+or
+
+`status: done`: means cloud-init has finished work
+
+<br>
+
+You can also use the following flag, which will only respond when cloud-init is finished:
+
+	cloud-init status --wait
+
 
 ## How to specify user or vendor data
 

--- a/doc/reference/devices_disk.md
+++ b/doc/reference/devices_disk.md
@@ -61,7 +61,7 @@ ISO file
       lxc config device add <instance_name> <device_name> disk source=<file_path_on_host>
 
 VM `cloud-init`
-: You can generate a `cloud-init` configuration ISO from the `cloud-init.vendor-data`, `cloud-init.user-data` and `user.meta-data` configuration keys (see {ref}`instance-options`) and attach it to a virtual machine.
+: You can generate a `cloud-init` configuration ISO from the `cloud-init.vendor-data` and `cloud-init.user-data` configuration keys (see {ref}`instance-options`) and attach it to a virtual machine.
   The `cloud-init` that is running inside the VM then detects the drive on boot and applies the configuration.
 
   This source type is applicable only to VMs.

--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -67,7 +67,6 @@ Key                                             | Type      | Default           
 `cloud-init.network-config`                     | string    | `DHCP on eth0`    | no            | if supported by image     | Network configuration for `cloud-init` (content is used as seed value)
 `cloud-init.user-data`                          | string    | `#cloud-config`   | no            | if supported by image     | User data for `cloud-init` (content is used as seed value)
 `cloud-init.vendor-data`                        | string    | `#cloud-config`   | no            | if supported by image     | Vendor data for `cloud-init` (content is used as seed value)
-`user.meta-data`                                | string    | -                 | no            | if supported by image     | Legacy meta-data for `cloud-init` (content is appended to seed value)
 `user.network-config`                           | string    | `DHCP on eth0`    | no            | if supported by image     | Legacy version of `cloud-init.network-config`
 `user.user-data`                                | string    | `#cloud-config`   | no            | if supported by image     | Legacy version of `cloud-init.user-data`
 `user.vendor-data`                              | string    | `#cloud-config`   | no            | if supported by image     | Legacy version of `cloud-init.vendor-data`


### PR DESCRIPTION
Cleanup of the existing docs.
The first two commits move around existing content and do **not** contain content changes. :wink: