### PR TITLE
API: Fix clustered instances list

### DIFF
--- a/lxd/instances_get.go
+++ b/lxd/instances_get.go
@@ -375,6 +375,7 @@ func doInstancesGet(s *state.State, r *http.Request) (any, error) {
 					}
 
 					for _, apiInst := range apiInsts {
+						apiInst := apiInst // Local variable for append.
 						resultFullListAppend(&api.InstanceFull{Instance: apiInst})
 					}
 
@@ -391,6 +392,7 @@ func doInstancesGet(s *state.State, r *http.Request) (any, error) {
 				}
 
 				for _, c := range cs {
+					c := c // Local variable for append.
 					resultFullListAppend(&c)
 				}
 			}(memberAddress, instances)


### PR DESCRIPTION
Passing a pointer to the loop iterator variable meant that the resulting instance actually appended was non-deterministic. This resulted in missing entries and duplicated entries in the instance list.