### PR TITLE
Migration: Socket improvements

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -440,7 +440,7 @@ func (r *ProtocolLXD) rawWebsocket(url string) (*websocket.Conn, error) {
 	if remoteTCP != nil {
 		err = tcp.SetTimeouts(remoteTCP, 0)
 		if err != nil {
-			logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+			logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}
 	}
 

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -1054,11 +1054,11 @@ func dqliteNetworkDial(ctx context.Context, name string, addr string, g *Gateway
 
 	remoteTCP, err := tcp.ExtractConn(conn)
 	if err != nil {
-		l.Error("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
+		l.Warn("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
 	} else {
 		err := tcp.SetTimeouts(remoteTCP, time.Second*30)
 		if err != nil {
-			l.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+			l.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}
 	}
 
@@ -1147,11 +1147,11 @@ func dqliteProxy(name string, stopCh chan struct{}, remote net.Conn, local net.C
 
 	remoteTCP, err := tcp.ExtractConn(remote)
 	if err != nil {
-		l.Error("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
+		l.Warn("Failed extracting TCP connection from remote connection", logger.Ctx{"err": err})
 	} else {
 		err := tcp.SetTimeouts(remoteTCP, time.Second*30)
 		if err != nil {
-			l.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+			l.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}
 	}
 

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -94,7 +94,7 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 				if remoteTCP != nil {
 					err = tcp.SetTimeouts(remoteTCP, 0)
 					if err != nil {
-						logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+						logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 					}
 				}
 

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -392,6 +392,15 @@ func (s *migrationSink) Connect(op *operations.Operation, r *http.Request, w htt
 		return err
 	}
 
+	// Set TCP timeout options.
+	remoteTCP, _ := tcp.ExtractConn(c.UnderlyingConn())
+	if remoteTCP != nil {
+		err = tcp.SetTimeouts(remoteTCP, 0)
+		if err != nil {
+			logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+		}
+	}
+
 	*conn = c
 
 	// Check criteria for considering all channels to be connected.

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -205,7 +205,7 @@ func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w
 	if remoteTCP != nil {
 		err = tcp.SetTimeouts(remoteTCP, 0)
 		if err != nil {
-			logger.Error("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+			logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
 		}
 	}
 

--- a/shared/network.go
+++ b/shared/network.go
@@ -414,21 +414,16 @@ func (w *WebsocketIO) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
-func (w *WebsocketIO) Write(p []byte) (n int, err error) {
+func (w *WebsocketIO) Write(p []byte) (int, error) {
 	w.muw.Lock()
 	defer w.muw.Unlock()
 
-	wr, err := w.Conn.NextWriter(websocket.BinaryMessage)
+	err := w.Conn.WriteMessage(websocket.BinaryMessage, p)
 	if err != nil {
 		return -1, err
 	}
 
-	n, err = wr.Write(p)
-	if err != nil {
-		return -1, err
-	}
-
-	return n, wr.Close()
+	return len(p), nil
 }
 
 // Close sends a control message indicating the stream is finished, but it does not actually close the socket.


### PR DESCRIPTION
- Add read lock to `WebsocketIO.Read()` function as the underlying gorilla websocket package only allows 1 reader at a time.
- Use gorilla websocket's `WriteMessage()` function in `WebsocketIO.Write()` function as this benefits from a fastpath mode.
- Set timeouts in migration push mode to mirror those setup in pull mode.
- Fixes hang in `zfs send` (and potentially other storage drivers) due to Go waiting for socket to become writable sometimes when migration fails on target (even though websocket is closed).