### PR TITLE
Device: Fix VF and representor interface cleanup when using OVN NIC with `acceleration=sriov`

### DIFF
--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -657,13 +657,13 @@ func networkSRIOVSetupVF(d deviceCommon, vfParent string, vfDevice string, vfID 
 	// Record properties of VF device.
 	err = networkSnapshotPhysicalNIC(volatile["host_name"], volatile)
 	if err != nil {
-		return vfPCIDev, 0, err
+		return vfPCIDev, 0, fmt.Errorf("Failed recording NIC %q settings: %w", volatile["host_name"], err)
 	}
 
 	// Get VF device's PCI Slot Name so we can unbind and rebind it from the host.
 	vfPCIDev, err = network.SRIOVGetVFDevicePCISlot(vfParent, volatile["last_state.vf.id"])
 	if err != nil {
-		return vfPCIDev, 0, err
+		return vfPCIDev, 0, fmt.Errorf("Failed getting PCI slot for VF %q: %w", volatile["last_state.vf.id"], err)
 	}
 
 	// Unbind VF device from the host so that the settings will take effect when we rebind it.
@@ -679,7 +679,7 @@ func networkSRIOVSetupVF(d deviceCommon, vfParent string, vfDevice string, vfID 
 		link := &ip.Link{Name: vfParent}
 		err := link.SetVfVlan(volatile["last_state.vf.id"], d.config["vlan"])
 		if err != nil {
-			return vfPCIDev, 0, err
+			return vfPCIDev, 0, fmt.Errorf("Failed setting VLAN for VF %q: %w", volatile["last_state.vf.id"], err)
 		}
 	}
 
@@ -701,13 +701,13 @@ func networkSRIOVSetupVF(d deviceCommon, vfParent string, vfDevice string, vfID 
 		link := &ip.Link{Name: vfParent}
 		err = link.SetVfAddress(volatile["last_state.vf.id"], mac)
 		if err != nil {
-			return vfPCIDev, 0, err
+			return vfPCIDev, 0, fmt.Errorf("Failed setting MAC for VF %q: %w", volatile["last_state.vf.id"], err)
 		}
 
 		// Now that MAC is set on VF, we can enable spoof checking.
 		err = link.SetVfSpoofchk(volatile["last_state.vf.id"], "on")
 		if err != nil {
-			return vfPCIDev, 0, err
+			return vfPCIDev, 0, fmt.Errorf("Failed enabling spoof check for VF %q: %w", volatile["last_state.vf.id"], err)
 		}
 	} else {
 		// Try to reset VF to ensure no previous MAC restriction exists, as some devices require this
@@ -716,14 +716,14 @@ func networkSRIOVSetupVF(d deviceCommon, vfParent string, vfDevice string, vfID 
 		link := &ip.Link{Name: vfParent}
 		err = link.SetVfAddress(volatile["last_state.vf.id"], "00:00:00:00:00:00")
 		if err != nil {
-			return vfPCIDev, 0, err
+			return vfPCIDev, 0, fmt.Errorf("Failed clearing MAC for VF %q: %w", volatile["last_state.vf.id"], err)
 		}
 
 		if useSpoofCheck {
 			// Ensure spoof checking is disabled if not enabled in instance (only for real VF).
 			err = link.SetVfSpoofchk(volatile["last_state.vf.id"], "off")
 			if err != nil {
-				return vfPCIDev, 0, err
+				return vfPCIDev, 0, fmt.Errorf("Failed disabling spoof check for VF %q: %w", volatile["last_state.vf.id"], err)
 			}
 		}
 
@@ -737,7 +737,7 @@ func networkSRIOVSetupVF(d deviceCommon, vfParent string, vfDevice string, vfID 
 
 			err = link.SetVfAddress(volatile["last_state.vf.id"], mac)
 			if err != nil {
-				return vfPCIDev, 0, err
+				return vfPCIDev, 0, fmt.Errorf("Failed setting MAC for VF %q: %w", volatile["last_state.vf.id"], err)
 			}
 		}
 	}
@@ -763,13 +763,13 @@ func networkSRIOVSetupVF(d deviceCommon, vfParent string, vfDevice string, vfID 
 	} else if d.inst.Type() == instancetype.VM {
 		pciIOMMUGroup, err = pcidev.DeviceIOMMUGroup(vfPCIDev.SlotName)
 		if err != nil {
-			return vfPCIDev, 0, err
+			return vfPCIDev, 0, fmt.Errorf("Failed getting IOMMU group for VF device %q: %w", vfPCIDev.SlotName, err)
 		}
 
 		// Register VF device with vfio-pci driver so it can be passed to VM.
 		err = pcidev.DeviceDriverOverride(vfPCIDev, "vfio-pci")
 		if err != nil {
-			return vfPCIDev, 0, err
+			return vfPCIDev, 0, fmt.Errorf("Failed overriding driver for VF device %q: %w", vfPCIDev.SlotName, err)
 		}
 
 		// Record original driver used by VF device for restore.

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -423,7 +423,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 			vfPCIDev, pciIOMMUGroup, err = networkSRIOVSetupVF(d.deviceCommon, vfParent, vfDev, vfID, false, saveData)
 			if err != nil {
 				network.SRIOVVirtualFunctionMutex.Unlock()
-				return nil, err
+				return nil, fmt.Errorf("Failed setting up VF: %w", err)
 			}
 
 			network.SRIOVVirtualFunctionMutex.Unlock()
@@ -432,7 +432,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 			if d.inst.Type() == instancetype.Container {
 				err := networkSRIOVSetupContainerVFNIC(saveData["host_name"], d.config)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("Failed setting up container VF NIC: %w", err)
 				}
 			}
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -388,7 +388,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	// Setup the host network interface (if not nested).
-	var peerName string
+	var peerName, integrationBridgeNICName string
 	var mtu uint32
 	var vfPCIDev pcidev.Device
 	var pciIOMMUGroup uint64
@@ -441,8 +441,8 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 				}
 			}
 
+			integrationBridgeNICName = vfRepresentor
 			peerName = vfDev
-			saveData["host_name"] = vfRepresentor
 		} else {
 			// Create veth pair and configure the peer end with custom hwaddr and mtu if supplied.
 			if d.inst.Type() == instancetype.Container {
@@ -453,6 +453,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 					}
 				}
 
+				integrationBridgeNICName = saveData["host_name"]
 				peerName, mtu, err = networkCreateVethPair(saveData["host_name"], d.config)
 				if err != nil {
 					return nil, err
@@ -465,6 +466,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 					}
 				}
 
+				integrationBridgeNICName = saveData["host_name"]
 				peerName = saveData["host_name"] // VMs use the host_name to link to the TAP FD.
 				mtu, err = networkCreateTap(saveData["host_name"], d.config)
 				if err != nil {
@@ -500,8 +502,8 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	})
 
 	// Associated host side interface to OVN logical switch port (if not nested).
-	if saveData["host_name"] != "" {
-		cleanup, err := d.setupHostNIC(saveData["host_name"], logicalPortName, uplink)
+	if integrationBridgeNICName != "" {
+		cleanup, err := d.setupHostNIC(integrationBridgeNICName, logicalPortName, uplink)
 		if err != nil {
 			return nil, err
 		}
@@ -758,29 +760,27 @@ func (d *nicOVN) postStop() error {
 
 	networkVethFillFromVolatile(d.config, v)
 
-	if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
-		if d.config["acceleration"] == "sriov" {
-			// Restoring host-side interface.
-			network.SRIOVVirtualFunctionMutex.Lock()
-			err := networkSRIOVRestoreVF(d.deviceCommon, false, v)
-			if err != nil {
-				network.SRIOVVirtualFunctionMutex.Unlock()
-				return err
-			}
-
+	if d.config["acceleration"] == "sriov" {
+		// Restoring host-side interface.
+		network.SRIOVVirtualFunctionMutex.Lock()
+		err := networkSRIOVRestoreVF(d.deviceCommon, false, v)
+		if err != nil {
 			network.SRIOVVirtualFunctionMutex.Unlock()
+			return err
+		}
 
-			link := &ip.Link{Name: d.config["host_name"]}
-			err = link.SetDown()
-			if err != nil {
-				return fmt.Errorf("Failed to bring down the host interface %s: %w", d.config["host_name"], err)
-			}
-		} else {
-			// Removing host-side end of veth pair will delete the peer end too.
-			err := network.InterfaceRemove(d.config["host_name"])
-			if err != nil {
-				return fmt.Errorf("Failed to remove interface %q: %w", d.config["host_name"], err)
-			}
+		network.SRIOVVirtualFunctionMutex.Unlock()
+
+		link := &ip.Link{Name: d.config["host_name"]}
+		err = link.SetDown()
+		if err != nil {
+			return fmt.Errorf("Failed to bring down the host interface %s: %w", d.config["host_name"], err)
+		}
+	} else if d.config["host_name"] != "" && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["host_name"])) {
+		// Removing host-side end of veth pair will delete the peer end too.
+		err := network.InterfaceRemove(d.config["host_name"])
+		if err != nil {
+			return fmt.Errorf("Failed to remove interface %q: %w", d.config["host_name"], err)
 		}
 	}
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -426,6 +426,10 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 				return nil, fmt.Errorf("Failed setting up VF: %w", err)
 			}
 
+			revert.Add(func() {
+				_ = networkSRIOVRestoreVF(d.deviceCommon, false, saveData)
+			})
+
 			network.SRIOVVirtualFunctionMutex.Unlock()
 
 			// Setup the guest network interface.

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1189,19 +1189,6 @@ func SubnetParseAppend(subnets []*net.IPNet, parseSubnet ...string) ([]*net.IPNe
 	return subnets, nil
 }
 
-// InterfaceBindWait waits for network interface to appear after being bound to a driver.
-func InterfaceBindWait(ifName string) error {
-	for i := 0; i < 10; i++ {
-		if InterfaceExists(ifName) {
-			return nil
-		}
-
-		time.Sleep(50 * time.Millisecond)
-	}
-
-	return fmt.Errorf("Bind of interface %q took too long", ifName)
-}
-
 // IPRangesOverlap checks whether two ip ranges have ip addresses in common.
 func IPRangesOverlap(r1, r2 *shared.IPRange) bool {
 	if r1.End == nil {


### PR DESCRIPTION
Fixes various cleanup issues with the `acceleration=sriov` `ovn` NIC implementation:

- `postStop` expected the VF interface to exist before triggering a cleanup - but it never will for VMs (it needs to be rebound to the host first).
- The representor interface was being stored in `volatile["host_name]` but its more useful to store the VF name so we can use it to rebind it onto the host.
- The representor interface was not being removed from OVN integration bridge.
- Improve handling of VF rebinding to accommodate slow kernel/drivers.
- The VF interface was not being cleaned up on failed starts.