### PR TITLE
lxd/apparmor: fix AppArmor forkdnsProfile

### DIFF
--- a/lxd/apparmor/network_forkdns.go
+++ b/lxd/apparmor/network_forkdns.go
@@ -28,9 +28,11 @@ profile "{{ .name }}" flags=(attach_disconnected,mediate_deleted) {
   {{ .varPath }}/networks/{{ .networkName }}/forkdns.servers/servers.conf r,
 
   # Needed for lxd fork commands
+  @{PROC}/@{pid}/cpuset r,
   {{ .exePath }} mr,
   @{PROC}/@{pid}/cmdline r,
   {{ .rootPath }}/{etc,lib,usr/lib}/os-release r,
+  {{ .rootPath }}/run/systemd/resolve/stub-resolv.conf r,
 
   # Things that we definitely don't need
   deny @{PROC}/@{pid}/cgroup r,


### PR DESCRIPTION
lxd uses /proc/pid/cpuset and /var/lib/snapd/hostfs/run/systemd/resolve/stub-resolv.conf so this path is added to AppArmor profile to prevent denials

Audit log:
[Sun Apr 16 11:31:07 2023] audit: type=1400 audit(1681644667.565:47): apparmor="DENIED" operation="open" profile="lxd_forkdns-lxdfan0_</var/snap/lxd/common/lxd>" name="/var/lib/snapd/hostfs/run/systemd/resolve/stub-resolv.conf" pid=3972 comm="lxd.debug" requested_mask="r" denied_mask="r" fsuid=999 ouid=101 [Sun Apr 16 11:31:07 2023] audit: type=1400 audit(1681644667.569:48): apparmor="DENIED" operation="open" profile="lxd_forkdns-lxdfan0_</var/snap/lxd/common/lxd>" name="/proc/3972/cpuset" pid=3972 comm="lxd.debug" requested_mask="r" denied_mask="r" fsuid=999 ouid=999