### PR TITLE
shared/simplestream: Don't write zero length cache files in cachedDownload

### DIFF
--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -138,6 +138,10 @@ func (s *SimpleStreams) cachedDownload(path string) ([]byte, error) {
 		return nil, err
 	}
 
+	if len(body) == 0 {
+		return nil, fmt.Errorf("No content in download from %q", uri)
+	}
+
 	// Attempt to store in cache
 	if s.cachePath != "" {
 		cacheName := filepath.Join(s.cachePath, fileName)
@@ -159,11 +163,13 @@ func (s *SimpleStreams) parseStream() (*Stream, error) {
 		return nil, err
 	}
 
+	pathURL, _ := shared.JoinUrls(s.url, path)
+
 	// Parse the idnex
 	stream := Stream{}
 	err = json.Unmarshal(body, &stream)
 	if err != nil {
-		return nil, fmt.Errorf("Failed decoding stream JSON from %q: %w", path, err)
+		return nil, fmt.Errorf("Failed decoding stream JSON from %q: %w (%q)", pathURL, err, string(body))
 	}
 
 	s.cachedStream = &stream


### PR DESCRIPTION
During my migration work I ended up reloading LXD a lot (when sideloading new binaries) and I started to notice that I was sometimes ending up with empty cached simplestreams index files that couldn't then be parsed as JSON.

I'm not sure if this is the issue, but it seems to be a sensible validation check to add, as even if there are no images available the download should still be non-empty as it will be an empty json document like `{}`.

And improve errors.