### PR TITLE
Instance: Only add profiles the instance is using to backup config

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -5461,30 +5461,11 @@ func (b *lxdBackend) GenerateInstanceBackupConfig(inst instance.Instance, snapsh
 		Volume: &volume.StorageVolume,
 	}
 
-	// Set profiles
-	err = b.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
-		projectName := inst.Project().Name
-		filter := cluster.ProfileFilter{
-			Project: &projectName,
-		}
-
-		profiles, err := cluster.GetProfiles(ctx, tx.Tx(), filter)
-		if err != nil {
-			return err
-		}
-
-		config.Profiles = make([]*api.Profile, len(profiles))
-		for i, profile := range profiles {
-			config.Profiles[i], err = profile.ToAPI(ctx, tx.Tx())
-			if err != nil {
-				return err
-			}
-		}
-
-		return err
-	})
-	if err != nil {
-		return nil, err
+	// Add profiles from instance.
+	instProfiles := inst.Profiles()
+	config.Profiles = make([]*api.Profile, len(instProfiles))
+	for i := range instProfiles {
+		config.Profiles[i] = &instProfiles[i]
 	}
 
 	// Only populate Container field for non-snapshot instances.


### PR DESCRIPTION
Previously all profiles in the instance's project were being included. This avoids an extra DB transaction and queries too, which is valuable given that this function is called during instance start up.

@stgraber does this make sense? To my mind there's no reason to include all profiles from the project in the backup.yaml of every instance? But only the profiles assigned to the instance.