### PR TITLE
Instance: Rework intra-cluster ceph instance move to use migration subsystem

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3170,7 +3170,7 @@ func evacuateClusterMember(d *Daemon, r *http.Request, mode string) response.Res
 				Live: live,
 			}
 
-			err = migrateInstance(d, r, inst, targetMemberInfo.Name, false, req, op)
+			err = migrateInstance(d, r, inst, targetMemberInfo.Name, req, op)
 			if err != nil {
 				return fmt.Errorf("Failed to migrate instance %q in project %q: %w", inst.Name(), instProject.Name, err)
 			}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -46,7 +46,6 @@ var apiInternal = []APIEndpoint{
 	internalClusterAcceptCmd,
 	internalClusterAssignCmd,
 	internalClusterHandoverCmd,
-	internalClusterInstanceMovedCmd,
 	internalClusterRaftNodeCmd,
 	internalClusterRebalanceCmd,
 	internalContainerOnStartCmd,

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5661,7 +5661,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	// When doing a cluster same-name move we cannot load the storage pool using the instance's volume DB
 	// record because it may be associated to the wrong cluster member. Instead we ascertain the pool to load
 	// using the instance's root disk device.
-	if args.ClusterSameNameMove {
+	if args.ClusterMoveSourceName == d.name {
 		_, rootDiskDevice, err := d.getRootDiskDevice()
 		if err != nil {
 			return fmt.Errorf("Failed getting root disk: %w", err)
@@ -5937,7 +5937,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 				// Only create snapshot instance DB records if not doing a cluster same-name move.
 				// As otherwise the DB records will already exist.
-				if !args.ClusterSameNameMove {
+				if args.ClusterMoveSourceName != d.name {
 					snapArgs, err := instance.SnapshotProtobufToInstanceArgs(d.state, d, snap)
 					if err != nil {
 						return err
@@ -5995,7 +5995,7 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			return err
 		}
 
-		if !args.ClusterSameNameMove {
+		if args.ClusterMoveSourceName != d.name {
 			err = d.DeferTemplateApply(instance.TemplateTriggerCopy)
 			if err != nil {
 				return err

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5971,9 +5971,11 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			return fmt.Errorf("Failed creating instance on target: %w", err)
 		}
 
+		isRemoteClusterMove := args.ClusterMoveSourceName != "" && pool.Driver().Info().Remote
+
 		// Only delete all instance volumes on error if the pool volume creation has succeeded to
 		// avoid deleting an existing conflicting volume.
-		if !volTargetArgs.Refresh {
+		if !volTargetArgs.Refresh && !isRemoteClusterMove {
 			revert.Add(func() {
 				snapshots, _ := d.Snapshots()
 				snapshotCount := len(snapshots)

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5906,14 +5906,15 @@ func (d *lxc) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		}
 
 		volTargetArgs := migration.VolumeTargetArgs{
-			IndexHeaderVersion: respHeader.GetIndexHeaderVersion(),
-			Name:               d.Name(),
-			MigrationType:      respTypes[0],
-			Refresh:            args.Refresh,                // Indicate to receiver volume should exist.
-			TrackProgress:      true,                        // Use a progress tracker on receiver to get in-cluster progress information.
-			Live:               sendFinalFsDelta,            // Indicates we will get a final rootfs sync.
-			VolumeSize:         offerHeader.GetVolumeSize(), // Block size setting override.
-			VolumeOnly:         !args.Snapshots,
+			IndexHeaderVersion:    respHeader.GetIndexHeaderVersion(),
+			Name:                  d.Name(),
+			MigrationType:         respTypes[0],
+			Refresh:               args.Refresh,                // Indicate to receiver volume should exist.
+			TrackProgress:         true,                        // Use a progress tracker on receiver to get in-cluster progress information.
+			Live:                  sendFinalFsDelta,            // Indicates we will get a final rootfs sync.
+			VolumeSize:            offerHeader.GetVolumeSize(), // Block size setting override.
+			VolumeOnly:            !args.Snapshots,
+			ClusterMoveSourceName: args.ClusterMoveSourceName,
 		}
 
 		// At this point we have already figured out the parent container's root

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -5170,6 +5170,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 		AllowInconsistent:  args.AllowInconsistent,
 		VolumeOnly:         !args.Snapshots,
 		Info:               &migration.Info{Config: srcConfig},
+		ClusterMove:        args.ClusterMoveSourceName != "",
 	}
 
 	// Only send the snapshots that the target requests when refreshing.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -395,7 +395,7 @@ func (d *qemu) getMonitorEventHandler() func(event string, data map[string]any) 
 			d.logger.Debug("Instance agent started")
 			err := d.advertiseVsockAddress()
 			if err != nil {
-				d.logger.Error("Failed to advertise vsock address", logger.Ctx{"err": err})
+				d.logger.Warn("Failed to advertise vsock address to instance agent", logger.Ctx{"err": err})
 				return
 			}
 		} else if event == "SHUTDOWN" {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6089,9 +6089,11 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			return fmt.Errorf("Failed creating instance on target: %w", err)
 		}
 
+		isRemoteClusterMove := args.ClusterMoveSourceName != "" && pool.Driver().Info().Remote
+
 		// Only delete all instance volumes on error if the pool volume creation has succeeded to
 		// avoid deleting an existing conflicting volume.
-		if !volTargetArgs.Refresh {
+		if !volTargetArgs.Refresh && !isRemoteClusterMove {
 			revert.Add(func() {
 				snapshots, _ := d.Snapshots()
 				snapshotCount := len(snapshots)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5822,7 +5822,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 	// When doing a cluster same-name move we cannot load the storage pool using the instance's volume DB
 	// record because it may be associated to the wrong cluster member. Instead we ascertain the pool to load
 	// using the instance's root disk device.
-	if args.ClusterSameNameMove {
+	if args.ClusterMoveSourceName == d.name {
 		_, rootDiskDevice, err := d.getRootDiskDevice()
 		if err != nil {
 			return fmt.Errorf("Failed getting root disk: %w", err)
@@ -6055,7 +6055,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 
 				// Only create snapshot instance DB records if not doing a cluster same-name move.
 				// As otherwise the DB records will already exist.
-				if !args.ClusterSameNameMove {
+				if args.ClusterMoveSourceName != d.name {
 					snapArgs, err := instance.SnapshotProtobufToInstanceArgs(d.state, d, snap)
 					if err != nil {
 						return err
@@ -6105,7 +6105,7 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 			})
 		}
 
-		if !args.ClusterSameNameMove {
+		if args.ClusterMoveSourceName != d.name {
 			err = d.DeferTemplateApply(instance.TemplateTriggerCopy)
 			if err != nil {
 				return err

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5723,6 +5723,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 		AllowInconsistent:  args.AllowInconsistent,
 		VolumeOnly:         !args.Snapshots,
 		Info:               &migration.Info{Config: srcConfig},
+		ClusterMove:        args.ClusterMoveSourceName != "",
 	}
 
 	// Only send the snapshots that the target requests when refreshing.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6024,14 +6024,15 @@ func (d *qemu) MigrateReceive(args instance.MigrateReceiveArgs) error {
 		}
 
 		volTargetArgs := migration.VolumeTargetArgs{
-			IndexHeaderVersion: respHeader.GetIndexHeaderVersion(),
-			Name:               d.Name(),
-			MigrationType:      respTypes[0],
-			Refresh:            args.Refresh,                // Indicate to receiver volume should exist.
-			TrackProgress:      true,                        // Use a progress tracker on receiver to get in-cluster progress information.
-			Live:               false,                       // Indicates we won't get a final rootfs sync.
-			VolumeSize:         offerHeader.GetVolumeSize(), // Block size setting override.
-			VolumeOnly:         !args.Snapshots,
+			IndexHeaderVersion:    respHeader.GetIndexHeaderVersion(),
+			Name:                  d.Name(),
+			MigrationType:         respTypes[0],
+			Refresh:               args.Refresh,                // Indicate to receiver volume should exist.
+			TrackProgress:         true,                        // Use a progress tracker on receiver to get in-cluster progress information.
+			Live:                  false,                       // Indicates we won't get a final rootfs sync.
+			VolumeSize:            offerHeader.GetVolumeSize(), // Block size setting override.
+			VolumeOnly:            !args.Snapshots,
+			ClusterMoveSourceName: args.ClusterMoveSourceName,
 		}
 
 		// At this point we have already figured out the parent instances's root

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -204,14 +204,14 @@ type Info struct {
 
 // MigrateArgs represent arguments for instance migration send and receive.
 type MigrateArgs struct {
-	ControlSend         func(m proto.Message) error
-	ControlReceive      func(m proto.Message) error
-	StateConn           io.ReadWriteCloser
-	FilesystemConn      io.ReadWriteCloser
-	Snapshots           bool
-	Live                bool
-	Disconnect          func()
-	ClusterSameNameMove bool
+	ControlSend           func(m proto.Message) error
+	ControlReceive        func(m proto.Message) error
+	StateConn             io.ReadWriteCloser
+	FilesystemConn        io.ReadWriteCloser
+	Snapshots             bool
+	Live                  bool
+	Disconnect            func()
+	ClusterMoveSourceName string // Will be empty if not a cluster move, othwise indicates the source instance.
 }
 
 // MigrateSendArgs represent arguments for instance migration send.

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -204,6 +204,12 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		if resp != nil {
 			return resp
 		}
+	} else if sourceNodeOffline {
+		// If a target was specified, forward the request to the relevant node.
+		resp := forwardedResponseIfTargetIsRemote(s, r)
+		if resp != nil {
+			return resp
+		}
 	}
 
 	body, err := io.ReadAll(r.Body)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -320,7 +320,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		instanceOnly := req.InstanceOnly || req.ContainerOnly
-		ws, err := newMigrationSource(inst, req.Live, instanceOnly, req.AllowInconsistent, false)
+		ws, err := newMigrationSource(inst, req.Live, instanceOnly, req.AllowInconsistent, "")
 		if err != nil {
 			return response.InternalError(err)
 		}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -306,7 +306,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			run := func(op *operations.Operation) error {
-				return migrateInstance(d, r, inst, targetNode, sourceNodeOffline, req, op)
+				return migrateInstance(d, r, inst, targetNode, req, op)
 			}
 
 			resources := map[string][]string{}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -663,7 +663,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 			}
 		}
 
-		ws, err := newMigrationSource(snapInst, reqNew.Live, true, false, false)
+		ws, err := newMigrationSource(snapInst, reqNew.Live, true, false, "")
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -148,8 +148,8 @@ func (c *migrationFields) controlChannel() <-chan *migration.ControlResponse {
 type migrationSourceWs struct {
 	migrationFields
 
-	allConnected        *cancel.Canceller
-	clusterSameNameMove bool
+	allConnected          *cancel.Canceller
+	clusterMoveSourceName string
 }
 
 func (s *migrationSourceWs) Metadata() any {
@@ -296,12 +296,12 @@ type migrationSink struct {
 	// fields are used since the client will connect to the sockets.
 	dest migrationFields
 
-	url                 string
-	dialer              websocket.Dialer
-	allConnected        *cancel.Canceller
-	push                bool
-	clusterSameNameMove bool
-	refresh             bool
+	url                   string
+	dialer                websocket.Dialer
+	allConnected          *cancel.Canceller
+	push                  bool
+	clusterMoveSourceName string
+	refresh               bool
 }
 
 // MigrationSinkArgs arguments to configure migration sink.
@@ -313,13 +313,13 @@ type migrationSinkArgs struct {
 	URL     string
 
 	// Instance specific fields
-	Instance            instance.Instance
-	InstanceOnly        bool
-	Idmap               *idmap.IdmapSet
-	Live                bool
-	Refresh             bool
-	ClusterSameNameMove bool
-	Snapshots           []*migration.Snapshot
+	Instance              instance.Instance
+	InstanceOnly          bool
+	Idmap                 *idmap.IdmapSet
+	Live                  bool
+	Refresh               bool
+	ClusterMoveSourceName string
+	Snapshots             []*migration.Snapshot
 
 	// Storage specific fields
 	VolumeOnly bool

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -59,22 +59,24 @@ type VolumeSourceArgs struct {
 	Refresh            bool
 	Info               *Info
 	VolumeOnly         bool
+	ClusterMove        bool
 }
 
 // VolumeTargetArgs represents the arguments needed to setup a volume migration sink.
 type VolumeTargetArgs struct {
-	IndexHeaderVersion uint32
-	Name               string
-	Description        string
-	Config             map[string]string // Only used for custom volume migration.
-	Snapshots          []string
-	MigrationType      Type
-	TrackProgress      bool
-	Refresh            bool
-	Live               bool
-	VolumeSize         int64
-	ContentType        string
-	VolumeOnly         bool
+	IndexHeaderVersion    uint32
+	Name                  string
+	Description           string
+	Config                map[string]string // Only used for custom volume migration.
+	Snapshots             []string
+	MigrationType         Type
+	TrackProgress         bool
+	Refresh               bool
+	Live                  bool
+	VolumeSize            int64
+	ContentType           string
+	VolumeOnly            bool
+	ClusterMoveSourceName string
 }
 
 // TypesToHeader converts one or more Types to a MigrationHeader. It uses the first type argument

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1800,7 +1800,7 @@ func (b *lxdBackend) CreateInstanceFromMigration(inst instance.Instance, conn io
 		return fmt.Errorf("Volume exists in database but not on storage")
 	}
 
-	// Consistenct check for refresh mode.
+	// Consistency check for refresh mode.
 	// We expect that the args.Refresh setting will have already been set to false by the caller as part of
 	// detecting if the instance DB record exists or not. If we get here then something has gone wrong.
 	if args.Refresh && !volExists {

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -168,6 +168,10 @@ func (b *mockBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteC
 	return nil
 }
 
+func (b *mockBackend) CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error {
+	return nil
+}
+
 func (b *mockBackend) RefreshCustomVolume(projectName string, srcProjectName string, volName string, desc string, config map[string]string, srcPoolName, srcVolName string, srcVolOnly bool, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -68,6 +68,7 @@ type Pool interface {
 	GenerateInstanceBackupConfig(inst instance.Instance, snapshots bool, op *operations.Operation) (*backupConfig.Config, error)
 	CheckInstanceBackupFileSnapshots(backupConf *backupConfig.Config, projectName string, deleteMissing bool, op *operations.Operation) ([]*api.InstanceSnapshot, error)
 	ImportInstance(inst instance.Instance, poolVol *backupConfig.Config, op *operations.Operation) error
+	CleanupInstancePaths(inst instance.Instance, op *operations.Operation) error
 
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args *migration.VolumeSourceArgs, op *operations.Operation) error
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error


### PR DESCRIPTION
- Pushes instance cluster move on ceph storage pools down into migration subsystem (if the source member is online).
- This lays the groundwork for adding VM live migration support for instance cluster member moves on ceph.
- Prevents rename of instance when doing "live" (currently stateful stop/start) cluster member move.
- Adds support for cleaning up instance mount paths on the source member when doing cluster member move using ceph (previously they were just left behind from what I can see).