### PR TITLE
Migration: Reworks how migration connections are established and managed

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5721,6 +5721,15 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 		}
 	}
 
+	// Wait for migration connections.
+	connectionsCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	filesystemConn := args.FilesystemConn(connectionsCtx)
+	if filesystemConn == nil {
+		return fmt.Errorf("Timed out waiting for migration filesystem connection")
+	}
+
 	g, ctx := errgroup.WithContext(context.Background())
 
 	// Start control connection monitor.
@@ -5774,7 +5783,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 			}
 		}
 
-		err = pool.MigrateInstance(d, args.FilesystemConn, volSourceArgs, d.op)
+		err = pool.MigrateInstance(d, filesystemConn, volSourceArgs, d.op)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -1,6 +1,7 @@
 package instance
 
 import (
+	"context"
 	"crypto/x509"
 	"io"
 	"net"
@@ -206,8 +207,8 @@ type Info struct {
 type MigrateArgs struct {
 	ControlSend           func(m proto.Message) error
 	ControlReceive        func(m proto.Message) error
-	StateConn             io.ReadWriteCloser
-	FilesystemConn        io.ReadWriteCloser
+	StateConn             func(ctx context.Context) io.ReadWriteCloser
+	FilesystemConn        func(ctx context.Context) io.ReadWriteCloser
 	Snapshots             bool
 	Live                  bool
 	Disconnect            func()

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -319,7 +319,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		instanceOnly := req.InstanceOnly || req.ContainerOnly
-		ws, err := newMigrationSource(inst, req.Live, instanceOnly, req.AllowInconsistent, "")
+		ws, err := newMigrationSource(inst, req.Live, instanceOnly, req.AllowInconsistent, "", req.Target)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -341,12 +341,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		if req.Target != nil {
-			// Push mode
-			err := ws.ConnectContainerTarget(*req.Target)
-			if err != nil {
-				return response.InternalError(err)
-			}
-
+			// Push mode.
 			op, err := operations.OperationCreate(s, projectName, operations.OperationClassTask, operationtype.InstanceMigrate, resources, nil, run, nil, nil, r)
 			if err != nil {
 				return response.InternalError(err)

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -663,7 +663,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 			}
 		}
 
-		ws, err := newMigrationSource(snapInst, reqNew.Live, true, false, "")
+		ws, err := newMigrationSource(snapInst, reqNew.Live, true, false, "", req.Target)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -680,12 +680,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		}
 
 		if req.Target != nil {
-			// Push mode
-			err := ws.ConnectContainerTarget(*req.Target)
-			if err != nil {
-				return response.InternalError(err)
-			}
-
+			// Push mode.
 			op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotTransfer, resources, nil, run, nil, nil, r)
 			if err != nil {
 				return response.InternalError(err)
@@ -694,7 +689,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 			return operations.OperationResponse(op)
 		}
 
-		// Pull mode
+		// Pull mode.
 		op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassWebsocket, operationtype.SnapshotTransfer, resources, ws.Metadata(), run, nil, ws.Connect, r)
 		if err != nil {
 			return response.InternalError(err)

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -6,13 +6,9 @@
 package main
 
 import (
-	"crypto/x509"
-	"encoding/pem"
+	"context"
 	"fmt"
 	"net/http"
-	"net/url"
-	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -20,27 +16,17 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/lxc/lxd/lxd/instance"
-	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
-	"github.com/lxc/lxd/shared/cancel"
 	"github.com/lxc/lxd/shared/idmap"
-	"github.com/lxc/lxd/shared/logger"
-	"github.com/lxc/lxd/shared/tcp"
 )
 
 type migrationFields struct {
-	controlSecret string
-	controlConn   *websocket.Conn
-	controlLock   sync.Mutex
+	controlLock sync.Mutex
 
-	stateSecret string
-	stateConn   *websocket.Conn
-
-	fsSecret string
-	fsConn   *websocket.Conn
+	conns map[string]*migrationConn
 
 	// container specific fields
 	live         bool
@@ -67,12 +53,13 @@ func (c *migrationFields) send(m proto.Message) error {
 	c.controlLock.Lock()
 	defer c.controlLock.Unlock()
 
-	if c.controlConn == nil {
-		return fmt.Errorf("Control connection not initialized")
+	conn, err := c.conns[api.SecretNameControl].WebSocket(context.TODO())
+	if err != nil {
+		return fmt.Errorf("Control connection not initialized: %w", err)
 	}
 
-	_ = c.controlConn.SetWriteDeadline(time.Now().Add(time.Second * 30))
-	err := migration.ProtoSend(c.controlConn, m)
+	_ = conn.SetWriteDeadline(time.Now().Add(time.Second * 30))
+	err = migration.ProtoSend(conn, m)
 	if err != nil {
 		return err
 	}
@@ -81,18 +68,21 @@ func (c *migrationFields) send(m proto.Message) error {
 }
 
 func (c *migrationFields) recv(m proto.Message) error {
-	return migration.ProtoRecv(c.controlConn, m)
+	conn, err := c.conns[api.SecretNameControl].WebSocket(context.TODO())
+	if err != nil {
+		return fmt.Errorf("Control connection not initialized: %w", err)
+	}
+
+	return migration.ProtoRecv(conn, m)
 }
 
 func (c *migrationFields) disconnect() {
-	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
-
 	c.controlLock.Lock()
-	if c.controlConn != nil {
-		_ = c.controlConn.SetWriteDeadline(time.Now().Add(time.Second * 30))
-		_ = c.controlConn.WriteMessage(websocket.CloseMessage, closeMsg)
-		_ = c.controlConn.Close()
-		c.controlConn = nil /* don't close twice */
+	conn, _ := c.conns[api.SecretNameControl].WebSocket(context.TODO())
+	if conn != nil {
+		closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+		_ = conn.SetWriteDeadline(time.Now().Add(time.Second * 30))
+		_ = conn.WriteMessage(websocket.CloseMessage, closeMsg)
 	}
 
 	c.controlLock.Unlock()
@@ -105,19 +95,16 @@ func (c *migrationFields) disconnect() {
 	 * connection, since we report the error over the control channel
 	 * anyway.
 	 */
-	if c.fsConn != nil {
-		_ = c.fsConn.Close()
-	}
-
-	if c.stateConn != nil {
-		_ = c.stateConn.Close()
+	for _, conn := range c.conns {
+		conn.Close()
 	}
 }
 
 func (c *migrationFields) sendControl(err error) {
 	c.controlLock.Lock()
-	if c.controlConn != nil {
-		migration.ProtoSendControl(c.controlConn, err)
+	conn, _ := c.conns[api.SecretNameControl].WebSocket(context.TODO())
+	if conn != nil {
+		migration.ProtoSendControl(conn, err)
 	}
 
 	c.controlLock.Unlock()
@@ -148,152 +135,50 @@ func (c *migrationFields) controlChannel() <-chan *migration.ControlResponse {
 type migrationSourceWs struct {
 	migrationFields
 
-	allConnected          *cancel.Canceller
 	clusterMoveSourceName string
+
+	pushCertificate  string
+	pushOperationURL string
+	pushSecrets      map[string]string
 }
 
 func (s *migrationSourceWs) Metadata() any {
-	secrets := shared.Jmap{
-		api.SecretNameControl:    s.controlSecret,
-		api.SecretNameFilesystem: s.fsSecret,
-	}
-
-	if s.stateSecret != "" {
-		secrets[api.SecretNameState] = s.stateSecret
+	secrets := make(shared.Jmap, len(s.conns))
+	for connName, conn := range s.conns {
+		secrets[connName] = conn.Secret()
 	}
 
 	return secrets
 }
 
 func (s *migrationSourceWs) Connect(op *operations.Operation, r *http.Request, w http.ResponseWriter) error {
-	secret := r.FormValue("secret")
-	if secret == "" {
-		return fmt.Errorf("Missing migration source secret")
+	incomingSecret := r.FormValue("secret")
+	if incomingSecret == "" {
+		return api.StatusErrorf(http.StatusBadRequest, "Missing migration source secret")
 	}
 
-	var conn **websocket.Conn
-	var connName string
-
-	switch secret {
-	case s.controlSecret:
-		conn = &s.controlConn
-		connName = api.SecretNameControl
-	case s.stateSecret:
-		conn = &s.stateConn
-		connName = api.SecretNameState
-	case s.fsSecret:
-		conn = &s.fsConn
-		connName = api.SecretNameFilesystem
-	default:
-		// If we didn't find the right secret, the user provided a bad
-		// one, which 403, not 404, since this operation actually
-		// exists.
-		return os.ErrPermission
-	}
-
-	if *conn != nil {
-		return api.StatusErrorf(http.StatusConflict, "Migration source %q connection already established", connName)
-	}
-
-	c, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return err
-	}
-
-	// Set TCP timeout options.
-	remoteTCP, _ := tcp.ExtractConn(c.UnderlyingConn())
-	if remoteTCP != nil {
-		err = tcp.SetTimeouts(remoteTCP, 0)
-		if err != nil {
-			logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+	for connName, conn := range s.conns {
+		if incomingSecret != conn.Secret() {
+			continue
 		}
-	}
 
-	*conn = c
+		err := conn.AcceptIncoming(r, w)
+		if err != nil {
+			return fmt.Errorf("Failed accepting incoming migration source %q connection: %w", connName, err)
+		}
 
-	// Check criteria for considering all channels to be connected.
-	if s.instance != nil && s.instance.Type() == instancetype.Container && s.live && s.stateConn == nil {
 		return nil
 	}
 
-	if s.controlConn == nil {
-		return nil
-	}
-
-	if s.fsConn == nil {
-		return nil
-	}
-
-	s.allConnected.Cancel()
-
-	return nil
-}
-
-func (s *migrationSourceWs) ConnectTarget(certificate string, operation string, websockets map[string]string) error {
-	var err error
-	var cert *x509.Certificate
-
-	if certificate != "" {
-		certBlock, _ := pem.Decode([]byte(certificate))
-		if certBlock == nil {
-			return fmt.Errorf("Invalid certificate")
-		}
-
-		cert, err = x509.ParseCertificate(certBlock.Bytes)
-		if err != nil {
-			return err
-		}
-	}
-
-	config, err := shared.GetTLSConfig("", "", "", cert)
-	if err != nil {
-		return err
-	}
-
-	dialer := websocket.Dialer{
-		TLSClientConfig:  config,
-		NetDialContext:   shared.RFC3493Dialer,
-		HandshakeTimeout: time.Second * 5,
-	}
-
-	for name, secret := range websockets {
-		var conn **websocket.Conn
-
-		switch name {
-		case api.SecretNameControl:
-			conn = &s.controlConn
-		case api.SecretNameFilesystem:
-			conn = &s.fsConn
-		case api.SecretNameState:
-			conn = &s.stateConn
-		default:
-			return fmt.Errorf("Unknown secret provided: %s", name)
-		}
-
-		query := url.Values{"secret": []string{secret}}
-
-		// The URL is a https URL to the operation, mangle to be a wss URL to the secret
-		wsURL := fmt.Sprintf("wss://%s/websocket?%s", strings.TrimPrefix(operation, "https://"), query.Encode())
-
-		wsConn, _, err := dialer.Dial(wsURL, http.Header{})
-		if err != nil {
-			return err
-		}
-
-		*conn = wsConn
-	}
-
-	s.allConnected.Cancel()
-
-	return nil
+	// If we didn't find the right secret, the user provided a bad one, so return 403, not 404, since this
+	// operation actually exists.
+	return api.StatusErrorf(http.StatusForbidden, "Invalid migration source secret")
 }
 
 type migrationSink struct {
 	migrationFields
 
 	url                   string
-	dialer                websocket.Dialer
-	allConnected          *cancel.Canceller
 	push                  bool
 	clusterMoveSourceName string
 	refresh               bool
@@ -302,7 +187,7 @@ type migrationSink struct {
 // MigrationSinkArgs arguments to configure migration sink.
 type migrationSinkArgs struct {
 	// General migration fields
-	Dialer  websocket.Dialer
+	Dialer  *websocket.Dialer
 	Push    bool
 	Secrets map[string]string
 	URL     string
@@ -324,29 +209,11 @@ type migrationSinkArgs struct {
 	RsyncFeatures []string
 }
 
-func (s *migrationSink) connectWithSecret(secret string) (*websocket.Conn, error) {
-	query := url.Values{"secret": []string{secret}}
-
-	// The URL is a https URL to the operation, mangle to be a wss URL to the secret
-	wsURL := fmt.Sprintf("wss://%s/websocket?%s", strings.TrimPrefix(s.url, "https://"), query.Encode())
-
-	conn, _, err := s.dialer.Dial(wsURL, http.Header{})
-	if err != nil {
-		return nil, err
-	}
-
-	return conn, err
-}
-
 // Metadata returns metadata for the migration sink.
 func (s *migrationSink) Metadata() any {
-	secrets := shared.Jmap{
-		api.SecretNameControl:    s.controlSecret,
-		api.SecretNameFilesystem: s.fsSecret,
-	}
-
-	if s.stateSecret != "" {
-		secrets[api.SecretNameState] = s.stateSecret
+	secrets := make(shared.Jmap, len(s.conns))
+	for connName, conn := range s.conns {
+		secrets[connName] = conn.Secret()
 	}
 
 	return secrets
@@ -354,64 +221,25 @@ func (s *migrationSink) Metadata() any {
 
 // Connect connects to the migration source.
 func (s *migrationSink) Connect(op *operations.Operation, r *http.Request, w http.ResponseWriter) error {
-	secret := r.FormValue("secret")
-	if secret == "" {
-		return fmt.Errorf("Missing migration sink secret")
+	incomingSecret := r.FormValue("secret")
+	if incomingSecret == "" {
+		return api.StatusErrorf(http.StatusBadRequest, "Missing migration sink secret")
 	}
 
-	var conn **websocket.Conn
-	var connName string
-
-	switch secret {
-	case s.controlSecret:
-		conn = &s.controlConn
-		connName = api.SecretNameControl
-	case s.stateSecret:
-		conn = &s.stateConn
-		connName = api.SecretNameState
-	case s.fsSecret:
-		conn = &s.fsConn
-		connName = api.SecretNameFilesystem
-	default:
-		/* If we didn't find the right secret, the user provided a bad one,
-		 * which 403, not 404, since this operation actually exists */
-		return os.ErrPermission
-	}
-
-	if *conn != nil {
-		return api.StatusErrorf(http.StatusConflict, "Migration target %q connection already established", connName)
-	}
-
-	c, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
-	if err != nil {
-		return err
-	}
-
-	// Set TCP timeout options.
-	remoteTCP, _ := tcp.ExtractConn(c.UnderlyingConn())
-	if remoteTCP != nil {
-		err = tcp.SetTimeouts(remoteTCP, 0)
-		if err != nil {
-			logger.Warn("Failed setting TCP timeouts on remote connection", logger.Ctx{"err": err})
+	for connName, conn := range s.conns {
+		if incomingSecret != conn.Secret() {
+			continue
 		}
-	}
 
-	*conn = c
+		err := conn.AcceptIncoming(r, w)
+		if err != nil {
+			return fmt.Errorf("Failed accepting incoming migration sink %q connection: %w", connName, err)
+		}
 
-	// Check criteria for considering all channels to be connected.
-	if s.instance != nil && s.instance.Type() == instancetype.Container && s.live && s.stateConn == nil {
 		return nil
 	}
 
-	if s.controlConn == nil {
-		return nil
-	}
-
-	if s.fsConn == nil {
-		return nil
-	}
-
-	s.allConnected.Cancel()
-
-	return nil
+	// If we didn't find the right secret, the user provided a bad one, so return 403, not 404, since this
+	// operation actually exists.
+	return api.StatusErrorf(http.StatusForbidden, "Invalid migration sink secret")
 }

--- a/lxd/migration_connection.go
+++ b/lxd/migration_connection.go
@@ -1,0 +1,174 @@
+package main
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/tcp"
+)
+
+// setupWebsocketDialer uses a certificate to parse and configure a websocket.Dialer.
+func setupWebsocketDialer(certificate string) (*websocket.Dialer, error) {
+	var err error
+	var cert *x509.Certificate
+
+	if certificate != "" {
+		certBlock, _ := pem.Decode([]byte(certificate))
+		if certBlock == nil {
+			return nil, fmt.Errorf("Failed PEM decoding certificate")
+		}
+
+		cert, err = x509.ParseCertificate(certBlock.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("Failed parsing certificate: %w", err)
+		}
+	}
+
+	config, err := shared.GetTLSConfig("", "", "", cert)
+	if err != nil {
+		return nil, fmt.Errorf("Failed configuring TLS: %w", err)
+	}
+
+	dialer := &websocket.Dialer{
+		TLSClientConfig:  config,
+		NetDialContext:   shared.RFC3493Dialer,
+		HandshakeTimeout: time.Second * 5,
+	}
+
+	return dialer, nil
+}
+
+// newMigrationConn configures a new migration connection handler.
+func newMigrationConn(secret string, outgoingDialer *websocket.Dialer, outgoingURL *url.URL) *migrationConn {
+	return &migrationConn{
+		secret:         secret,
+		outgoingDialer: outgoingDialer,
+		outgoingURL:    outgoingURL,
+		connected:      make(chan struct{}),
+	}
+}
+
+// migrationConn represents a handler for both accepting and making new migration connections.
+type migrationConn struct {
+	mu             sync.Mutex
+	secret         string
+	outgoingDialer *websocket.Dialer
+	outgoingURL    *url.URL
+	conn           *websocket.Conn
+	connected      chan struct{}
+	disconnected   bool
+}
+
+// Secret returns the secret for this connection.
+func (c *migrationConn) Secret() string {
+	return c.secret
+}
+
+// AcceptIncoming takes an incoming HTTP request and upgrades it to a websocket.
+func (c *migrationConn) AcceptIncoming(r *http.Request, w http.ResponseWriter) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.disconnected {
+		return fmt.Errorf("Connection already disconnected")
+	}
+
+	if c.conn != nil {
+		return api.StatusErrorf(http.StatusConflict, "Connection already established")
+	}
+
+	var err error
+	c.conn, err = shared.WebsocketUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return fmt.Errorf("Failed upgrading incoming request to websocket: %w", err)
+	}
+
+	// Set TCP timeout options.
+	remoteTCP, _ := tcp.ExtractConn(c.conn.UnderlyingConn())
+	if remoteTCP != nil {
+		err = tcp.SetTimeouts(remoteTCP, 0)
+		if err != nil {
+			logger.Warn("Failed setting TCP timeouts on incoming websocket connection", logger.Ctx{"err": err})
+		}
+	}
+
+	close(c.connected)
+
+	return nil
+}
+
+// WebSocket returns the underlying websocket connection.
+// If the connection isn't yet active it will either wait for an incoming connection or if configured, will atempt
+// to initiate a new outbound connection. If the context is cancelled before the connection is established it
+// will return with an error.
+func (c *migrationConn) WebSocket(ctx context.Context) (*websocket.Conn, error) {
+	c.mu.Lock()
+
+	if c.disconnected {
+		c.mu.Unlock()
+		return nil, fmt.Errorf("Connection already disconnected")
+	}
+
+	if c.conn != nil {
+		c.mu.Unlock()
+		return c.conn, nil
+	}
+
+	if c.outgoingURL != nil && c.outgoingDialer != nil {
+		var err error
+		q := c.outgoingURL.Query()
+		q.Set("secret", c.secret)
+		c.outgoingURL.RawQuery = q.Encode()
+		c.conn, _, err = c.outgoingDialer.DialContext(ctx, c.outgoingURL.String(), http.Header{})
+		if err != nil {
+			c.mu.Unlock()
+			return nil, err
+		}
+
+		c.mu.Unlock()
+		return c.conn, nil
+	}
+
+	c.mu.Unlock()
+
+	select {
+	case <-c.connected:
+		return c.conn, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
+// WebsocketIO calles WebSocket and returns the connection wrapped in a shared.WebsocketIO.
+func (c *migrationConn) WebsocketIO(ctx context.Context) (*shared.WebsocketIO, error) {
+	wsConn, err := c.WebSocket(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &shared.WebsocketIO{Conn: wsConn}, nil
+}
+
+// Close closes the connection (if established) and marks it as disconnected so that it cannot be used again.
+func (c *migrationConn) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.disconnected = true
+
+	if c.conn != nil {
+		c.conn.Close()
+		c.conn = nil
+	}
+}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -873,7 +873,7 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 	// to avoid this function relying on the legacy storage layer.
 	migrationArgs := migrationSinkArgs{
 		URL: req.Source.Operation,
-		Dialer: websocket.Dialer{
+		Dialer: &websocket.Dialer{
 			TLSClientConfig:  config,
 			NetDialContext:   shared.RFC3493Dialer,
 			HandshakeTimeout: time.Second * 5,

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1139,7 +1139,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 // storagePoolVolumeTypePostMigration handles volume migration type POST requests.
 func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, volumeName string, req api.StorageVolumePost) response.Response {
-	ws, err := newStorageMigrationSource(req.VolumeOnly)
+	ws, err := newStorageMigrationSource(req.VolumeOnly, req.Target)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -1152,12 +1152,7 @@ func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, req
 	}
 
 	if req.Target != nil {
-		// Push mode
-		err := ws.ConnectStorageTarget(*req.Target)
-		if err != nil {
-			return response.InternalError(err)
-		}
-
+		// Push mode.
 		op, err := operations.OperationCreate(state, requestProjectName, operations.OperationClassTask, operationtype.VolumeMigrate, resources, nil, run, nil, nil, r)
 		if err != nil {
 			return response.InternalError(err)
@@ -1166,7 +1161,7 @@ func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, req
 		return operations.OperationResponse(op)
 	}
 
-	// Pull mode
+	// Pull mode.
 	op, err := operations.OperationCreate(state, requestProjectName, operations.OperationClassWebsocket, operationtype.VolumeMigrate, resources, ws.Metadata(), run, nil, ws.Connect, r)
 	if err != nil {
 		return response.InternalError(err)

--- a/shared/network.go
+++ b/shared/network.go
@@ -498,7 +498,8 @@ func WebsocketConsoleMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadClo
 }
 
 var WebsocketUpgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+	CheckOrigin:      func(r *http.Request) bool { return true },
+	HandshakeTimeout: time.Second * 5,
 }
 
 // AllocatePort asks the kernel for a free open port that is ready to use.


### PR DESCRIPTION
Rather than using dedicated variables for each type of migration connection, as well as duplicating the associated certificate parsing and connection establishment logic, this PR introduces the concept of a `migrationConn` type that manages the lifecycle of the underlying `websocket.Conn`.

This allows us to stop using a separate variable for the connection itself and any associated "connection established" type variables, and instead store them all in a central `conns` map keyed on the existing `api.Secret*` constants (which are already used exchanging secrets between LXD servers).

This PR also brings the parsing of the push target certificate earlier on in the process, before the operation is created.

Whilst I feel this PR makes the handling of migration connections easier to understand and reason about, the primary reason for doing this refactor was to provide the ability for specific instance types to decide to establish a state connection *after* the main migration negotiation has taken place over the control socket.

This is going to be required for VM live migration, because we won't know if both sides support using the state socket until the storage pool negotiation has taken place. This is unlike containers where the state migration is independent of the storage layer.

Whilst this really only affected the state socket, I thought it would be cleaner to make all sockets behave the same way so they are tested more thoroughly.