### PR TITLE
Single Purpose Printers

### DIFF
--- a/lxc/util/csv.go
+++ b/lxc/util/csv.go
@@ -1,0 +1,26 @@
+package printers
+
+import (
+	"encoding/csv"
+	"io"
+)
+
+type csvPrinter struct{}
+
+func NewCSVPrinter() ResourcePrinter {
+	return &csvPrinter{}
+}
+
+func (p *csvPrinter) PrintObj(obj any, writer io.Writer) error {
+	w := csv.NewWriter(writer)
+	data, err := mustConvertToSliceOfSlices(obj)
+	if err != nil {
+		return err
+	}
+	err = w.WriteAll(data)
+	if err != nil {
+		return err
+	}
+
+	return w.Error()
+}

--- a/lxc/util/csv_test.go
+++ b/lxc/util/csv_test.go
@@ -1,0 +1,49 @@
+package printers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCSVPrinter(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		data     [][]string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "csv format no data",
+			data:     [][]string{},
+			wantErr:  false,
+			expected: "",
+		},
+		{
+			name: "csv format",
+			data: [][]string{
+				{"Val 1.1", "Val 1.2", "Val 1.3"},
+				{"Val 2.1", "Val 2.1", "Val 2.3"},
+			},
+			wantErr: false,
+			expected: `Val 1.1,Val 1.2,Val 1.3
+Val 2.1,Val 2.1,Val 2.3
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := bytes.NewBuffer([]byte{})
+			printer := NewCSVPrinter()
+			err := printer.PrintObj(test.data, out)
+			if test.wantErr && err != nil {
+				t.Errorf("Run() error = %v, wantErr %v", err, test.wantErr)
+			}
+			assert.Equal(t, test.expected, out.String())
+		})
+	}
+
+}

--- a/lxc/util/interface.go
+++ b/lxc/util/interface.go
@@ -1,0 +1,19 @@
+package printers
+
+import "io"
+
+// TODO at some point it might be worth discussing a generic object model, so we can use this here instead of 'any'
+type ResourcePrinterFunc func(obj any, writer io.Writer) error
+
+func (fn ResourcePrinterFunc) PrintObj(obj any, writer io.Writer) error {
+	return fn(obj, writer)
+}
+
+type ResourcePrinter interface {
+	PrintObj(raw any, writer io.Writer) error
+}
+
+type PrintOptions struct {
+	CompactMode  bool
+	ColumnLabels []string
+}

--- a/lxc/util/json.go
+++ b/lxc/util/json.go
@@ -1,0 +1,22 @@
+package printers
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type jsonPrinter struct{}
+
+func NewJSONPrinter() ResourcePrinter {
+	return &jsonPrinter{}
+}
+
+func (p *jsonPrinter) PrintObj(obj any, writer io.Writer) error {
+	data, err := json.MarshalIndent(obj, "", "    ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	_, err = writer.Write(data)
+	return err
+}

--- a/lxc/util/json_test.go
+++ b/lxc/util/json_test.go
@@ -1,0 +1,59 @@
+package printers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestJSONPrinter(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		data     [][]string
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "json format no data",
+			data:     [][]string{},
+			wantErr:  false,
+			expected: "[]\n",
+		},
+		{
+			name: "json array format",
+			data: [][]string{
+				{"Val 1.1", "Val 1.2", "Val 1.3"},
+				{"Val 2.1", "Val 2.1", "Val 2.3"},
+			},
+			wantErr: false,
+			expected: `[
+    [
+        "Val 1.1",
+        "Val 1.2",
+        "Val 1.3"
+    ],
+    [
+        "Val 2.1",
+        "Val 2.1",
+        "Val 2.3"
+    ]
+]
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := bytes.NewBuffer([]byte{})
+			printer := NewJSONPrinter()
+			err := printer.PrintObj(test.data, out)
+			if test.wantErr && err != nil {
+				t.Errorf("Run() error = %v, wantErr %v", err, test.wantErr)
+			}
+			assert.Equal(t, test.expected, out.String())
+		})
+	}
+
+}

--- a/lxc/util/table.go
+++ b/lxc/util/table.go
@@ -1,0 +1,78 @@
+package printers
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/olekukonko/tablewriter"
+)
+
+type tablePrinter struct {
+	options PrintOptions
+}
+
+func NewTablePrinter(options PrintOptions) ResourcePrinter {
+	return &tablePrinter{
+		options: options,
+	}
+}
+
+func (p *tablePrinter) PrintObj(obj any, writer io.Writer) error {
+
+	rows, err := mustConvertToSliceOfSlices(obj)
+	if err != nil {
+		return err
+	}
+	table := getBaseTable(writer, p.options.ColumnLabels, rows)
+
+	if p.options.CompactMode {
+		table.SetColumnSeparator("")
+		table.SetHeaderLine(false)
+		table.SetBorder(false)
+	} else {
+		table.SetRowLine(true)
+	}
+
+	table.Render()
+
+	return nil
+}
+
+// TODO integrate more print options here
+func getBaseTable(writer io.Writer, header []string, data [][]string) *tablewriter.Table {
+	table := tablewriter.NewWriter(writer)
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeader(header)
+	table.AppendBulk(data)
+	return table
+}
+
+// TODO at some point there should be a more generic object model, which will make this obsolete
+func mustConvertToSliceOfSlices(input interface{}) ([][]string, error) {
+	inputValue := reflect.ValueOf(input)
+	if inputValue.Kind() != reflect.Slice {
+		return nil, errors.New("input is not a slice")
+	}
+
+	result := make([][]string, inputValue.Len())
+	for i := 0; i < inputValue.Len(); i++ {
+		inner := inputValue.Index(i)
+		if inner.Kind() != reflect.Slice {
+			return nil, fmt.Errorf("element at index %d is not a slice", i)
+		}
+
+		result[i] = make([]string, inner.Len())
+		for j := 0; j < inner.Len(); j++ {
+			elem := inner.Index(j)
+			if elem.Kind() != reflect.String {
+				return nil, fmt.Errorf("element at index (%d, %d) is not a string", i, j)
+			}
+			result[i][j] = elem.String()
+		}
+	}
+
+	return result, nil
+}

--- a/lxc/util/table_test.go
+++ b/lxc/util/table_test.go
@@ -1,0 +1,99 @@
+package printers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTablePrinter(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		data     [][]string
+		options  PrintOptions
+		expected string
+		wantErr  bool
+	}{
+		{
+			name: "table format no data",
+			data: [][]string{},
+			options: PrintOptions{
+				ColumnLabels: []string{
+					"Col A", "Col B", "Col C",
+				},
+			},
+			wantErr: false,
+			expected: `+-------+-------+-------+
+| COL A | COL B | COL C |
++-------+-------+-------+
+`,
+		},
+		{
+			name: "table format",
+			data: [][]string{
+				{"Val 1.1", "Val 1.2", "Val 1.3"},
+				{"Val 2.1", "Val 2.1", "Val 2.3"},
+			},
+			options: PrintOptions{
+				ColumnLabels: []string{
+					"Col A", "Col B", "Col C",
+				},
+			},
+			wantErr: false,
+			expected: `+---------+---------+---------+
+|  COL A  |  COL B  |  COL C  |
++---------+---------+---------+
+| Val 1.1 | Val 1.2 | Val 1.3 |
++---------+---------+---------+
+| Val 2.1 | Val 2.1 | Val 2.3 |
++---------+---------+---------+
+`,
+		},
+		{
+			name: "table compact format no data",
+			data: [][]string{},
+			options: PrintOptions{
+				ColumnLabels: []string{
+					"Col A", "Col B", "Col C",
+				},
+				CompactMode: true,
+			},
+			wantErr: false,
+			expected: `  COL A  COL B  COL C  
+`,
+		},
+		{
+			name: "table compact format",
+			data: [][]string{
+				{"Val 1.1", "Val 1.2", "Val 1.3"},
+				{"Val 2.1", "Val 2.1", "Val 2.3"},
+			},
+			options: PrintOptions{
+				ColumnLabels: []string{
+					"Col A", "Col B", "Col C",
+				},
+				CompactMode: true,
+			},
+			wantErr: false,
+			expected: `   COL A    COL B    COL C   
+  Val 1.1  Val 1.2  Val 1.3  
+  Val 2.1  Val 2.1  Val 2.3  
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := bytes.NewBuffer([]byte{})
+			printer := NewTablePrinter(test.options)
+			err := printer.PrintObj(test.data, out)
+			if test.wantErr && err != nil {
+				t.Errorf("Run() error = %v, wantErr %v", err, test.wantErr)
+			}
+			assert.Equal(t, test.expected, out.String())
+		})
+	}
+
+}

--- a/lxc/util/yaml.go
+++ b/lxc/util/yaml.go
@@ -1,0 +1,28 @@
+package printers
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type yamlPrinter struct{}
+
+func NewYAMLPrinter() ResourcePrinter {
+	return &yamlPrinter{}
+}
+
+func (p *yamlPrinter) PrintObj(obj any, writer io.Writer) error {
+	output, err := yaml.Marshal(obj)
+	if err != nil {
+		return err
+	}
+	if strings.TrimRight(string(output), "\n") == "null" {
+		fmt.Fprint(writer, "")
+	} else {
+		_, err = fmt.Fprint(writer, string(output))
+	}
+	return err
+}

--- a/lxc/util/yaml_test.go
+++ b/lxc/util/yaml_test.go
@@ -1,0 +1,77 @@
+package printers
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/lxc/lxd/shared/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestYAMLPrinter(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		data     any
+		expected string
+		wantErr  bool
+	}{
+		{
+			name:     "yaml format no data",
+			data:     nil,
+			wantErr:  false,
+			expected: "",
+		},
+		{
+			name: "yaml array format",
+			data: api.Cluster{
+				ServerName: "server",
+				Enabled:    false,
+				MemberConfig: []api.ClusterMemberConfigKey{
+					{
+						Entity:      "entity1",
+						Name:        "node1",
+						Key:         "12345",
+						Value:       "value",
+						Description: "d1",
+					},
+					{
+						Entity:      "entity2",
+						Name:        "node2",
+						Key:         "54321",
+						Value:       "value2",
+						Description: "d2",
+					},
+				},
+			},
+			wantErr: false,
+			expected: `server_name: server
+enabled: false
+member_config:
+- entity: entity1
+  name: node1
+  key: "12345"
+  value: value
+  description: d1
+- entity: entity2
+  name: node2
+  key: "54321"
+  value: value2
+  description: d2
+`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			out := bytes.NewBuffer([]byte{})
+			printer := NewYAMLPrinter()
+			err := printer.PrintObj(test.data, out)
+			if test.wantErr && err != nil {
+				t.Errorf("Run() error = %v, wantErr %v", err, test.wantErr)
+			}
+			assert.Equal(t, test.expected, out.String())
+		})
+	}
+
+}


### PR DESCRIPTION
Hey guys. Ever since writing some tests for some micro* ctl I found that testing cli outputs is quite tedious for two reasons:
the hardwired writing to stdout in `RenderTable`, and also they way the data is being handed over.

I am proposing an approach that's similar to kubectl, though a little less elaborate. 
Also there is room for enhancement, for example introducing printable resources, to get rid of the `any` black hole.

Let me know what you think :)
