### PR TITLE
GitHub actions: cancel running tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static-analysis:
     env:


### PR DESCRIPTION
This cancels running tests when a change is pushed to the branch (which retriggers the tests anyway) - this definitely makes sense for the documentation checks, but I don't know for sure about the other tests. I don't really see why we wouldn't want it there though.

Also, should we add the same for the builds?