### PR TITLE
lxd/apparmor: fix AppArmor instance_qemu profile

### DIFF
--- a/lxd/apparmor/instance_qemu.go
+++ b/lxd/apparmor/instance_qemu.go
@@ -75,7 +75,7 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
 
   # Snap-specific paths
   /var/snap/lxd/common/ceph/**                         r,
-  /var/snap/microceph/current/conf/**                  r,
+  /var/snap/microceph/*/conf/**                        r,
   {{ .rootPath }}/etc/ceph/**                          r,
   {{ .rootPath }}/run/systemd/resolve/stub-resolv.conf r,
   {{ .rootPath }}/run/systemd/resolve/resolv.conf      r,


### PR DESCRIPTION
Fixing an error that appears during the startup of a vm when lxd uses ceph storage:
```
Error: Failed setting up device via monitor: Failed adding block device for disk device "root": Failed adding block device: error reading conf file /etc/ceph/ceph.conf: No such file or directory
```
Audit log:
```
audit: type=1400 audit(1678041471.655:71): apparmor="DENIED" operation="open" class="file" profile="lxd-adapting-mantis_</var/snap/lxd/common/lxd>" name="/var/snap/microceph/220/conf/ceph.conf" pid=2388 comm="qemu-system-x86" requested_mask="r" denied_mask="r" fsuid=999 ouid=0
```
Related discussion: https://discuss.linuxcontainers.org/t/lxc-launch-ubuntu-22-04-vm-fails-when-lxd-uses-ceph-storage/16580