### PR TITLE
Instance: Fix hang during migration if target member encounters an error

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -651,8 +651,8 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 		}
 
 		// Call the control handler with a connection to the control socket
-		if args.Control != nil && fds["control"] != "" {
-			conn, err := r.GetOperationWebsocket(opAPI.ID, fds["control"])
+		if args.Control != nil && fds[api.SecretNameControl] != "" {
+			conn, err := r.GetOperationWebsocket(opAPI.ID, fds[api.SecretNameControl])
 			if err != nil {
 				return nil, err
 			}
@@ -1546,11 +1546,11 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 
 	var controlConn *websocket.Conn
 	// Call the control handler with a connection to the control socket
-	if fds["control"] == "" {
+	if fds[api.SecretNameControl] == "" {
 		return nil, fmt.Errorf("Did not receive a file descriptor for the control channel")
 	}
 
-	controlConn, err = r.GetOperationWebsocket(opAPI.ID, fds["control"])
+	controlConn, err = r.GetOperationWebsocket(opAPI.ID, fds[api.SecretNameControl])
 	if err != nil {
 		return nil, err
 	}

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
 	go.starlark.net v0.0.0-20230128213706-3f75dec8e403
 	golang.org/x/crypto v0.6.0
+	golang.org/x/sync v0.1.0
 	golang.org/x/sys v0.5.0
 	golang.org/x/term v0.5.0
 	golang.org/x/text v0.7.0
@@ -130,7 +131,6 @@ require (
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.7.0 // indirect
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	google.golang.org/genproto v0.0.0-20230209215440-0dfe4f8abfcc // indirect
 	google.golang.org/grpc v1.53.0 // indirect

--- a/lxc-to-lxd/utils.go
+++ b/lxc-to-lxd/utils.go
@@ -5,18 +5,19 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/migration"
+	"github.com/lxc/lxd/shared/api"
 )
 
 func transferRootfs(dst lxd.ContainerServer, op lxd.Operation, rootfs string, rsyncArgs string) error {
 	opAPI := op.Get()
 
 	// Connect to the websockets
-	wsControl, err := op.GetWebsocket(opAPI.Metadata["control"].(string))
+	wsControl, err := op.GetWebsocket(opAPI.Metadata[api.SecretNameControl].(string))
 	if err != nil {
 		return err
 	}
 
-	wsFs, err := op.GetWebsocket(opAPI.Metadata["fs"].(string))
+	wsFs, err := op.GetWebsocket(opAPI.Metadata[api.SecretNameFilesystem].(string))
 	if err != nil {
 		return err
 	}

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -167,7 +167,7 @@ func (s *execWs) Metadata() any {
 	fds := shared.Jmap{}
 	for fd, secret := range s.fds {
 		if fd == execWSControl {
-			fds["control"] = secret
+			fds[api.SecretNameControl] = secret
 		} else {
 			fds[strconv.Itoa(fd)] = secret
 		}

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -31,12 +31,12 @@ func transferRootfs(ctx context.Context, dst lxd.InstanceServer, op lxd.Operatio
 	opAPI := op.Get()
 
 	// Connect to the websockets
-	wsControl, err := op.GetWebsocket(opAPI.Metadata["control"].(string))
+	wsControl, err := op.GetWebsocket(opAPI.Metadata[api.SecretNameControl].(string))
 	if err != nil {
 		return err
 	}
 
-	wsFs, err := op.GetWebsocket(opAPI.Metadata["fs"].(string))
+	wsFs, err := op.GetWebsocket(opAPI.Metadata[api.SecretNameFilesystem].(string))
 	if err != nil {
 		return err
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5188,7 +5188,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 		}
 	}
 
-	// If s.live is true or Criu is set to CRIUTYPE_NONE rather than nil, it indicates that the source instance
+	// If s.live is true or Criu is set to CRIUType_NONE rather than nil, it indicates that the source instance
 	// is running, and if we are doing a non-optimized transfer (i.e using rsync or raw block transfer) then we
 	// should do a two stage transfer to minimize downtime.
 	instanceRunning := args.Live || (respHeader.Criu != nil && *respHeader.Criu == migration.CRIUType_NONE)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6020,8 +6020,10 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 		}
 
-		// Record first non-nil error to return.
+		// Handle first non-nil error to return.
 		if err != nil && i == 0 {
+			args.Disconnect() // Close everything down (causes receive go routines to end).
+
 			resultErr = err
 		}
 	}

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -6012,7 +6012,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 					msg.Message = proto.String(err.Error())
 				}
 
-				d.logger.Debug("Sent migration completion response to source", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
+				d.logger.Debug("Sending migration completion response to source", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
 				sendErr := args.ControlSend(&msg)
 				if sendErr != nil {
 					d.logger.Warn("Failed sending control error to source", logger.Ctx{"err": sendErr})

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3676,15 +3676,13 @@ func (d *lxc) delete(force bool) error {
 				return err
 			}
 		} else {
-			// Remove all snapshots by initialising each snapshot as an Instance and
-			// calling its Delete function.
+			// Remove all snapshots.
 			err := instance.DeleteSnapshots(d)
 			if err != nil {
-				d.logger.Error("Failed to delete instance snapshots", logger.Ctx{"err": err})
-				return err
+				return fmt.Errorf("Failed deleting instance snapshots; %w", err)
 			}
 
-			// Remove the storage volume, snapshot volumes and database records.
+			// Remove the storage volume and database records.
 			err = pool.DeleteInstance(d, nil)
 			if err != nil {
 				return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5119,14 +5119,13 @@ func (d *qemu) delete(force bool) error {
 				return err
 			}
 		} else {
-			// Remove all snapshots by initialising each snapshot as an Instance and
-			// calling its Delete function.
+			// Remove all snapshots.
 			err := instance.DeleteSnapshots(d)
 			if err != nil {
-				return err
+				return fmt.Errorf("Failed deleting instance snapshots; %w", err)
 			}
 
-			// Remove the storage volume, snapshot volumes and database records.
+			// Remove the storage volume and database records.
 			err = pool.DeleteInstance(d, nil)
 			if err != nil {
 				return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5587,7 +5587,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 
 	d.logger.Debug("Starting storage migration phase")
 
-	err = pool.MigrateInstance(d, args.DataConn, volSourceArgs, d.op)
+	err = pool.MigrateInstance(d, args.FilesystemConn, volSourceArgs, d.op)
 	if err != nil {
 		return err
 	}
@@ -5818,7 +5818,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 		}
 
-		err = pool.CreateInstanceFromMigration(d, args.DataConn, volTargetArgs, d.op)
+		err = pool.CreateInstanceFromMigration(d, args.FilesystemConn, volTargetArgs, d.op)
 		if err != nil {
 			restore <- fmt.Errorf("Failed creating instance on target: %w", err)
 			return

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -31,6 +31,7 @@ import (
 	"github.com/mdlayher/vsock"
 	"github.com/pborman/uuid"
 	"github.com/pkg/sftp"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/proto"
 	"gopkg.in/yaml.v2"
@@ -5755,8 +5756,56 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	revert := revert.New()
 	defer revert.Fail()
 
-	restore := make(chan error)
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Start control connection monitor.
+	g.Go(func() error {
+		d.logger.Debug("Migrate receive control monitor started")
+		defer d.logger.Debug("Migrate receive control monitor finished")
+
+		controlResult := make(chan error, 1) // Buffered to allow go routine to end if no readers.
+
+		// This will read the result message from the source side and detect disconnections.
+		go func() {
+			resp := migration.MigrationControl{}
+			err := args.ControlReceive(&resp)
+			if err != nil {
+				err = fmt.Errorf("Error reading migration control source: %w", err)
+			} else if !resp.GetSuccess() {
+				err = fmt.Errorf("Error from migration control source: %s", resp.GetMessage())
+			}
+
+			controlResult <- err
+		}()
+
+		// End as soon as we get control message/disconnection from the source side or a local error.
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case err = <-controlResult:
+		}
+
+		return err
+	})
+
+	// Start error monitoring routine, this will detect when an error is returned from the other routines,
+	// and if that happens it will disconnect the migration connections which will trigger the other routines
+	// to finish.
 	go func() {
+		<-ctx.Done()
+		args.Disconnect()
+	}()
+
+	// Start filesystem transfer routine and initialise a channel that is closed when the routine finishes.
+	fsTransferDone := make(chan struct{})
+	g.Go(func() error {
+		defer close(fsTransferDone)
+
+		d.logger.Debug("Migrate receive transfer started")
+		defer d.logger.Debug("Migrate receive transfer finished")
+
+		var err error
+
 		snapshots := make([]*migration.Snapshot, 0)
 
 		// Legacy: we only sent the snapshot names, so we just copy the instances's config over,
@@ -5814,8 +5863,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		}
 
 		if parentStoragePool == "" {
-			restore <- fmt.Errorf("Instance's root device is missing the pool property")
-			return
+			return fmt.Errorf("Instance's root device is missing the pool property")
 		}
 
 		// A zero length Snapshots slice indicates volume only migration in
@@ -5826,8 +5874,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 				volTargetArgs.Snapshots = append(volTargetArgs.Snapshots, *snap.Name)
 				snapArgs, err := instance.SnapshotProtobufToInstanceArgs(d.state, d, snap)
 				if err != nil {
-					restore <- err
-					return
+					return err
 				}
 
 				// Ensure that snapshot and parent instance have the same storage pool in
@@ -5844,8 +5891,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 				// Create the snapshot instance.
 				_, snapInstOp, cleanup, err := instance.CreateInternal(d.state, *snapArgs, true)
 				if err != nil {
-					restore <- fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
-					return
+					return fmt.Errorf("Failed creating instance snapshot record %q: %w", snapArgs.Name, err)
 				}
 
 				revert.Add(cleanup)
@@ -5855,14 +5901,18 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 		err = pool.CreateInstanceFromMigration(d, args.FilesystemConn, volTargetArgs, d.op)
 		if err != nil {
-			restore <- fmt.Errorf("Failed creating instance on target: %w", err)
-			return
+			return fmt.Errorf("Failed creating instance on target: %w", err)
 		}
 
 		// Only delete entire instance on error if the pool volume creation has succeeded to avoid
 		// deleting an existing conflicting volume.
 		if !volTargetArgs.Refresh {
 			revert.Add(func() { _ = d.delete(true) })
+		}
+
+		err = d.DeferTemplateApply(instance.TemplateTriggerCopy)
+		if err != nil {
+			return err
 		}
 
 		if args.Live {
@@ -5872,81 +5922,59 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 			err = d.start(true, args.InstanceOperation)
 			if err != nil {
-				restore <- err
-				return
+				return err
 			}
 		}
 
-		err = d.DeferTemplateApply(instance.TemplateTriggerCopy)
+		return nil
+	})
+
+	{
+		// Wait until the filesystem transfer routine has finished.
+		<-fsTransferDone
+
+		// If context is cancelled by this stage, then an error has occurred.
+		// Wait for all routines to finish and collect the first error that occurred.
+		if ctx.Err() != nil {
+			err := g.Wait()
+
+			// Send failure response to source.
+			msg := migration.MigrationControl{
+				Success: proto.Bool(err == nil),
+			}
+
+			if err != nil {
+				msg.Message = proto.String(err.Error())
+			}
+
+			d.logger.Debug("Sending migration failure response to source", logger.Ctx{"err": err})
+			sendErr := args.ControlSend(&msg)
+			if sendErr != nil {
+				d.logger.Warn("Failed sending migration failure to source", logger.Ctx{"err": sendErr})
+			}
+
+			return err
+		}
+
+		// Send success response to source to control as nothing has gone wrong so far.
+		msg := migration.MigrationControl{
+			Success: proto.Bool(true),
+		}
+
+		d.logger.Debug("Sending migration success response to source", logger.Ctx{"success": msg.GetSuccess()})
+		err := args.ControlSend(&msg)
 		if err != nil {
-			restore <- err
-			return
+			d.logger.Warn("Failed sending migration success to source", logger.Ctx{"err": err})
+			return fmt.Errorf("Failed sending migration success to source: %w", err)
 		}
 
-		restore <- nil
-	}()
+		// Wait for all routines to finish (in this case it will be the control monitor) but do
+		// not collect the error, as it will just be a disconnect error from the source.
+		_ = g.Wait()
 
-	control := make(chan error)
-	go func() {
-		resp := migration.MigrationControl{}
-		err := args.ControlReceive(&resp)
-		if err != nil {
-			err = fmt.Errorf("Got error reading migration source: %w", err)
-		} else if !resp.GetSuccess() {
-			err = fmt.Errorf(resp.GetMessage())
-		}
-
-		control <- err
-	}()
-
-	var resultErr error
-	for i := 0; i < 2; i++ {
-		var err error
-
-		select {
-		case err = <-control:
-			// Send response to source to confirm receipt if first result and control not closed.
-			var wsCloseErr *websocket.CloseError
-			if i == 0 && !errors.As(err, &wsCloseErr) {
-				msg := migration.MigrationControl{
-					Success: proto.Bool(err == nil),
-					Message: proto.String(err.Error()),
-				}
-
-				sendErr := args.ControlSend(&msg)
-				if sendErr != nil {
-					d.logger.Warn("Failed sending control receipt to source", logger.Ctx{"err": sendErr})
-				}
-			}
-		case err = <-restore:
-			// Send restore response to source if first result.
-			if i == 0 {
-				msg := migration.MigrationControl{
-					Success: proto.Bool(err == nil),
-				}
-
-				if err != nil {
-					msg.Message = proto.String(err.Error())
-				}
-
-				d.logger.Debug("Sending migration completion response to source", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
-				sendErr := args.ControlSend(&msg)
-				if sendErr != nil {
-					d.logger.Warn("Failed sending control error to source", logger.Ctx{"err": sendErr})
-				}
-			}
-		}
-
-		// Handle first non-nil error to return.
-		if err != nil && i == 0 {
-			args.Disconnect() // Close everything down (causes receive go routines to end).
-
-			resultErr = err
-		}
+		revert.Success()
+		return nil
 	}
-
-	revert.Success()
-	return resultErr
 }
 
 // CGroupSet is not implemented for VMs.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5895,7 +5895,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 					msg.Message = proto.String(err.Error())
 				}
 
-				d.logger.Debug("Sent migration completion response to source", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
+				d.logger.Debug("Sending migration completion response to source", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
 				sendErr := args.ControlSend(&msg)
 				if sendErr != nil {
 					d.logger.Warn("Failed sending control error to source", logger.Ctx{"err": sendErr})

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5578,37 +5578,72 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 		}
 	}
 
-	if args.Live {
-		err = d.Stop(true)
-		if err != nil {
-			return fmt.Errorf("Failed statefully stopping instance: %w", err)
+	g, ctx := errgroup.WithContext(context.Background())
+
+	// Start control connection monitor.
+	g.Go(func() error {
+		d.logger.Debug("Migrate send control monitor started")
+		defer d.logger.Debug("Migrate send control monitor finished")
+
+		controlResult := make(chan error, 1) // Buffered to allow go routine to end if no readers.
+
+		// This will read the result message from the target side and detect disconnections.
+		go func() {
+			resp := migration.MigrationControl{}
+			err := args.ControlReceive(&resp)
+			if err != nil {
+				err = fmt.Errorf("Error reading migration control target: %w", err)
+			} else if !resp.GetSuccess() {
+				err = fmt.Errorf("Error from migration control target: %s", resp.GetMessage())
+			}
+
+			controlResult <- err
+		}()
+
+		// End as soon as we get control message/disconnection from the target side or a local error.
+		select {
+		case <-ctx.Done():
+			err = ctx.Err()
+		case err = <-controlResult:
 		}
-	}
 
-	d.logger.Debug("Starting storage migration phase")
+		return err
+	})
 
-	err = pool.MigrateInstance(d, args.FilesystemConn, volSourceArgs, d.op)
-	if err != nil {
+	// Start error monitoring routine, this will detect when an error is returned from the other routines,
+	// and if that happens it will disconnect the migration connections which will trigger the other routines
+	// to finish.
+	go func() {
+		<-ctx.Done()
+		args.Disconnect()
+	}()
+
+	g.Go(func() error {
+		d.logger.Debug("Migrate send transfer started")
+		defer d.logger.Debug("Migrate send transfer finished")
+
+		var err error
+
+		if args.Live {
+			err = d.Stop(true)
+			if err != nil {
+				return fmt.Errorf("Failed statefully stopping instance: %w", err)
+			}
+		}
+
+		err = pool.MigrateInstance(d, args.FilesystemConn, volSourceArgs, d.op)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	// Wait for routines to finish and collect first error.
+	{
+		err := g.Wait()
 		return err
 	}
-
-	d.logger.Debug("Finished storage migration phase")
-
-	// Receive response from target.
-	d.logger.Debug("Waiting for migration completion response from target")
-	msg := migration.MigrationControl{}
-	err = args.ControlReceive(&msg)
-	if err != nil {
-		return fmt.Errorf("Failed receiving migration completion response: %w", err)
-	}
-
-	d.logger.Debug("Got migration completion response from target", logger.Ctx{"success": msg.GetSuccess(), "message": msg.GetMessage()})
-
-	if !msg.GetSuccess() {
-		return fmt.Errorf(msg.GetMessage())
-	}
-
-	return nil
 }
 
 func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5903,8 +5903,10 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			}
 		}
 
-		// Record first non-nil error to return.
+		// Handle first non-nil error to return.
 		if err != nil && i == 0 {
+			args.Disconnect() // Close everything down (causes receive go routines to end).
+
 			resultErr = err
 		}
 	}

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -206,8 +206,8 @@ type Info struct {
 type MigrateArgs struct {
 	ControlSend    func(m proto.Message) error
 	ControlReceive func(m proto.Message) error
-	LiveConn       io.ReadWriteCloser
-	DataConn       io.ReadWriteCloser
+	StateConn      io.ReadWriteCloser
+	FilesystemConn io.ReadWriteCloser
 	Snapshots      bool
 	Live           bool
 	Disconnect     func()

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -210,6 +210,7 @@ type MigrateArgs struct {
 	DataConn       io.ReadWriteCloser
 	Snapshots      bool
 	Live           bool
+	Disconnect     func()
 }
 
 // MigrateSendArgs represent arguments for instance migration send.

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -64,7 +64,7 @@ func (s *consoleWs) Metadata() any {
 	fds := shared.Jmap{}
 	for fd, secret := range s.fds {
 		if fd == -1 {
-			fds["control"] = secret
+			fds[api.SecretNameControl] = secret
 		} else {
 			fds[strconv.Itoa(fd)] = secret
 		}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -55,7 +55,7 @@ func (s *execWs) Metadata() any {
 	fds := shared.Jmap{}
 	for fd, secret := range s.fds {
 		if fd == execWSControl {
-			fds["control"] = secret
+			fds[api.SecretNameControl] = secret
 		} else {
 			fds[strconv.Itoa(fd)] = secret
 		}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -323,7 +323,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, profile
 		push = true
 	}
 
-	migrationArgs := MigrationSinkArgs{
+	migrationArgs := migrationSinkArgs{
 		URL: req.Source.Operation,
 		Dialer: websocket.Dialer{
 			TLSClientConfig:  config,

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -1167,7 +1167,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		}
 	}
 
-	if targetMemberInfo != nil && targetMemberInfo.Address != "" && targetMemberInfo.Address != s.ServerName {
+	if targetMemberInfo != nil && targetMemberInfo.Address != "" && targetMemberInfo.Name != s.ServerName {
 		client, err := cluster.Connect(targetMemberInfo.Address, d.endpoints.NetworkCert(), d.serverCert(), r, true)
 		if err != nil {
 			return response.SmartError(err)
@@ -1176,7 +1176,7 @@ func instancesPost(d *Daemon, r *http.Request) response.Response {
 		client = client.UseProject(targetProjectName)
 		client = client.UseTarget(targetMemberInfo.Name)
 
-		logger.Debug("Forward instance post request", logger.Ctx{"member": targetMemberInfo.Address})
+		logger.Debug("Forward instance post request", logger.Ctx{"local": s.ServerName, "target": targetMemberInfo.Name, "targetAddress": targetMemberInfo.Address})
 		op, err := client.CreateInstance(req)
 		if err != nil {
 			return response.SmartError(err)

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -281,7 +281,7 @@ func createFromMigration(d *Daemon, r *http.Request, projectName string, profile
 			return response.InternalError(err)
 		}
 
-		// Create the instance and storage DB records for main instance.
+		// Create the instance DB record for main instance.
 		// Note: At this stage we do not yet know if snapshots are going to be received and so we cannot
 		// create their DB records. This will be done if needed in the migrationSink.Do() function called
 		// as part of the operation below.

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -83,6 +83,7 @@ func (c *migrationFields) disconnect() {
 
 	c.controlLock.Lock()
 	if c.controlConn != nil {
+		_ = c.controlConn.SetWriteDeadline(time.Now().Add(time.Second * 30))
 		_ = c.controlConn.WriteMessage(websocket.CloseMessage, closeMsg)
 		_ = c.controlConn.Close()
 		c.controlConn = nil /* don't close twice */

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/tcp"
@@ -147,12 +148,12 @@ type migrationSourceWs struct {
 
 func (s *migrationSourceWs) Metadata() any {
 	secrets := shared.Jmap{
-		"control": s.controlSecret,
-		"fs":      s.fsSecret,
+		api.SecretNameControl:    s.controlSecret,
+		api.SecretNameFilesystem: s.fsSecret,
 	}
 
 	if s.stateSecret != "" {
-		secrets["criu"] = s.stateSecret
+		secrets[api.SecretNameState] = s.stateSecret
 	}
 
 	return secrets
@@ -245,11 +246,11 @@ func (s *migrationSourceWs) ConnectTarget(certificate string, operation string, 
 		var conn **websocket.Conn
 
 		switch name {
-		case "control":
+		case api.SecretNameControl:
 			conn = &s.controlConn
-		case "fs":
+		case api.SecretNameFilesystem:
 			conn = &s.fsConn
-		case "criu":
+		case api.SecretNameState:
 			conn = &s.stateConn
 		default:
 			return fmt.Errorf("Unknown secret provided: %s", name)
@@ -329,12 +330,12 @@ func (s *migrationSink) connectWithSecret(secret string) (*websocket.Conn, error
 // Metadata returns metadata for the migration sink.
 func (s *migrationSink) Metadata() any {
 	secrets := shared.Jmap{
-		"control": s.dest.controlSecret,
-		"fs":      s.dest.fsSecret,
+		api.SecretNameControl:    s.dest.controlSecret,
+		api.SecretNameFilesystem: s.dest.fsSecret,
 	}
 
 	if s.dest.stateSecret != "" {
-		secrets["criu"] = s.dest.stateSecret
+		secrets[api.SecretNameState] = s.dest.stateSecret
 	}
 
 	return secrets

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -288,7 +288,7 @@ type migrationSink struct {
 }
 
 // MigrationSinkArgs arguments to configure migration sink.
-type MigrationSinkArgs struct {
+type migrationSinkArgs struct {
 	// General migration fields
 	Dialer  websocket.Dialer
 	Push    bool

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -34,8 +34,8 @@ type migrationFields struct {
 	controlConn   *websocket.Conn
 	controlLock   sync.Mutex
 
-	criuSecret string
-	criuConn   *websocket.Conn
+	stateSecret string
+	stateConn   *websocket.Conn
 
 	fsSecret string
 	fsConn   *websocket.Conn
@@ -103,8 +103,8 @@ func (c *migrationFields) disconnect() {
 		_ = c.fsConn.Close()
 	}
 
-	if c.criuConn != nil {
-		_ = c.criuConn.Close()
+	if c.stateConn != nil {
+		_ = c.stateConn.Close()
 	}
 }
 
@@ -151,8 +151,8 @@ func (s *migrationSourceWs) Metadata() any {
 		"fs":      s.fsSecret,
 	}
 
-	if s.criuSecret != "" {
-		secrets["criu"] = s.criuSecret
+	if s.stateSecret != "" {
+		secrets["criu"] = s.stateSecret
 	}
 
 	return secrets
@@ -169,8 +169,8 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 	switch secret {
 	case s.controlSecret:
 		conn = &s.controlConn
-	case s.criuSecret:
-		conn = &s.criuConn
+	case s.stateSecret:
+		conn = &s.stateConn
 	case s.fsSecret:
 		conn = &s.fsConn
 	default:
@@ -197,7 +197,7 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 	*conn = c
 
 	// Check criteria for considering all channels to be connected.
-	if s.instance != nil && s.instance.Type() == instancetype.Container && s.live && s.criuConn == nil {
+	if s.instance != nil && s.instance.Type() == instancetype.Container && s.live && s.stateConn == nil {
 		return nil
 	}
 
@@ -250,7 +250,7 @@ func (s *migrationSourceWs) ConnectTarget(certificate string, operation string, 
 		case "fs":
 			conn = &s.fsConn
 		case "criu":
-			conn = &s.criuConn
+			conn = &s.stateConn
 		default:
 			return fmt.Errorf("Unknown secret provided: %s", name)
 		}
@@ -333,8 +333,8 @@ func (s *migrationSink) Metadata() any {
 		"fs":      s.dest.fsSecret,
 	}
 
-	if s.dest.criuSecret != "" {
-		secrets["criu"] = s.dest.criuSecret
+	if s.dest.stateSecret != "" {
+		secrets["criu"] = s.dest.stateSecret
 	}
 
 	return secrets
@@ -352,8 +352,8 @@ func (s *migrationSink) Connect(op *operations.Operation, r *http.Request, w htt
 	switch secret {
 	case s.dest.controlSecret:
 		conn = &s.dest.controlConn
-	case s.dest.criuSecret:
-		conn = &s.dest.criuConn
+	case s.dest.stateSecret:
+		conn = &s.dest.stateConn
 	case s.dest.fsSecret:
 		conn = &s.dest.fsConn
 	default:
@@ -370,7 +370,7 @@ func (s *migrationSink) Connect(op *operations.Operation, r *http.Request, w htt
 	*conn = c
 
 	// Check criteria for considering all channels to be connected.
-	if s.src.instance != nil && s.src.instance.Type() == instancetype.Container && s.dest.live && s.dest.criuConn == nil {
+	if s.src.instance != nil && s.src.instance.Type() == instancetype.Container && s.dest.live && s.dest.stateConn == nil {
 		return nil
 	}
 

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -66,6 +66,10 @@ func (c *migrationFields) send(m proto.Message) error {
 	c.controlLock.Lock()
 	defer c.controlLock.Unlock()
 
+	if c.controlConn == nil {
+		return fmt.Errorf("Control connection not initialized")
+	}
+
 	_ = c.controlConn.SetWriteDeadline(time.Now().Add(time.Second * 30))
 	err := migration.ProtoSend(c.controlConn, m)
 	if err != nil {

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -34,12 +34,12 @@ func newMigrationSource(inst instance.Instance, stateful bool, instanceOnly bool
 	var err error
 	ret.controlSecret, err = shared.RandomCryptoString()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed creating migration source secret for control websocket: %w", err)
 	}
 
 	ret.fsSecret, err = shared.RandomCryptoString()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Failed creating migration source secret for filesystem websocket: %w", err)
 	}
 
 	if stateful && inst.IsRunning() {
@@ -53,7 +53,7 @@ func newMigrationSource(inst instance.Instance, stateful bool, instanceOnly bool
 
 			ret.stateSecret, err = shared.RandomCryptoString()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("Failed creating migration source secret for state websocket: %w", err)
 			}
 		}
 	}
@@ -147,33 +147,33 @@ func newMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 	if sink.push {
 		sink.dest.controlSecret, err = shared.RandomCryptoString()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed creating migration sink secret for control websocket: %w", err)
 		}
 
 		sink.dest.fsSecret, err = shared.RandomCryptoString()
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("Failed creating migration sink secret for filesystem websocket: %w", err)
 		}
 
 		sink.dest.live = args.Live
 		if sink.dest.live {
 			sink.dest.stateSecret, err = shared.RandomCryptoString()
 			if err != nil {
-				return nil, err
+				return nil, fmt.Errorf("Failed creating migration sink secret for state websocket: %w", err)
 			}
 		}
 	} else {
-		sink.src.controlSecret, ok = args.Secrets["control"]
+		sink.src.controlSecret, ok = args.Secrets[api.SecretNameControl]
 		if !ok {
-			return nil, fmt.Errorf("Missing control secret")
+			return nil, fmt.Errorf("Missing migration sink secret for control websocket")
 		}
 
-		sink.src.fsSecret, ok = args.Secrets["fs"]
+		sink.src.fsSecret, ok = args.Secrets[api.SecretNameFilesystem]
 		if !ok {
-			return nil, fmt.Errorf("Missing fs secret")
+			return nil, fmt.Errorf("Missing migration sink secret for filesystem websocket")
 		}
 
-		sink.src.stateSecret, ok = args.Secrets["criu"]
+		sink.src.stateSecret, ok = args.Secrets[api.SecretNameState]
 		sink.src.live = ok || args.Live
 	}
 

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -119,7 +119,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 	return nil
 }
 
-func newMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {
+func newMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 	sink := migrationSink{
 		src:     migrationFields{instance: args.Instance, instanceOnly: args.InstanceOnly},
 		dest:    migrationFields{instanceOnly: args.InstanceOnly},

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -62,7 +62,7 @@ func newMigrationSource(inst instance.Instance, stateful bool, instanceOnly bool
 }
 
 func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operation) error {
-	l := logger.AddContext(logger.Log, logger.Ctx{"project": s.instance.Project().Name, "instance": s.instance.Name()})
+	l := logger.AddContext(logger.Log, logger.Ctx{"project": s.instance.Project().Name, "instance": s.instance.Name(), "live": s.live})
 
 	l.Info("Waiting for migration channel connections on source")
 

--- a/lxd/migrate_instance.go
+++ b/lxd/migrate_instance.go
@@ -86,6 +86,15 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 			DataConn:       &shared.WebsocketIO{Conn: s.fsConn},
 			Snapshots:      !s.instanceOnly,
 			Live:           s.live,
+			Disconnect: func() {
+				if s.fsConn != nil {
+					_ = s.fsConn.Close()
+				}
+
+				if s.criuConn != nil {
+					_ = s.criuConn.Close()
+				}
+			},
 		},
 		AllowInconsistent: s.allowInconsistent,
 	})
@@ -251,6 +260,15 @@ func (c *migrationSink) Do(state *state.State, instOp *operationlock.InstanceOpe
 			DataConn:       &shared.WebsocketIO{Conn: dataConn},
 			Snapshots:      !c.dest.instanceOnly,
 			Live:           live,
+			Disconnect: func() {
+				if dataConn != nil {
+					_ = dataConn.Close()
+				}
+
+				if liveConn != nil {
+					_ = liveConn.Close()
+				}
+			},
 		},
 		InstanceOperation: instOp,
 		Refresh:           c.refresh,

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -28,14 +28,12 @@ func newStorageMigrationSource(volumeOnly bool) (*migrationSourceWs, error) {
 	var err error
 	ret.controlSecret, err = shared.RandomCryptoString()
 	if err != nil {
-		logger.Errorf("Failed to create migration source secrect for control websocket")
-		return nil, err
+		return nil, fmt.Errorf("Failed creating migration source secret for control websocket: %w", err)
 	}
 
 	ret.fsSecret, err = shared.RandomCryptoString()
 	if err != nil {
-		logger.Errorf("Failed to create migration source secrect for filesystem websocket")
-		return nil, err
+		return nil, fmt.Errorf("Failed creating migration source secret for control websocket: %w", err)
 	}
 
 	return &ret, nil
@@ -183,26 +181,22 @@ func newStorageMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 	if sink.push {
 		sink.dest.controlSecret, err = shared.RandomCryptoString()
 		if err != nil {
-			logger.Errorf("Failed to create migration sink secrect for control websocket")
-			return nil, err
+			return nil, fmt.Errorf("Failed creating migration sink secret for control websocket: %w", err)
 		}
 
 		sink.dest.fsSecret, err = shared.RandomCryptoString()
 		if err != nil {
-			logger.Errorf("Failed to create migration sink secrect for filesystem websocket")
-			return nil, err
+			return nil, fmt.Errorf("Failed creating migration sink secret for filesystem websocket: %w", err)
 		}
 	} else {
-		sink.src.controlSecret, ok = args.Secrets["control"]
+		sink.src.controlSecret, ok = args.Secrets[api.SecretNameControl]
 		if !ok {
-			logger.Errorf("Missing migration sink secrect for control websocket")
-			return nil, fmt.Errorf("Missing control secret")
+			return nil, fmt.Errorf("Missing migration sink secret for control websocket")
 		}
 
-		sink.src.fsSecret, ok = args.Secrets["fs"]
+		sink.src.fsSecret, ok = args.Secrets[api.SecretNameFilesystem]
 		if !ok {
-			logger.Errorf("Missing migration sink secrect for filesystem websocket")
-			return nil, fmt.Errorf("Missing fs secret")
+			return nil, fmt.Errorf("Missing migration sink secret for filesystem websocket")
 		}
 	}
 

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -164,7 +164,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 	return nil
 }
 
-func newStorageMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {
+func newStorageMigrationSink(args *migrationSinkArgs) (*migrationSink, error) {
 	sink := migrationSink{
 		src:     migrationFields{volumeOnly: args.VolumeOnly},
 		dest:    migrationFields{volumeOnly: args.VolumeOnly},
@@ -271,7 +271,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 	}
 
 	// The function that will be executed to receive the sender's migration data.
-	var myTarget func(conn *websocket.Conn, op *operations.Operation, args MigrationSinkArgs) error
+	var myTarget func(conn *websocket.Conn, op *operations.Operation, args migrationSinkArgs) error
 
 	pool, err := storagePools.LoadByName(state, poolName)
 	if err != nil {
@@ -318,7 +318,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 
 	// Translate the legacy MigrationSinkArgs to a VolumeTargetArgs suitable for use
 	// with the new storage layer.
-	myTarget = func(conn *websocket.Conn, op *operations.Operation, args MigrationSinkArgs) error {
+	myTarget = func(conn *websocket.Conn, op *operations.Operation, args migrationSinkArgs) error {
 		volTargetArgs := migration.VolumeTargetArgs{
 			IndexHeaderVersion: respHeader.GetIndexHeaderVersion(),
 			Name:               req.Name,
@@ -424,7 +424,7 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 			// Get rsync options from sender, these are passed into mySink function
 			// as part of MigrationSinkArgs below.
 			rsyncFeatures := respHeader.GetRsyncFeaturesSlice()
-			args := MigrationSinkArgs{
+			args := migrationSinkArgs{
 				RsyncFeatures: rsyncFeatures,
 				Snapshots:     respHeader.Snapshots,
 				VolumeOnly:    c.src.volumeOnly,

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -871,7 +871,7 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 
 	// Initialise migrationArgs, don't set the Storage property yet, this is done in DoStorage,
 	// to avoid this function relying on the legacy storage layer.
-	migrationArgs := MigrationSinkArgs{
+	migrationArgs := migrationSinkArgs{
 		URL: req.Source.Operation,
 		Dialer: websocket.Dialer{
 			TLSClientConfig:  config,

--- a/shared/api/migration.go
+++ b/shared/api/migration.go
@@ -1,0 +1,10 @@
+package api
+
+// SecretNameControl is the secret name used for the migration control connection.
+const SecretNameControl = "control"
+
+// SecretNameFilesystem is the secret name used for the migration filesystem connection.
+const SecretNameFilesystem = "fs"
+
+// SecretNameState is the secret name used for the migration state connection.
+const SecretNameState = "criu" // Legacy value used for backward compatibility for clients.


### PR DESCRIPTION
Uses the `errgroup` package combined with the `args.Disconnect` call to coordinate detecting errors in each of the concurrent phases of migration receive. This ensures that all go routines are finished before `MigrateReceive` returns, but that only the first error is returned as to the cause of the failure. Additionally it ensures that each go routines' reverter (if used) is run before the function returns.

Additionally:

- Fixes an unnecessary redirect when creating instances in a cluster.
- Renames DataConn and CriuConn to FilesystemConn and StateConn respectively.
- Adds constants for migration channel secrets and uses them throughout code base (so we can easily see where those concepts are used).