### PR TITLE
Instance: Don't mask source errors with disconnection error by adding synchronisation of receipt of control message

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5962,58 +5962,65 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		restore <- nil
 	}()
 
-	source := make(chan *migration.ControlResponse, 1)
+	control := make(chan error)
 	go func() {
-		resp := migration.ControlResponse{}
-		err := args.ControlReceive(&resp.MigrationControl)
+		resp := migration.MigrationControl{}
+		err := args.ControlReceive(&resp)
 		if err != nil {
-			resp.Err = err
-			source <- &resp
-
-			return
+			err = fmt.Errorf("Got error reading migration source: %w", err)
+		} else if !resp.GetSuccess() {
+			err = fmt.Errorf(resp.GetMessage())
 		}
 
-		source <- &resp
+		control <- err
 	}()
 
-	select {
-	case err = <-restore:
-		if err != nil {
-			return err
+	var resultErr error
+	for i := 0; i < 2; i++ {
+		var err error
+
+		select {
+		case err = <-control:
+			// Send response to source to confirm receipt if first result and control not closed.
+			var wsCloseErr *websocket.CloseError
+			if i == 0 && !errors.As(err, &wsCloseErr) {
+				msg := migration.MigrationControl{
+					Success: proto.Bool(err == nil),
+					Message: proto.String(err.Error()),
+				}
+
+				sendErr := args.ControlSend(&msg)
+				if sendErr != nil {
+					d.logger.Warn("Failed sending control receipt to source", logger.Ctx{"err": sendErr})
+				}
+			}
+		case err = <-restore:
+			// Send restore response to source if first result.
+			if i == 0 {
+				msg := migration.MigrationControl{
+					Success: proto.Bool(err == nil),
+				}
+
+				if err != nil {
+					msg.Message = proto.String(err.Error())
+				}
+
+				d.logger.Debug("Sent migration completion response to source", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
+				sendErr := args.ControlSend(&msg)
+				if sendErr != nil {
+					d.logger.Warn("Failed sending control error to source", logger.Ctx{"err": sendErr})
+				}
+			}
 		}
 
-		break
-	case msg := <-source:
-		if msg.Err != nil {
-			return fmt.Errorf("Got error reading migration source: %w", msg.Err)
+		// Record first non-nil error to return.
+		if err != nil && i == 0 {
+			resultErr = err
 		}
-
-		if !msg.GetSuccess() {
-			return fmt.Errorf(msg.GetMessage())
-		}
-
-		return fmt.Errorf("Unknown message from migration source: %v", msg.GetMessage())
-	}
-
-	d.logger.Debug("Sending migration completion response to source")
-
-	// Send success message to other side.
-	msg := migration.MigrationControl{
-		Success: proto.Bool(true),
-	}
-
-	sendErr := args.ControlSend(&msg)
-	if sendErr != nil {
-		return fmt.Errorf("Failed sending migration completion response to source: %w", err)
-	}
-
-	err = d.DeferTemplateApply(instance.TemplateTriggerCopy)
-	if err != nil {
-		return err
 	}
 
 	revert.Success()
-	return nil
+	return resultErr
 }
 
 // Migrate migrates the instance to another node.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5828,66 +5828,78 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			err = d.start(true, args.InstanceOperation)
 			if err != nil {
 				restore <- err
-
 				return
 			}
+		}
+
+		err = d.DeferTemplateApply(instance.TemplateTriggerCopy)
+		if err != nil {
+			restore <- err
+			return
 		}
 
 		restore <- nil
 	}()
 
-	source := make(chan *migration.ControlResponse, 1)
+	control := make(chan error)
 	go func() {
-		resp := migration.ControlResponse{}
-		err := args.ControlReceive(&resp.MigrationControl)
+		resp := migration.MigrationControl{}
+		err := args.ControlReceive(&resp)
 		if err != nil {
-			resp.Err = err
-			source <- &resp
-
-			return
+			err = fmt.Errorf("Got error reading migration source: %w", err)
+		} else if !resp.GetSuccess() {
+			err = fmt.Errorf(resp.GetMessage())
 		}
 
-		source <- &resp
+		control <- err
 	}()
 
-	select {
-	case err = <-restore:
-		if err != nil {
-			return err
+	var resultErr error
+	for i := 0; i < 2; i++ {
+		var err error
+
+		select {
+		case err = <-control:
+			// Send response to source to confirm receipt if first result and control not closed.
+			var wsCloseErr *websocket.CloseError
+			if i == 0 && !errors.As(err, &wsCloseErr) {
+				msg := migration.MigrationControl{
+					Success: proto.Bool(err == nil),
+					Message: proto.String(err.Error()),
+				}
+
+				sendErr := args.ControlSend(&msg)
+				if sendErr != nil {
+					d.logger.Warn("Failed sending control receipt to source", logger.Ctx{"err": sendErr})
+				}
+			}
+		case err = <-restore:
+			// Send restore response to source if first result.
+			if i == 0 {
+				msg := migration.MigrationControl{
+					Success: proto.Bool(err == nil),
+				}
+
+				if err != nil {
+					msg.Message = proto.String(err.Error())
+				}
+
+				d.logger.Debug("Sent migration completion response to source", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
+				sendErr := args.ControlSend(&msg)
+				if sendErr != nil {
+					d.logger.Warn("Failed sending control error to source", logger.Ctx{"err": sendErr})
+				}
+			}
 		}
 
-		break
-	case msg := <-source:
-		if msg.Err != nil {
-			return fmt.Errorf("Got error reading migration source: %w", msg.Err)
+		// Record first non-nil error to return.
+		if err != nil && i == 0 {
+			resultErr = err
 		}
-
-		if !msg.GetSuccess() {
-			return fmt.Errorf(msg.GetMessage())
-		}
-
-		return fmt.Errorf("Unknown message from migration source: %v", msg.GetMessage())
-	}
-
-	d.logger.Debug("Sending migration completion response to source")
-
-	// Send success message to other side.
-	msg := migration.MigrationControl{
-		Success: proto.Bool(true),
-	}
-
-	sendErr := args.ControlSend(&msg)
-	if sendErr != nil {
-		return fmt.Errorf("Failed sending migration completion response to source: %w", err)
-	}
-
-	err = d.DeferTemplateApply(instance.TemplateTriggerCopy)
-	if err != nil {
-		return err
 	}
 
 	revert.Success()
-	return nil
+	return resultErr
 }
 
 // CGroupSet is not implemented for VMs.

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -65,6 +65,7 @@ func (c *migrationFields) send(m proto.Message) error {
 	c.controlLock.Lock()
 	defer c.controlLock.Unlock()
 
+	_ = c.controlConn.SetWriteDeadline(time.Now().Add(time.Second * 30))
 	err := migration.ProtoSend(c.controlConn, m)
 	if err != nil {
 		return err

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -257,21 +257,6 @@ func (c *migrationSink) Do(state *state.State, instOp *operationlock.InstanceOpe
 	})
 	if err != nil {
 		l.Error("Failed migration on target", logger.Ctx{"err": err})
-
-		var wsCloseErr *websocket.CloseError
-		if !errors.As(err, &wsCloseErr) {
-			// Send error to other side if not closed.
-			msg := migration.MigrationControl{
-				Success: proto.Bool(err == nil),
-				Message: proto.String(err.Error()),
-			}
-
-			sendErr := sender(&msg)
-			if sendErr != nil {
-				return fmt.Errorf("Failed sending control error to source: %v (%w)", sendErr, err)
-			}
-		}
-
 		return fmt.Errorf("Failed migration on target: %w", err)
 	}
 


### PR DESCRIPTION
This is done in a way that is backward compatible with older clients (by not waiting forever for a confirmation receipt).

I needed this as part of my live VM migration work as I noticed that migration errors were randomly being masked by disconnection errors. This has been a long term issue and was not introduced by the recent changes in:

https://github.com/lxc/lxd/pull/11440
https://github.com/lxc/lxd/pull/11414