### PR TITLE
Device: Adds nested OVN NIC support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2185,3 +2185,9 @@ This adds support for performing VM QEMU to QEMU live migration for both shared 
 non-shared storage pools.
 
 This also adds the `CRIUType_VM_QEMU` value of `3` for the migration `CRIUType` `protobuf` field.
+
+## `ovn_nic_nesting`
+This adds support for nesting an `ovn` NIC inside another `ovn` NIC on the same instance.
+This allows for an OVN logical switch port to be tunneled inside another OVN NIC using VLAN tagging.
+
+This feature is configured by specifying the parent NIC name using the `nested` property and the VLAN ID to use for tunneling with the `vlan` property.

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -214,25 +214,27 @@ SR-IOV hardware acceleration
 
 NIC devices of type `ovn` have the following device options:
 
-Key                                  | Type    | Default           | Managed | Description
-:--                                  | :--     | :--               | :--     | :--
-`acceleration`                       | string  | `none`            | no      | Enable hardware offloading (either `none` or `sriov`, see {ref}`devices-nic-hw-acceleration`)
-`boot.priority`                      | integer | -                 | no      | Boot priority for VMs (higher value boots first)
-`host_name`                          | string  | randomly assigned | no      | The name of the interface inside the host
-`hwaddr`                             | string  | randomly assigned | no      | The MAC address of the new interface
-`ipv4.address`                       | string  | -                 | no      | An IPv4 address to assign to the instance through DHCP
-`ipv4.routes`                        | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC
-`ipv4.routes.external`               | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC and publish on uplink network
-`ipv6.address`                       | string  | -                 | no      | An IPv6 address to assign to the instance through DHCP
-`ipv6.routes`                        | string  | -                 | no      | Comma-delimited list of IPv6 static routes to route to the NIC
-`ipv6.routes.external`               | string  | -                 | no      | Comma-delimited list of IPv6 static routes to route to the NIC and publish on uplink network
-`name`                               | string  | kernel assigned   | no      | The name of the interface inside the instance
-`network`                            | string  | -                 | yes     | The managed network to link the device to (required)
-`security.acls`                      | string  | -                 | no      | Comma-separated list of network ACLs to apply
-`security.acls.default.egress.action` | string | `reject`          | no      | Action to use for egress traffic that doesn't match any ACL rule
-`security.acls.default.egress.logged` | bool   | `false`           | no      | Whether to log egress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.action`| string | `reject`          | no      | Action to use for ingress traffic that doesn't match any ACL rule
-`security.acls.default.ingress.logged`| bool   | `false`           | no      | Whether to log ingress traffic that doesn't match any ACL rule
+Key                                   | Type    | Default           | Managed | Description
+:--                                   | :--     | :--               | :--     | :--
+`acceleration`                        | string  | `none`            | no      | Enable hardware offloading (either `none` or `sriov`, see {ref}`devices-nic-hw-acceleration`)
+`boot.priority`                       | integer | -                 | no      | Boot priority for VMs (higher value boots first)
+`host_name`                           | string  | randomly assigned | no      | The name of the interface inside the host
+`hwaddr`                              | string  | randomly assigned | no      | The MAC address of the new interface
+`ipv4.address`                        | string  | -                 | no      | An IPv4 address to assign to the instance through DHCP
+`ipv4.routes`                         | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC
+`ipv4.routes.external`                | string  | -                 | no      | Comma-delimited list of IPv4 static routes to route to the NIC and publish on uplink network
+`ipv6.address`                        | string  | -                 | no      | An IPv6 address to assign to the instance through DHCP
+`ipv6.routes`                         | string  | -                 | no      | Comma-delimited list of IPv6 static routes to route to the NIC
+`ipv6.routes.external`                | string  | -                 | no      | Comma-delimited list of IPv6 static routes to route to the NIC and publish on uplink network
+`name`                                | string  | kernel assigned   | no      | The name of the interface inside the instance
+`nested`                              | string  | -                 | no      | The parent NIC name to nest this NIC under (see also `vlan`)
+`network`                             | string  | -                 | yes     | The managed network to link the device to (required)
+`security.acls`                       | string  | -                 | no      | Comma-separated list of network ACLs to apply
+`security.acls.default.egress.action` | string  | `reject`          | no      | Action to use for egress traffic that doesn't match any ACL rule
+`security.acls.default.egress.logged` | bool    | `false`           | no      | Whether to log egress traffic that doesn't match any ACL rule
+`security.acls.default.ingress.action`| string  | `reject`          | no      | Action to use for ingress traffic that doesn't match any ACL rule
+`security.acls.default.ingress.logged`| bool    | `false`           | no      | Whether to log ingress traffic that doesn't match any ACL rule
+`vlan`                                | integer | -                 | no      | The VLAN ID to use when nesting (see also `nested`)
 
 (nic-physical)=
 ### `nictype`: `physical`

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -46,6 +46,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		"queue.tx.length":                      validate.Optional(validate.IsUint32),
 		"ipv4.routes.external":                 validate.Optional(validate.IsListOf(validate.IsNetworkV4)),
 		"ipv6.routes.external":                 validate.Optional(validate.IsListOf(validate.IsNetworkV6)),
+		"nested":                               validate.IsAny,
 		"security.acls":                        validate.IsAny,
 		"security.acls.default.ingress.action": validate.Optional(validate.IsOneOf(acl.ValidActions...)),
 		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -294,7 +294,8 @@ func (d *nicOVN) checkAddressConflict() error {
 		}
 
 		// Check there isn't another instance with the same DNS name connected to managed network.
-		if d.network != nil && nicCheckDNSNameConflict(d.inst.Name(), inst.Name) {
+		sameLogicalInstanceNestedNIC := sameLogicalInstance && (d.config["nested"] != "" || nicConfig["nested"] != "")
+		if d.network != nil && !sameLogicalInstanceNestedNIC && nicCheckDNSNameConflict(d.inst.Name(), inst.Name) {
 			if sameLogicalInstance {
 				return api.StatusErrorf(http.StatusConflict, "Instance DNS name %q conflict between %q and %q because both are connected to same network", strings.ToLower(inst.Name), d.name, nicName)
 			}

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -113,6 +113,8 @@ type OVNSwitchPortOpts struct {
 	IPs          []net.IP           // Optional, if empty IPs will be set to dynamic.
 	DHCPv4OptsID OVNDHCPOptionsUUID // Optional, if empty, no DHCPv4 enabled on port.
 	DHCPv6OptsID OVNDHCPOptionsUUID // Optional, if empty, no DHCPv6 enabled on port.
+	Parent       OVNSwitchPort      // Optional, if set a nested port is created.
+	VLAN         uint16             // Optional, use with Parent to request a specific VLAN for nested port.
 }
 
 // OVNACLRule represents an ACL rule that can be added to a logical switch or port group.
@@ -1102,6 +1104,11 @@ func (o *OVN) LogicalSwitchPortAdd(switchName OVNSwitch, portName OVNSwitchPort,
 
 	// Set switch port options if supplied.
 	if opts != nil {
+		// Created nested VLAN port if requested.
+		if opts.Parent != "" {
+			args = append(args, string(opts.Parent), fmt.Sprintf("%d", opts.VLAN))
+		}
+
 		ipStr := make([]string, 0, len(opts.IPs))
 		for _, ip := range opts.IPs {
 			ipStr = append(ipStr, ip.String())

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -366,6 +366,7 @@ var APIExtensions = []string{
 	"amd_sev",
 	"storage_pool_loop_resize",
 	"migration_vm_live",
+	"ovn_nic_nesting",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds support for nesting `ovn` NICs inside another `ovn` NIC.

This allows multiple logical OVN switch ports to be tunneled to an instance using VLAN tagging over a single `ovn` NIC, without having to incur the cost of passing multiple NICs to the instance.

This can be beneficial, for example, if you are running containers inside a virtual machine, and want each container to join the parent OVN network, without having to pass in a NIC per container. 

Instead a single "proper" `ovn` NIC is added to the instance, and then one or more "nested" `ovn` NICs are added that specify the propert `ovn` NIC as its `nested` parent. Each nested NIC also needs to specify which `vlan` ID it will use when tunneling through the parent NIC.

Inside the instance, the admin is required to setup virtual interfaces for the specific VLANs (using the MAC address assigned for the nested NIC). These can then be used as needed inside the instance.

Associated tests https://github.com/lxc/lxc-ci/pull/724