### PR TITLE
Feature expose memory and disk in state api

### DIFF
--- a/lxc/info.go
+++ b/lxc/info.go
@@ -501,8 +501,8 @@ func (c *cmdInfo) instanceInfo(d lxd.InstanceServer, remote config.Remote, name 
 		diskInfo := ""
 		if inst.State.Disk != nil {
 			for entry, disk := range inst.State.Disk {
-				if disk.Usage != 0 {
-					diskInfo += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage, 2))
+				if disk.Usage.Used != 0 {
+					diskInfo += fmt.Sprintf("    %s: %s\n", entry, units.GetByteSizeStringIEC(disk.Usage.Used, 2))
 				}
 			}
 		}

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -851,8 +851,8 @@ func (c *cmdList) cpuUsageSecondsColumnData(cInfo api.InstanceFull) string {
 func (c *cmdList) diskUsageColumnData(cInfo api.InstanceFull) string {
 	rootDisk, _, _ := shared.GetRootDiskDevice(cInfo.ExpandedDevices)
 
-	if cInfo.State != nil && cInfo.State.Disk != nil && cInfo.State.Disk[rootDisk].Usage > 0 {
-		return units.GetByteSizeStringIEC(cInfo.State.Disk[rootDisk].Usage, 2)
+	if cInfo.State != nil && cInfo.State.Disk != nil && cInfo.State.Disk[rootDisk].Usage.Used > 0 {
+		return units.GetByteSizeStringIEC(cInfo.State.Disk[rootDisk].Usage.Used, 2)
 	}
 
 	return ""

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7037,7 +7037,7 @@ func (d *lxc) diskState() map[string]api.InstanceStateDisk {
 			continue
 		}
 
-		var usage int64
+		var usage *storagePools.VolumeState
 
 		if dev.Config["path"] == "/" {
 			pool, err := storagePools.LoadByInstance(d.state, d)
@@ -7073,7 +7073,7 @@ func (d *lxc) diskState() map[string]api.InstanceStateDisk {
 			continue
 		}
 
-		disk[dev.Name] = api.InstanceStateDisk{Usage: usage}
+		disk[dev.Name] = api.InstanceStateDisk{Usage: *usage}
 	}
 
 	return disk

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -6602,7 +6602,7 @@ func (d *qemu) diskState() (map[string]api.InstanceStateDisk, error) {
 	}
 
 	disk := map[string]api.InstanceStateDisk{}
-	disk[rootDiskName] = api.InstanceStateDisk{Usage: usage}
+	disk[rootDiskName] = api.InstanceStateDisk{Usage: *usage}
 	return disk, nil
 }
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2481,19 +2481,19 @@ func (b *lxdBackend) BackupInstance(inst instance.Instance, tarWriter *instancew
 }
 
 // GetInstanceUsage returns the disk usage of the instance's root volume.
-func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (int64, error) {
+func (b *lxdBackend) GetInstanceUsage(inst instance.Instance) (*VolumeState, error) {
 	l := logger.AddContext(b.logger, logger.Ctx{"project": inst.Project().Name, "instance": inst.Name()})
 	l.Debug("GetInstanceUsage started")
 	defer l.Debug("GetInstanceUsage finished")
 
 	err := b.isStatusReady()
 	if err != nil {
-		return -1, err
+		return nil, err
 	}
 
 	volType, err := InstanceTypeToVolumeType(inst.Type())
 	if err != nil {
-		return -1, err
+		return nil, err
 	}
 
 	contentType := InstanceContentType(inst)
@@ -4965,15 +4965,15 @@ func (b *lxdBackend) GetCustomVolumeDisk(projectName, volName string) (string, e
 }
 
 // GetCustomVolumeUsage returns the disk space used by the custom volume.
-func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (int64, error) {
+func (b *lxdBackend) GetCustomVolumeUsage(projectName, volName string) (*VolumeState, error) {
 	err := b.isStatusReady()
 	if err != nil {
-		return -1, err
+		return nil, err
 	}
 
 	volume, err := VolumeDBGet(b, projectName, volName, drivers.VolumeTypeCustom)
 	if err != nil {
-		return -1, err
+		return nil, err
 	}
 
 	// Get the volume name on storage.

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -184,8 +184,8 @@ func (b *mockBackend) BackupInstance(inst instance.Instance, tarWriter *instance
 	return nil
 }
 
-func (b *mockBackend) GetInstanceUsage(inst instance.Instance) (int64, error) {
-	return 0, nil
+func (b *mockBackend) GetInstanceUsage(inst instance.Instance) (*VolumeState, error) {
+	return nil, nil
 }
 
 func (b *mockBackend) SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error {
@@ -304,8 +304,8 @@ func (b *mockBackend) GetCustomVolumeDisk(projectName string, volName string) (s
 	return "", nil
 }
 
-func (b *mockBackend) GetCustomVolumeUsage(projectName string, volName string) (int64, error) {
-	return 0, nil
+func (b *mockBackend) GetCustomVolumeUsage(projectName string, volName string) (*VolumeState, error) {
+	return nil, nil
 }
 
 func (b *mockBackend) MountCustomVolume(projectName string, volName string, op *operations.Operation) error {

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -2,6 +2,7 @@ package drivers
 
 import (
 	"fmt"
+	"github.com/lxc/lxd/lxd/storage"
 	"io"
 	"net/url"
 	"os/exec"
@@ -352,8 +353,8 @@ func (d *common) UpdateVolume(vol Volume, changedConfig map[string]string) error
 }
 
 // GetVolumeUsage returns the disk space usage of a volume.
-func (d *common) GetVolumeUsage(vol Volume) (int64, error) {
-	return -1, ErrNotSupported
+func (d *common) GetVolumeUsage(vol Volume) (*storage.VolumeState, error) {
+	return nil, ErrNotSupported
 }
 
 // SetVolumeQuota applies a size limit on volume.

--- a/lxd/storage/drivers/driver_mock.go
+++ b/lxd/storage/drivers/driver_mock.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"github.com/lxc/lxd/lxd/storage"
 	"io"
 
 	"github.com/lxc/lxd/lxd/backup"
@@ -128,8 +129,8 @@ func (d *mock) UpdateVolume(vol Volume, changedConfig map[string]string) error {
 }
 
 // GetVolumeUsage returns the disk space used by the volume.
-func (d *mock) GetVolumeUsage(vol Volume) (int64, error) {
-	return 0, nil
+func (d *mock) GetVolumeUsage(vol Volume) (*storage.VolumeState, error) {
+	return nil, nil
 }
 
 // SetVolumeQuota applies a size limit on volume.

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"github.com/lxc/lxd/lxd/storage"
 	"io"
 	"net/url"
 
@@ -69,7 +70,7 @@ type Driver interface {
 	DeleteVolume(vol Volume, op *operations.Operation) error
 	RenameVolume(vol Volume, newName string, op *operations.Operation) error
 	UpdateVolume(vol Volume, changedConfig map[string]string) error
-	GetVolumeUsage(vol Volume) (int64, error)
+	GetVolumeUsage(vol Volume) (*storage.VolumeState, error)
 	SetVolumeQuota(vol Volume, size string, allowUnsafeResize bool, op *operations.Operation) error
 	GetVolumeDiskPath(vol Volume) (string, error)
 	ListVolumes() ([]Volume, error)

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -18,6 +18,11 @@ import (
 	"github.com/lxc/lxd/shared/instancewriter"
 )
 
+type VolumeState struct {
+	Size int64
+	Used int64
+}
+
 // MountInfo represents info about the result of a mount operation.
 type MountInfo struct {
 	DiskPath string // The location of the block disk (if supported).
@@ -74,7 +79,7 @@ type Pool interface {
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, allowInconsistent bool, op *operations.Operation) error
 	BackupInstance(inst instance.Instance, tarWriter *instancewriter.InstanceTarWriter, optimized bool, snapshots bool, op *operations.Operation) error
 
-	GetInstanceUsage(inst instance.Instance) (int64, error)
+	GetInstanceUsage(inst instance.Instance) (*VolumeState, error)
 	SetInstanceQuota(inst instance.Instance, size string, vmStateSize string, op *operations.Operation) error
 
 	MountInstance(inst instance.Instance, op *operations.Operation) (*MountInfo, error)
@@ -111,7 +116,7 @@ type Pool interface {
 	RenameCustomVolume(projectName string, volName string, newVolName string, op *operations.Operation) error
 	DeleteCustomVolume(projectName string, volName string, op *operations.Operation) error
 	GetCustomVolumeDisk(projectName string, volName string) (string, error)
-	GetCustomVolumeUsage(projectName string, volName string) (int64, error)
+	GetCustomVolumeUsage(projectName string, volName string) (*VolumeState, error)
 	MountCustomVolume(projectName string, volName string, op *operations.Operation) error
 	UnmountCustomVolume(projectName string, volName string, op *operations.Operation) (bool, error)
 	ImportCustomVolume(projectName string, poolVol *backupConfig.Config, op *operations.Operation) error

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -935,7 +935,8 @@ func RenderSnapshotUsage(s *state.State, snapInst instance.Instance) func(respon
 			// It is important that the snapshot not be mounted here as mounting a snapshot can trigger a very
 			// expensive filesystem UUID regeneration, so we rely on the driver implementation to get the info
 			// we are requesting as cheaply as possible.
-			apiRes.Size, _ = pool.GetInstanceUsage(snapInst)
+			volumeState, _ := pool.GetInstanceUsage(snapInst)
+			apiRes.Size = volumeState.Size
 		}
 
 		return nil

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -113,7 +113,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Fetch the current usage.
-	var used int64
+	var used *storagePools.VolumeState
 	if volumeType == db.StoragePoolVolumeTypeCustom {
 		// Custom volumes.
 		used, err = pool.GetCustomVolumeUsage(projectName, volumeName)
@@ -147,8 +147,8 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 	state.Usage = &api.StorageVolumeStateUsage{}
 
 	// Only fill 'used' field if receiving a valid value.
-	if used >= 0 {
-		state.Usage.Used = uint64(used)
+	if used != nil {
+		state.Usage.Used = uint64(used.Used)
 	}
 
 	var dbVolume *db.StorageVolume

--- a/shared/api/instance_state.go
+++ b/shared/api/instance_state.go
@@ -1,5 +1,7 @@
 package api
 
+import "github.com/lxc/lxd/lxd/storage"
+
 // InstanceStatePut represents the modifiable fields of a LXD instance's state.
 //
 // swagger:model
@@ -66,7 +68,7 @@ type InstanceState struct {
 type InstanceStateDisk struct {
 	// Disk usage in bytes
 	// Example: 502239232
-	Usage int64 `json:"usage" yaml:"usage"`
+	Usage storage.VolumeState `json:"usage" yaml:"usage"`
 }
 
 // InstanceStateCPU represents the cpu information section of a LXD instance's state.


### PR DESCRIPTION
# Issue
Closes #11155

# Changes

- Introduce a VolumeState struct in lxd/storage/
- Modify GetVolumeUsage in lxd/storage/drivers to return that struct rather than the current int64
- Update the callers of that function (GetInstanceUsage and GetCustomVolumeUsage) to similarly return that struct
- Change InstanceStateDisk's Usage field from int64 to VolumeState type.