### PR TITLE
Storage: Fix UnmountVolume not deactivating ZFS block devices

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -175,6 +175,11 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			opts = []string{"volmode=none"}
 		}
 
+		// Avoid double caching in the ARC cache and in the guest OS filesystem cache.
+		if vol.volType == VolumeTypeVM {
+			opts = append(opts, "primarycache=metadata", "secondarycache=metadata")
+		}
+
 		loopPath := loopFilePath(d.name)
 		if d.config["source"] == loopPath {
 			// Create the volume dataset with sync disabled (to avoid kernel lockups when using a disk based pool).

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1898,8 +1898,8 @@ func (d *zfs) activateVolume(vol Volume) (bool, error) {
 
 // deactivateVolume deactivates a ZFS volume if activate. Returns true if deactivated, false if not.
 func (d *zfs) deactivateVolume(vol Volume) (bool, error) {
-	if !vol.IsBlockBacked() {
-		return false, nil // Nothing to do for non-block backed volumes.
+	if vol.contentType != ContentTypeBlock && !vol.IsBlockBacked() {
+		return false, nil // Nothing to do for non-block and non-block backed volumes.
 	}
 
 	dataset := d.dataset(vol, false)


### PR DESCRIPTION
Something I noticed this morning while working on VM live migration.

Most likely a regression introduced by https://github.com/lxc/lxd/pull/11206 as the logic for deactivating a block volume was only considering block backed filesystem volumes, and not VM or custom block volumes.

Also avoided an unnecessary extra call to ascertain to the block volume's `volmode` which was being done twice.

Finally also introduced a changed discussed with @stgraber yesterday that stops using the ARC cache for VM volume content, as this would lead to double caching both inside the guest OS's filesystem cache and on the host.