### PR TITLE
test: Use per-instance storage pool VG for clustering tests

### DIFF
--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -165,6 +165,7 @@ EOF
       cat >> "${LXD_DIR}/preseed.yaml" <<EOF
   config:
     volume.size: 25MB
+    lvm.vg_name: lxdtest-$(basename "${TEST_DIR}")-${ns}
 EOF
     fi
     if [ "${driver}" = "ceph" ]; then


### PR DESCRIPTION
This brings LVM inline with other storage driver tests. And tries to avoid the "data volume group not empty" errors.