### PR TITLE
Support VDPA alongside SR-IOV on OVN NICs

### DIFF
--- a/.sphinx/.wordlist.txt
+++ b/.sphinx/.wordlist.txt
@@ -264,6 +264,7 @@ userspace
 UUID
 vCPU
 vCPUs
+VDPA
 VFs
 VFS
 VirtIO

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -2212,3 +2212,7 @@ With this mode enabled the following changes are made to the network:
 * Static routes for active instance NIC addresses will be added to the virtual router.
 * A discard route for the entire internal subnet will be added to the virtual router to prevent packets destined for inactive addresses from escaping to the uplink network.
 * The DHCPv4 server will be configured to indicate that a netmask of 255.255.255.255 be used for instance configuration.
+
+## `ovn_nic_acceleration_vdpa`
+
+This updates the `ovn_nic_acceleration` API extension. The `acceleration` configuration key for OVN NICs can now takes the value `vdpa` to support Virtual Data Path Acceleration (VDPA).

--- a/doc/reference/devices_nic.md
+++ b/doc/reference/devices_nic.md
@@ -210,13 +210,21 @@ SR-IOV hardware acceleration
       ip link set enp9s0f0np0 up
       ```
 
+VDPA hardware acceleration
+: To use `acceleration=vdpa`, you must have a compatible VDPA physical NIC.
+  The setup is the same as for SR-IOV hardware acceleration, except that you must also enable the `vhost_vdpa` module and check that you have some available VDPA management devices :
+
+  ```
+  modprobe vhost_vdpa && vdpa mgmtdev show
+  ```
+
 #### Device options
 
 NIC devices of type `ovn` have the following device options:
 
 Key                                   | Type    | Default           | Managed | Description
 :--                                   | :--     | :--               | :--     | :--
-`acceleration`                        | string  | `none`            | no      | Enable hardware offloading (either `none` or `sriov`, see {ref}`devices-nic-hw-acceleration`)
+`acceleration`                        | string  | `none`            | no      | Enable hardware offloading (either `none`, `sriov` or `vdpa`, see {ref}`devices-nic-hw-acceleration`)
 `boot.priority`                       | integer | -                 | no      | Boot priority for VMs (higher value boots first)
 `host_name`                           | string  | randomly assigned | no      | The name of the interface inside the host
 `hwaddr`                              | string  | randomly assigned | no      | The MAC address of the new interface

--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -432,6 +432,7 @@ Key                                         | Type      | Description
 `volatile.<name>.last_state.created`        | string    | Whether the network device physical device was created (`true` or `false`)
 `volatile.<name>.last_state.mtu`            | string    | Network device original MTU used when moving a physical device into an instance
 `volatile.<name>.last_state.hwaddr`         | string    | Network device original MAC used when moving a physical device into an instance
+`volatile.<name>.last_state.vdpa.name`      | string    | VDPA device name used when moving a VDPA device file descriptor into an instance
 `volatile.<name>.last_state.vf.id`          | string    | SR-IOV virtual function ID used when moving a VF into an instance
 `volatile.<name>.last_state.vf.hwaddr`      | string    | SR-IOV virtual function original MAC used when moving a VF into an instance
 `volatile.<name>.last_state.vf.vlan`        | string    | SR-IOV virtual function original VLAN used when moving a VF into an instance

--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -4370,6 +4370,8 @@ definitions:
                 example: "2:7"
                 type: string
                 x-go-name: USBAddress
+            vdpa:
+                $ref: '#/definitions/ResourcesNetworkCardVDPA'
             vendor:
                 description: Name of the vendor
                 example: Aquantia Corp.
@@ -4518,6 +4520,19 @@ definitions:
                     $ref: '#/definitions/ResourcesNetworkCard'
                 type: array
                 x-go-name: VFs
+        type: object
+        x-go-package: github.com/lxc/lxd/shared/api
+    ResourcesNetworkCardVDPA:
+        description: ResourceNetworkCardVDPA represents the VDPA configuration of the network card
+        properties:
+            device:
+                description: Device identifier of the VDPA device
+                type: string
+                x-go-name: Device
+            name:
+                description: Name of the VDPA device
+                type: string
+                x-go-name: Name
         type: object
         x-go-package: github.com/lxc/lxd/shared/api
     ResourcesPCI:

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.2
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635
+	github.com/vishvananda/netlink v1.2.1-beta.2
 	github.com/zitadel/oidc/v2 v2.5.0
 	go.starlark.net v0.0.0-20230302034142-4b1e35fe2254
 	golang.org/x/crypto v0.8.0
@@ -131,7 +132,6 @@ require (
 	github.com/tinylib/msgp v1.1.8 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
-	github.com/vishvananda/netlink v1.2.1-beta.2 // indirect
 	github.com/vishvananda/netns v0.0.4 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
 	golang.org/x/mod v0.10.0 // indirect

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -14,7 +14,7 @@ import (
 func nicValidationRules(requiredFields []string, optionalFields []string, instConf instance.ConfigReader) map[string]func(value string) error {
 	// Define a set of default validators for each field name.
 	defaultValidators := map[string]func(value string) error{
-		"acceleration":                         validate.Optional(validate.IsOneOf("none", "sriov")),
+		"acceleration":                         validate.Optional(validate.IsOneOf("none", "sriov", "vdpa")),
 		"name":                                 validate.Optional(validate.IsInterfaceName, func(_ string) error { return nicCheckNamesUnique(instConf) }),
 		"parent":                               validate.IsAny,
 		"network":                              validate.IsAny,

--- a/lxd/ip/vdpa.go
+++ b/lxd/ip/vdpa.go
@@ -1,0 +1,411 @@
+package ip
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+
+	"github.com/vishvananda/netlink"
+	"github.com/vishvananda/netlink/nl"
+)
+
+// vDPA Netlink name.
+const (
+	vDPAGenlName = "vdpa"
+)
+
+// vDPA Netlink command.
+const (
+	_ uint8 = iota
+	_
+	vDPACmdMgmtDevGet
+	vDPACmdDevNew
+	vDPACmdDevDel
+	vDPACmdDevGet
+	_
+)
+
+// vDPA Netlink Attributes.
+const (
+	_ = iota
+
+	// bus name (optional) + dev name together make the parent device handle.
+	vDPAAttrMgmtDevBusName          // string
+	vDPAAttrMgmtDevDevName          // string
+	vDPAAttrMgmtDevSupportedClasses // u64
+
+	vDPAAttrDevName      // string
+	vDPAAttrDevID        // u32
+	vDPAAttrDevVendorID  // u32
+	vDPAAttrDevMaxVqs    // u32
+	vDPAAttrDevMaxVqSize // u16
+	vDPAAttrDevMinVqSize // u16
+
+	vDPAAttrDevNetCfgMacAddr // binary
+	vDPAAttrDevNetStatus     // u8
+	vDPAAttrDevNetCfgMaxVqp  // u16
+	vDPAAttrGetNetCfgMTU     // u16
+)
+
+// Base flags passed to all Netlink requests.
+const (
+	commonNLFlags = syscall.NLM_F_REQUEST | syscall.NLM_F_ACK
+)
+
+// MAX_VQP is the maximum number of VQPs supported by the vDPA device and is always the same as of now.
+const (
+	vDPAMaxVQP = uint16(16)
+)
+
+// vDPA device classes.
+const (
+	vdpaBusDevDir   = "/sys/bus/vdpa/devices"
+	vdpaVhostDevDir = "/dev"
+)
+
+// VhostVdpa is the vhost-vdpa device information.
+type VhostVDPA struct {
+	Name string
+	Path string
+}
+
+// MgmtVDPADev represents the vDPA management device information.
+type MgmtVDPADev struct {
+	BusName string // e.g. "pci"
+	DevName string // e.g. "0000:00:08.2"
+}
+
+// VDPADev represents the vDPA device information.
+type VDPADev struct {
+	// Name of the vDPA created device. e.g. "vdpa0" (note: the iproute2 associated command would look like `vdpa dev add mgmtdev pci/<PCI_SLOT_NAME> name vdpa0 max_vqp <MAX_VQP>`).
+	Name string
+	// Max VQs supported by the vDPA device.
+	MaxVQs uint32
+	// Associated vDPA management device.
+	MgmtDev *MgmtVDPADev
+	// Associated vhost-vdpa device.
+	VhostVDPA *VhostVDPA
+}
+
+// ParseAttributes parses the attributes of a netlink message for a vDPA management device.
+func (d *MgmtVDPADev) parseAttributes(attrs []syscall.NetlinkRouteAttr) error {
+	for _, attr := range attrs {
+		switch attr.Attr.Type {
+		case vDPAAttrMgmtDevBusName:
+			d.BusName = string(attr.Value[:len(attr.Value)-1])
+		case vDPAAttrMgmtDevDevName:
+			d.DevName = string(attr.Value[:len(attr.Value)-1])
+		}
+	}
+	return nil
+}
+
+// getVhostVDPADevInPath returns the VhostVDPA found in the provided parent device's path.
+func getVhostVDPADevInPath(parentPath string) (*VhostVDPA, error) {
+	fd, err := os.Open(parentPath)
+	if err != nil {
+		return nil, fmt.Errorf("Can not open %s: %v", parentPath, err)
+	}
+
+	defer fd.Close()
+
+	fileInfos, err := fd.Readdir(-1)
+	if err != nil {
+		return nil, fmt.Errorf("Can not get FileInfos: %v", err)
+	}
+
+	for _, file := range fileInfos {
+		if strings.Contains(file.Name(), "vhost-vdpa") && file.IsDir() {
+			devicePath := filepath.Join(vdpaVhostDevDir, file.Name())
+			info, err := os.Stat(devicePath)
+			if err != nil {
+				return nil, fmt.Errorf("Vhost device %s is not a valid device", devicePath)
+			}
+
+			if info.Mode()&os.ModeDevice == 0 {
+				return nil, fmt.Errorf("Vhost device %s is not a valid device", devicePath)
+			}
+
+			return &VhostVDPA{
+				Name: file.Name(),
+				Path: devicePath,
+			}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("No vhost-vdpa device found in %s", parentPath)
+}
+
+// ParseAttributes parses the attributes of a netlink message for a vDPA device.
+func (d *VDPADev) parseAttributes(attrs []syscall.NetlinkRouteAttr) error {
+	d.MgmtDev = &MgmtVDPADev{}
+	for _, attr := range attrs {
+		switch attr.Attr.Type {
+		case vDPAAttrDevName:
+			d.Name = string(attr.Value[:len(attr.Value)-1])
+		case vDPAAttrDevMaxVqs:
+			d.MaxVQs = binary.LittleEndian.Uint32(attr.Value[:len(attr.Value)])
+		case vDPAAttrMgmtDevBusName:
+			d.MgmtDev.BusName = string(attr.Value[:len(attr.Value)-1])
+		case vDPAAttrMgmtDevDevName:
+			d.MgmtDev.DevName = string(attr.Value[:len(attr.Value)-1])
+		}
+	}
+
+	// Get the vhost-vdpa device associated with the vDPA device.
+	vhostVDPA, err := getVhostVDPADevInPath(filepath.Join(vdpaBusDevDir, d.Name))
+	if err != nil {
+		return err
+	}
+
+	d.VhostVDPA = vhostVDPA
+	return nil
+}
+
+// runVDPANetlinkCmd executes a vDPA netlink command and returns the response.
+func runVDPANetlinkCmd(command uint8, flags int, data []*nl.RtAttr) ([][]byte, error) {
+	f, err := netlink.GenlFamilyGet(vDPAGenlName)
+	if err != nil {
+		return nil, fmt.Errorf("Could not get the vDPA Netlink family : %v", err)
+	}
+
+	msg := &nl.Genlmsg{
+		Command: command,
+		Version: nl.GENL_CTRL_VERSION,
+	}
+
+	req := nl.NewNetlinkRequest(int(f.ID), commonNLFlags|flags)
+	// Pass the data into the request header
+	req.AddData(msg)
+	for _, d := range data {
+		req.AddData(d)
+	}
+
+	// Execute the request
+	msgs, err := req.Execute(syscall.NETLINK_GENERIC, 0)
+	if err != nil {
+		return nil, fmt.Errorf("Could not execute vDPA Netlink request : %v", err)
+	}
+
+	return msgs, nil
+}
+
+// newNetlinkAttribute creates a new netlink attribute based on the attribute type and data.
+func newNetlinkAttribute(attrType int, data interface{}) (*nl.RtAttr, error) {
+	switch attrType {
+	case vDPAAttrMgmtDevBusName, vDPAAttrMgmtDevDevName, vDPAAttrDevName:
+		strData, ok := data.(string)
+		if !ok {
+			return nil, fmt.Errorf("Netlink attribute type %d requires string data", attrType)
+		}
+
+		bytes := make([]byte, len(strData)+1)
+		copy(bytes, strData)
+		return nl.NewRtAttr(attrType, bytes), nil
+	case vDPAAttrMgmtDevSupportedClasses:
+		u64Data, ok := data.(uint64)
+		if !ok {
+			return nil, fmt.Errorf("Netlink attribute type %d requires uint64 data", attrType)
+		}
+
+		return nl.NewRtAttr(attrType, nl.Uint64Attr(u64Data)), nil
+	case vDPAAttrDevID, vDPAAttrDevVendorID, vDPAAttrDevMaxVqs:
+		u32Data, ok := data.(uint32)
+		if !ok {
+			return nil, fmt.Errorf("Netlink attribute type %d requires uint32 data", attrType)
+		}
+
+		return nl.NewRtAttr(attrType, nl.Uint32Attr(u32Data)), nil
+	case vDPAAttrDevMaxVqSize, vDPAAttrDevMinVqSize, vDPAAttrDevNetCfgMaxVqp, vDPAAttrGetNetCfgMTU:
+		u16Data, ok := data.(uint16)
+		if !ok {
+			return nil, fmt.Errorf("Netlink attribute type %d requires uint16 data", attrType)
+		}
+
+		return nl.NewRtAttr(attrType, nl.Uint16Attr(u16Data)), nil
+	case vDPAAttrDevNetStatus:
+		u8Data, ok := data.(uint8)
+		if !ok {
+			return nil, fmt.Errorf("Netlink attribute type %d requires uint8 data", attrType)
+		}
+
+		return nl.NewRtAttr(attrType, nl.Uint8Attr(u8Data)), nil
+	case vDPAAttrDevNetCfgMacAddr:
+		binData, ok := data.([]byte)
+		if !ok {
+			return nil, fmt.Errorf("Netlink attribute type %d requires []byte data", attrType)
+		}
+
+		return nl.NewRtAttr(attrType, binData), nil
+	default:
+		return nil, fmt.Errorf("Unknown netlink attribute type %d", attrType)
+	}
+}
+
+// parseMgmtVDPADevList parses a list of vDPA management device netlink messages.
+func parseMgmtVDPADevList(msgs [][]byte) ([]*MgmtVDPADev, error) {
+	devices := make([]*MgmtVDPADev, 0, len(msgs))
+	for _, m := range msgs {
+		attrs, err := nl.ParseRouteAttr(m[nl.SizeofGenlmsg:])
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse Netlink vDPA management device route attributes : %v", err)
+		}
+
+		dev := &MgmtVDPADev{}
+		if err = dev.parseAttributes(attrs); err != nil {
+			return nil, err
+		}
+
+		devices = append(devices, dev)
+	}
+
+	return devices, nil
+}
+
+// parseVDPADevList parses a list of vDPA device netlink messages.
+func parseVDPADevList(msgs [][]byte) ([]*VDPADev, error) {
+	devices := make([]*VDPADev, 0, len(msgs))
+	for _, m := range msgs {
+		attrs, err := nl.ParseRouteAttr(m[nl.SizeofGenlmsg:])
+		if err != nil {
+			return nil, fmt.Errorf("Could not parse Netlink vDPA device route attributes : %v", err)
+		}
+
+		dev := &VDPADev{}
+		if err = dev.parseAttributes(attrs); err != nil {
+			return nil, err
+		}
+
+		devices = append(devices, dev)
+	}
+
+	return devices, nil
+}
+
+// ListVDPAMgmtDevices returns the list of all vDPA management devices.
+func ListVDPAMgmtDevices() ([]*MgmtVDPADev, error) {
+	resp, err := runVDPANetlinkCmd(vDPACmdMgmtDevGet, syscall.NLM_F_DUMP, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	mgtmDevs, err := parseMgmtVDPADevList(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return mgtmDevs, nil
+}
+
+// ListVDPADevices returns the list of all vDPA devices.
+func ListVDPADevices() ([]*VDPADev, error) {
+	resp, err := runVDPANetlinkCmd(vDPACmdDevGet, syscall.NLM_F_DUMP, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	devices, err := parseVDPADevList(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	return devices, nil
+}
+
+// AddVDPADevice adds a new vDPA device.
+func AddVDPADevice(pciDevSlotName string, volatile map[string]string) (*VDPADev, error) {
+	// List existing vDPA devices
+	vdpaDevs, err := ListVDPADevices()
+	if err != nil {
+		return nil, err
+	}
+
+	existingVDPADevNames := make(map[string]struct{})
+	for _, vdpaDev := range vdpaDevs {
+		existingVDPADevNames[vdpaDev.Name] = struct{}{}
+	}
+
+	// Create the netlink attributes
+	header := []*nl.RtAttr{}
+	busName, err := newNetlinkAttribute(vDPAAttrMgmtDevBusName, "pci")
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating vDPA `busName` netlink attr : %v", err)
+	}
+
+	header = append(header, busName)
+
+	mgmtDevDevName, err := newNetlinkAttribute(vDPAAttrMgmtDevDevName, pciDevSlotName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating vDPA `pciDevSlotName` netlink attr : %v", err)
+	}
+
+	header = append(header, mgmtDevDevName)
+
+	// Generate a unique attribute name for the vDPA device (i.e, vdpa0, vdpa1, etc.)
+	baseVDPAName, idx, generatedVDPADevName := "vdpa", 0, ""
+	for {
+		generatedVDPADevName = fmt.Sprintf("%s%d", baseVDPAName, idx)
+		_, ok := existingVDPADevNames[generatedVDPADevName]
+		if !ok {
+			break
+		}
+
+		idx++
+	}
+
+	devName, err := newNetlinkAttribute(vDPAAttrDevName, generatedVDPADevName)
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating vDPA `generatedVDPADevName` netlink attr : %v", err)
+	}
+
+	header = append(header, devName)
+
+	maxVQP, err := newNetlinkAttribute(vDPAAttrDevNetCfgMaxVqp, vDPAMaxVQP)
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating vDPA `maxVQP` netlink attr : %v", err)
+	}
+
+	header = append(header, maxVQP)
+
+	_, err = runVDPANetlinkCmd(vDPACmdDevNew, 0, header)
+	if err != nil {
+		return nil, fmt.Errorf("Failed creating vDPA device : %v", err)
+	}
+
+	// Now that the vDPA device has been created in the kernel, return the VDPADev struct
+	msgs, err := runVDPANetlinkCmd(vDPACmdDevGet, 0, []*nl.RtAttr{devName})
+	if err != nil {
+		return nil, fmt.Errorf("Failed getting vDPA device : %v", err)
+	}
+
+	vdpaDevs, err = parseVDPADevList(msgs)
+	if err != nil {
+		return nil, fmt.Errorf("Failed parsing vDPA device : %v", err)
+	}
+
+	// Update the volatile map
+	volatile["last_state.vdpa.name"] = generatedVDPADevName
+
+	return vdpaDevs[0], nil
+}
+
+// DeleteVDPADevice deletes a vDPA management device.
+func DeleteVDPADevice(vDPADevName string) error {
+	header := []*nl.RtAttr{}
+	devName, err := newNetlinkAttribute(vDPAAttrDevName, vDPADevName)
+	if err != nil {
+		return fmt.Errorf("Failed creating vDPA `vDPADevName` netlink attr : %v", err)
+	}
+
+	header = append(header, devName)
+
+	_, err = runVDPANetlinkCmd(vDPACmdDevDel, 0, header)
+	if err != nil {
+		return fmt.Errorf("Cannot delete VDPA dev: %v", err)
+	}
+
+	return nil
+}

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -404,6 +404,11 @@ type ResourcesNetworkCard struct {
 	// SRIOV information (when supported by the card)
 	SRIOV *ResourcesNetworkCardSRIOV `json:"sriov,omitempty" yaml:"sriov,omitempty"`
 
+	// vDPA information (when supported by the card)
+	//
+	// API extension: ovn_nic_acceleration_vdpa
+	VDPA *ResourcesNetworkCardVDPA `json:"vdpa,omitempty" yaml:"vdpa,omitempty"`
+
 	// NUMA node the card is a part of
 	// Example: 0
 	NUMANode uint64 `json:"numa_node" yaml:"numa_node"`
@@ -549,6 +554,19 @@ type ResourcesNetworkCardSRIOV struct {
 	// List of VFs (as additional Network devices)
 	// Example: null
 	VFs []ResourcesNetworkCard `json:"vfs" yaml:"vfs"`
+}
+
+// ResourceNetworkCardVDPA represents the VDPA configuration of the network card
+//
+// swagger:model
+//
+// API extension: ovn_nic_acceleration_vdpa.
+type ResourcesNetworkCardVDPA struct {
+	// Name of the VDPA device
+	Name string `json:"name" yaml:"name"`
+
+	// Device identifier of the VDPA device
+	Device string `json:"device" yaml:"device"`
 }
 
 // ResourcesStorage represents the local storage

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -369,6 +369,7 @@ var APIExtensions = []string{
 	"ovn_nic_nesting",
 	"oidc",
 	"network_ovn_l3only",
+	"ovn_nic_acceleration_vdpa",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
- [x] Add VDPA device tracking to resources API containing additional fields for `name` (`vdpa<ID>`) and a `device` (`vhost-vdpa-<ID>`, in /sys/bus/vdpa/drivers/vhost_vdpa/vdpa*)
- [x] Grow the `acceleration=="vdpa"` logic in `ovn_nic.go`
- [x] Utilities to create vDPA mgmt devices (need to be tested now)
- [x] Pass parameters to QEMU
- [x] Handle postStop in QEMU to setup the volatile["last_state.vdpa.name"]
- [x] Populate `ResourcesNetworkCardVDPA` in resources API
- [ ] Investigate QMP interface to switch an existing network card between vhost-vdpa and vhost-user at run time

