### PR TITLE
Fix `config trust` command fail when remote is specified

### DIFF
--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -139,7 +139,14 @@ func (c *cmdConfigTrustAdd) Run(cmd *cobra.Command, args []string) error {
 
 	cert := api.CertificatesPost{}
 
-	if len(args) == 0 {
+	// Check if remote is the first argument
+	// to detect method of adding trusted client
+	useToken := false
+	if len(args) == 0 || (len(args) == 1 && resource.name == "") {
+		useToken = true
+	}
+
+	if useToken {
 		// Use token
 		cert.Token = true
 


### PR DESCRIPTION
Checks the meaning of the first argument (is remote or not). This allow to determine the method of adding trusted client.

Fixes: #11466