### PR TITLE
Migration: Fixes VM live migration premature error cleanup process

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -807,13 +807,13 @@ func (d *qemu) killQemuProcess(pid int) error {
 }
 
 // restoreState restores the VM state from a file handle.
-func (d *qemu) restoreStateHandle(monitor *qmp.Monitor, f *os.File) error {
+func (d *qemu) restoreStateHandle(ctx context.Context, monitor *qmp.Monitor, f *os.File) error {
 	err := monitor.SendFile("migration", f)
 	if err != nil {
 		return err
 	}
 
-	err = monitor.MigrateIncoming("fd:migration")
+	err = monitor.MigrateIncoming(ctx, "fd:migration")
 	if err != nil {
 		return err
 	}
@@ -823,6 +823,9 @@ func (d *qemu) restoreStateHandle(monitor *qmp.Monitor, f *os.File) error {
 
 // restoreState restores VM state from state file or from migration source if d.migrationReceiveStateful set.
 func (d *qemu) restoreState(monitor *qmp.Monitor) error {
+	stateCtx, stateCtxDone := context.WithCancel(context.Background())
+	defer stateCtxDone()
+
 	if d.migrationReceiveStateful != nil {
 		stateConn := d.migrationReceiveStateful[api.SecretNameState]
 		if stateConn == nil {
@@ -870,13 +873,17 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 			return err
 		}
 
-		go func() {
-			_, _ = io.Copy(pipeWrite, stateConn)
-			_ = pipeWrite.Close()
+		defer func() {
 			_ = pipeRead.Close()
+			_ = pipeWrite.Close()
 		}()
 
-		err = d.restoreStateHandle(monitor, pipeRead)
+		go func() {
+			_, _ = io.Copy(pipeWrite, stateConn)
+			stateCtxDone()
+		}()
+
+		err = d.restoreStateHandle(stateCtx, monitor, pipeRead)
 		if err != nil {
 			return fmt.Errorf("Failed restoring checkpoint from source: %w", err)
 		}
@@ -911,9 +918,12 @@ func (d *qemu) restoreState(monitor *qmp.Monitor) error {
 			_ = pipeWrite.Close()
 		}()
 
-		go func() { _, _ = io.Copy(pipeWrite, uncompressedState) }()
+		go func() {
+			_, _ = io.Copy(pipeWrite, uncompressedState)
+			stateCtxDone()
+		}()
 
-		err = d.restoreStateHandle(monitor, pipeRead)
+		err = d.restoreStateHandle(stateCtx, monitor, pipeRead)
 		if err != nil {
 			return fmt.Errorf("Failed restoring state from %q: %w", stateFile.Name(), err)
 		}

--- a/lxd/instance/drivers/qmp/commands.go
+++ b/lxd/instance/drivers/qmp/commands.go
@@ -347,7 +347,7 @@ func (m *Monitor) MigrateIncoming(uri string) error {
 
 	// Wait until it completes or fails.
 	for {
-		// Preapre the response.
+		// Prepare the response.
 		var resp struct {
 			Return struct {
 				Status string `json:"status"`


### PR DESCRIPTION
- Fixes source QEMU block device cleanup.
- Fixes target QEMU process hang on incoming migration state.
