### PR TITLE
Device: Add support for live VM cluster member move for `ovn` NICs

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5974,7 +5974,7 @@ func (d *qemu) MigrateSend(args instance.MigrateSendArgs) error {
 			if args.ClusterMoveSourceName == d.name {
 				// Disable VolatileSet from persisting changes to the database.
 				// This is so the volatile changes written by the running receiving member
-				//  are not lost when the source instance is stopped.
+				// are not lost when the source instance is stopped.
 				d.volatileSetPersistDisable = true
 
 				// Store a reference to this instance (which has the old volatile settings)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3481,6 +3481,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 		IPs:          staticIPs,
 		Parent:       nestedPortParentName,
 		VLAN:         nestedPortVLAN,
+		Location:     n.state.ServerName,
 	}, true)
 	if err != nil {
 		return "", err

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3886,16 +3886,26 @@ func (n *ovn) InstanceDevicePortStop(ovsExternalOVNPort openvswitch.OVNSwitchPor
 		source = "internal"
 	}
 
+	client, err := openvswitch.NewOVN(n.state)
+	if err != nil {
+		return fmt.Errorf("Failed to get OVN client: %w", err)
+	}
+
+	portLocation, err := client.LogicalSwitchPortLocationGet(instancePortName)
+	if err != nil {
+		return fmt.Errorf("Failed getting instance switch port options: %w", err)
+	}
+
+	// Don't delete logical switch port if already active on another chassis (i.e during live cluster move).
+	if portLocation != "" && portLocation != n.state.ServerName {
+		return nil
+	}
+
 	n.logger.Debug("Deleting instance port", logger.Ctx{"port": instancePortName, "source": source})
 
 	internalRoutes, externalRoutes, err := n.instanceDevicePortRoutesParse(opts.DeviceConfig)
 	if err != nil {
 		return fmt.Errorf("Failed parsing NIC device routes: %w", err)
-	}
-
-	client, err := openvswitch.NewOVN(n.state)
-	if err != nil {
-		return fmt.Errorf("Failed to get OVN client: %w", err)
 	}
 
 	// Load uplink network config.

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1202,6 +1202,22 @@ func (o *OVN) LogicalSwitchPortLocationGet(portName OVNSwitchPort) (string, erro
 	return strings.TrimSpace(location), nil
 }
 
+// LogicalSwitchPortOptionsSet sets the options for a logical switch port.
+func (o *OVN) LogicalSwitchPortOptionsSet(portName OVNSwitchPort, options map[string]string) error {
+	args := []string{"lsp-set-options", string(portName)}
+
+	for key, value := range options {
+		args = append(args, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	_, err := o.nbctl(args...)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // LogicalSwitchPortSetDNS sets up the switch port DNS records for the DNS name.
 // Returns the DNS record UUID, IPv4 and IPv6 addresses used for DNS records.
 func (o *OVN) LogicalSwitchPortSetDNS(switchName OVNSwitch, portName OVNSwitchPort, dnsName string, dnsIPv4 net.IP, dnsIPv6 net.IP) (OVNDNSUUID, error) {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -71,6 +71,7 @@ const ovnExtIDLXDSwitch = "lxd_switch"
 const ovnExtIDLXDSwitchPort = "lxd_switch_port"
 const ovnExtIDLXDProjectID = "lxd_project_id"
 const ovnExtIDLXDPortGroup = "lxd_port_group"
+const ovnExtIDLXDLocation = "lxd_location"
 
 // OVNIPv6RAOpts IPv6 router advertisements options that can be applied to a router.
 type OVNIPv6RAOpts struct {
@@ -116,6 +117,7 @@ type OVNSwitchPortOpts struct {
 	DHCPv6OptsID OVNDHCPOptionsUUID // Optional, if empty, no DHCPv6 enabled on port.
 	Parent       OVNSwitchPort      // Optional, if set a nested port is created.
 	VLAN         uint16             // Optional, use with Parent to request a specific VLAN for nested port.
+	Location     string             // Optional, use to indicate the name of the LXD server this port is bound to.
 }
 
 // OVNACLRule represents an ACL rule that can be added to a logical switch or port group.
@@ -1144,6 +1146,10 @@ func (o *OVN) LogicalSwitchPortAdd(switchName OVNSwitch, portName OVNSwitchPort,
 		if opts.DHCPv6OptsID != "" {
 			args = append(args, "--", "lsp-set-dhcpv6-options", string(portName), string(opts.DHCPv6OptsID))
 		}
+
+		if opts.Location != "" {
+			args = append(args, "--", "set", "logical_switch_port", string(portName), fmt.Sprintf("external_ids:%s=%s", ovnExtIDLXDLocation, opts.Location))
+		}
 	}
 
 	_, err := o.nbctl(args...)
@@ -1184,6 +1190,16 @@ func (o *OVN) LogicalSwitchPortDynamicIPs(portName OVNSwitchPort) ([]net.IP, err
 	}
 
 	return dynamicIPs, nil
+}
+
+// LogicalSwitchPortLocationGet returns the last set location of a logical switch port.
+func (o *OVN) LogicalSwitchPortLocationGet(portName OVNSwitchPort) (string, error) {
+	location, err := o.nbctl("--if-exists", "get", "logical_switch_port", string(portName), fmt.Sprintf("external-ids:%s", ovnExtIDLXDLocation))
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(location), nil
 }
 
 // LogicalSwitchPortSetDNS sets up the switch port DNS records for the DNS name.


### PR DESCRIPTION
Since adding support for live QEMU to QEMU VM migrations (https://discuss.linuxcontainers.org/t/lxd-online-vm-live-migration-qemu-to-qemu/16635) `ovn` NICs were breaking when performing live cluster member moves.

This is for 2 reasons:

1. The instance's logical switch port was being removed when the instance was stopped on the source after migration completed.
2. The logical switch port was not having its `requested-chassis` option set to the new chassis.

This PR fixes this by:

1. Storing the LXD server name in the `external-ids` field on device `Start()` so that it can be compared on device `Stop()` and if its no-longer the local server name then logical switch port cleanup is skipped, as it indicates this port has been started on another host.
2. Sets the `request-chassis` port option in the device's post-start hook so that once the migration has finished the logical switch port is transferred to the new target chassis.

Additionally a cleanup issue with unmounts not always occurring cleanly due to a file handle to the snapshot file being held open has been fixed.

Finally, there appears to be further room for improvement in reducing the downtime of a logical switch port, but this requires OVN 22.06 on the host which is not yet in Ubuntu LTS.

https://www.youtube.com/watch?v=ijZTMXAg-eI