### PR TITLE
instance: Add Generation ID support for Virtual Machines

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2158,3 +2158,9 @@ This adds the following new configuration options for ZFS storage pools:
 * `volume.zfs.block_mode`
 * `volume.block.mount_options`
 * `volume.block.filesystem`
+
+## `instance_generation_id`
+
+Adds support for instance generation ID. The VM or container generation ID will change whenever the instance's place in time moves backwards. As of now, the generation ID is only exposed through to VM type instances. This allows for the VM guest OS to reinitialize any state it needs to avoid duplicating potential state that has already occurred:
+
+* `volatile.uuid.generation`

--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -420,6 +420,7 @@ Key                                         | Type      | Description
 `volatile.last_state.power`                 | string    | Instance state as of last host shutdown
 `volatile.vsock_id`                         | string    | Instance `vsock` ID used as of last start
 `volatile.uuid`                             | string    | Instance UUID (globally unique across all servers and projects)
+`volatile.uuid.generation`                             | string    | Instance generation UUID that will change whenever the instance's place in time moves backwards (globally unique across all servers and projects)
 `volatile.<name>.apply_quota`               | string    | Disk quota to be applied the next time the instance starts
 `volatile.<name>.ceph_rbd`                  | string    | RBD device path for Ceph disk devices
 `volatile.<name>.host_name`                 | string    | Network device name on the host

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -1966,6 +1966,13 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 		volatileSet["volatile.uuid"] = instUUID
 	}
 
+	// For a container instance, we must also set the generation UUID.
+	genUUID := d.localConfig["volatile.uuid.generation"]
+	if genUUID == "" {
+		genUUID = instUUID
+		volatileSet["volatile.uuid.generation"] = genUUID
+	}
+
 	// Apply any volatile changes that need to be made.
 	err = d.VolatileSet(volatileSet)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1029,6 +1029,13 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		volatileSet["volatile.uuid"] = instUUID
 	}
 
+	// For a VM instance, we must also set the VM generation ID.
+	vmGenUUID := d.localConfig["volatile.uuid.generation"]
+	if vmGenUUID == "" {
+		vmGenUUID = instUUID
+		volatileSet["volatile.uuid.generation"] = vmGenUUID
+	}
+
 	// Generate the config drive.
 	err = d.generateConfigShare()
 	if err != nil {
@@ -1282,6 +1289,11 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 			op.Done(err)
 			return fmt.Errorf("Error updating instance stateful flag: %w", err)
 		}
+	}
+
+	// VM generation ID is only used on UEFI compatible architectures.
+	if d.architectureSupportsUEFI(d.architecture) {
+		qemuCmd = append(qemuCmd, "-device", fmt.Sprintf("vmgenid,guid=%s", d.localConfig["volatile.uuid.generation"]))
 	}
 
 	// SMBIOS only on x86_64 and aarch64.

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -768,6 +768,8 @@ func CreateInternal(s *state.State, args db.InstanceArgs, clearLogDir bool) (Ins
 		args.Config["volatile.uuid"] = uuid.New()
 	}
 
+	args.Config["volatile.uuid.generation"] = args.Config["volatile.uuid"]
+
 	if args.Devices == nil {
 		args.Devices = deviceConfig.Devices{}
 	}

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/gorilla/mux"
+	"github.com/pborman/uuid"
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
@@ -201,6 +202,9 @@ func instanceSnapRestore(s *state.State, projectName string, name string, snap s
 			return err
 		}
 	}
+
+	// Generate a new `volatile.uuid.generation` to differentiate this instance restored from a snapshot from the original instance.
+	source.LocalConfig()["volatile.uuid.generation"] = uuid.New()
 
 	err = inst.Restore(source, stateful)
 	if err != nil {

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -150,6 +150,7 @@ var InstanceConfigKeysAny = map[string]func(value string) error{
 	"volatile.apply_quota":            validate.IsAny,
 	"volatile.uuid":                   validate.Optional(validate.IsUUID),
 	"volatile.vsock_id":               validate.Optional(validate.IsInt64),
+	"volatile.uuid.generation":        validate.Optional(validate.IsUUID),
 
 	// Caller is responsible for full validation of any raw.* value.
 	"raw.idmap": validate.IsAny,

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -361,6 +361,7 @@ var APIExtensions = []string{
 	"instances_placement_scriptlet",
 	"storage_pool_source_wipe",
 	"zfs_block_mode",
+	"instance_generation_id",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -791,6 +791,7 @@ test_backup_different_instance_uuid() {
   echo "==> Checking instances UUID during backup operation"
   lxc launch testimage c1
   initialUUID=$(lxc config get c1 volatile.uuid)
+  initialGenerationID=$(lxc config get c1 volatile.uuid.generation)
 
   # export and import to trigger new UUID generation
   lxc export c1 "${LXD_DIR}/c1.tar.gz"
@@ -798,8 +799,9 @@ test_backup_different_instance_uuid() {
   lxc import "${LXD_DIR}/c1.tar.gz"
 
   newUUID=$(lxc config get c1 volatile.uuid)
+  newGenerationID=$(lxc config get c1 volatile.uuid.generation)
 
-  if [ "${initialUUID}" != "${newUUID}" ]; then
+  if [ "${initialGenerationID}" != "${newGenerationID}" ] || [ "${initialUUID}" != "${newUUID}" ]; then
     echo "==> UUID of the instance should remain the same after importing the backup file"
     false
   fi


### PR DESCRIPTION
closes #11449 

- [**READY FOR REVIEW**] The instance volatile.uuid key should remain unchanged during snapshot and backup restores (effectively reverting https://github.com/lxc/lxd/pull/11385). It should also remain unchanged when moved between servers. However it should change when a new instance is created by copying and existing instance (or snapshot). This should be existing behaviour and require no code changes. But worth checking.
- [**READY FOR REVIEW**] A new instance key called `volatile.uuid.vmgenid` should be added. This should be set to the same value as volatile.uuid at instance creation time (instance.CreateInternal) and should also be populated if not populated to the same value as volatile.uuid during qemu.Start().
- [**READY FOR REVIEW**] Whenever the `volatile.uuid` key is changed the `volatile.uuid.vmgenid` key should be changed to match the `volatile.uuid` value.
- [**READY FOR REVIEW**] The `volatile.uuid.vmgenid` value should be passed to QEMU as the VM's generation ID.
- [**READY FOR REVIEW**] On snapshot and backup restore a new `volatile.uuid.vmgenid` value should be generated and stored in the restored instance's DB record (the snapshot record should not be modified). And the `volatile.uuid` key should remain unchanged.
- [**READY FOR REVIEW** => lxc/lxc-ci#713] The daily test for VMs should check that the QEMU process contains the correct Machine ID and VM generation ID flag.
- [**READY FOR REVIEW**] Depending on the answer to https://github.com/lxc/lxd/issues/11449#issuecomment-1459743902 the test suite can test for the correct population of the volatile.uuid and generation UUID keys for containers too.