### PR TITLE
instance: stop API races while creating/deleting snapshots

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -74,7 +74,7 @@ type common struct {
 	node            string
 	profiles        []api.Profile
 	project         api.Project
-	snapshot        bool
+	isSnapshot      bool
 	stateful        bool
 
 	// Cached handles.
@@ -127,7 +127,7 @@ func (d *common) ExpandedDevices() deviceConfig.Devices {
 
 // ExpiryDate returns when this snapshot expires.
 func (d *common) ExpiryDate() time.Time {
-	if d.snapshot {
+	if d.isSnapshot {
 		return d.expiryDate
 	}
 
@@ -187,7 +187,7 @@ func (d *common) Project() api.Project {
 
 // IsSnapshot returns whether instance is snapshot or not.
 func (d *common) IsSnapshot() bool {
-	return d.snapshot
+	return d.isSnapshot
 }
 
 // IsStateful returns whether instance is stateful or not.
@@ -248,7 +248,7 @@ func (d *common) SetOperation(op *operations.Operation) {
 
 // Snapshots returns a list of snapshots.
 func (d *common) Snapshots() ([]instance.Instance, error) {
-	if d.snapshot {
+	if d.isSnapshot {
 		return []instance.Instance{}, nil
 	}
 
@@ -327,7 +327,7 @@ func (d *common) VolatileSet(changes map[string]string) error {
 	// Update the database if required.
 	if !d.volatileSetPersistDisable {
 		var err error
-		if d.snapshot {
+		if d.isSnapshot {
 			err = d.state.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 				return tx.UpdateInstanceSnapshotConfig(d.id, changes)
 			})
@@ -380,7 +380,7 @@ func (d *common) LogPath() string {
 
 // Path returns the instance's path.
 func (d *common) Path() string {
-	return storagePools.InstancePath(d.dbType, d.project.Name, d.name, d.snapshot)
+	return storagePools.InstancePath(d.dbType, d.project.Name, d.name, d.isSnapshot)
 }
 
 // RootfsPath returns the instance's rootfs path.

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -24,6 +24,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/instance/operationlock"
+	"github.com/lxc/lxd/lxd/locking"
 	"github.com/lxc/lxd/lxd/maas"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
@@ -711,29 +712,29 @@ func (d *common) isStartableStatusCode(statusCode api.StatusCode) error {
 	return nil
 }
 
-// startupSnapshot triggers a snapshot if configured.
-func (d *common) startupSnapshot(inst instance.Instance) error {
+// getStartupSnapNameAndExpiry returns the name and expiry for a snapshot to be taken at startup.
+func (d *common) getStartupSnapNameAndExpiry(inst instance.Instance) (string, *time.Time, error) {
 	schedule := strings.ToLower(d.expandedConfig["snapshots.schedule"])
 	if schedule == "" {
-		return nil
+		return "", nil, nil
 	}
 
 	triggers := strings.Split(schedule, ", ")
 	if !shared.StringInSlice("@startup", triggers) {
-		return nil
+		return "", nil, nil
 	}
 
 	expiry, err := shared.GetExpiry(time.Now(), d.expandedConfig["snapshots.expiry"])
 	if err != nil {
-		return err
+		return "", nil, err
 	}
 
 	name, err := instance.NextSnapshotName(d.state, inst, "snap%d")
 	if err != nil {
-		return err
+		return "", nil, err
 	}
 
-	return inst.Snapshot(name, expiry, false)
+	return name, &expiry, nil
 }
 
 // Internal MAAS handling.
@@ -1470,4 +1471,10 @@ func (d *common) devicesRemove(inst instance.Instance) {
 			}
 		}
 	}
+}
+
+// updateBackupFileLock acquires the update backup file lock that protects concurrent access to actions that will call UpdateBackupFile() as part of their operation.
+func (d *common) updateBackupFileLock(ctx context.Context) locking.UnlockFunc {
+	parentName, _, _ := api.GetParentAndSnapshotName(d.Name())
+	return locking.Lock(ctx, fmt.Sprintf("instance_updatebackupfile_%s_%s", d.Project().Name, parentName))
 }

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -180,7 +180,7 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.In
 			node:         args.Node,
 			profiles:     args.Profiles,
 			project:      p,
-			snapshot:     args.Snapshot,
+			isSnapshot:   args.Snapshot,
 			stateful:     args.Stateful,
 		},
 	}
@@ -317,13 +317,13 @@ func lxcCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.In
 		revert.Add(cleanup)
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.logger.Info("Created instance snapshot", logger.Ctx{"ephemeral": d.ephemeral})
 	} else {
 		d.logger.Info("Created instance", logger.Ctx{"ephemeral": d.ephemeral})
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotCreated.Event(d, nil))
 	} else {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
@@ -389,7 +389,7 @@ func lxcInstantiate(s *state.State, args db.InstanceArgs, expandedDevices device
 			node:         args.Node,
 			profiles:     args.Profiles,
 			project:      p,
-			snapshot:     args.Snapshot,
+			isSnapshot:   args.Snapshot,
 			stateful:     args.Stateful,
 		},
 	}
@@ -3645,7 +3645,7 @@ func (d *lxc) delete(force bool) error {
 		"ephemeral": d.ephemeral,
 		"used":      d.lastUsedDate}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.logger.Info("Deleting instance snapshot", ctxMap)
 	} else {
 		d.logger.Info("Deleting instance", ctxMap)
@@ -3747,13 +3747,13 @@ func (d *lxc) delete(force bool) error {
 		}
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.logger.Info("Deleted instance snapshot", ctxMap)
 	} else {
 		d.logger.Info("Deleted instance", ctxMap)
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotDeleted.Event(d, nil))
 	} else {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceDeleted.Event(d, nil))
@@ -3920,7 +3920,7 @@ func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
 	}
 
 	d.logger.Info("Renamed instance", ctxMap)
-	if d.snapshot {
+	if d.isSnapshot {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
 	} else {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
@@ -4722,7 +4722,7 @@ func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
 	undoChanges = false
 
 	if userRequested {
-		if d.snapshot {
+		if d.isSnapshot {
 			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotUpdated.Event(d, nil))
 		} else {
 			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceUpdated.Event(d, nil))

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2247,9 +2247,16 @@ func (d *lxc) startCommon() (string, []func() error, error) {
 	_ = unix.Unmount(d.RootfsPath(), unix.MNT_DETACH)
 
 	// Snapshot if needed.
-	err = d.startupSnapshot(d)
+	snapName, expiry, err := d.getStartupSnapNameAndExpiry(d)
 	if err != nil {
-		return "", nil, err
+		return "", nil, fmt.Errorf("Failed getting startup snapshot info: %w", err)
+	}
+
+	if snapName != "" && expiry != nil {
+		err := d.snapshot(snapName, *expiry, false)
+		if err != nil {
+			return "", nil, fmt.Errorf("Failed taking startup snapshot: %w", err)
+		}
 	}
 
 	// Update the backup.yaml file just before starting the instance process, but after all devices have been
@@ -2291,6 +2298,9 @@ func (d *lxc) detachInterfaceRename(netns string, ifName string, hostName string
 
 // Start starts the instance.
 func (d *lxc) Start(stateful bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	d.logger.Debug("Start started", logger.Ctx{"stateful": stateful})
 	defer d.logger.Debug("Start finished", logger.Ctx{"stateful": stateful})
 
@@ -3325,8 +3335,8 @@ func (d *lxc) RenderState(hostInterfaces []net.Interface) (*api.InstanceState, e
 	return d.renderState(d.statusCode(), hostInterfaces)
 }
 
-// Snapshot takes a new snapshot.
-func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
+// snapshot creates a snapshot of the instance.
+func (d *lxc) snapshot(name string, expiry time.Time, stateful bool) error {
 	// Deal with state.
 	if stateful {
 		// Quick checks.
@@ -3404,6 +3414,14 @@ func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
 	d.stopForkfile(false)
 
 	return d.snapshotCommon(d, name, expiry, stateful)
+}
+
+// Snapshot takes a new snapshot.
+func (d *lxc) Snapshot(name string, expiry time.Time, stateful bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
+	return d.snapshot(name, expiry, stateful)
 }
 
 // Restore restores a snapshot.
@@ -3764,6 +3782,9 @@ func (d *lxc) delete(force bool) error {
 
 // Rename renames the instance. Accepts an argument to enable applying deferred TemplateTriggerRename.
 func (d *lxc) Rename(newName string, applyTemplateTrigger bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	oldName := d.Name()
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
@@ -3953,6 +3974,9 @@ func (d *lxc) CGroupSet(key string, value string) error {
 
 // Update applies updated config.
 func (d *lxc) Update(args db.InstanceArgs, userRequested bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	// Setup a new operation
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionUpdate, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1052,6 +1052,9 @@ func (d *qemu) validateStartup(stateful bool, statusCode api.StatusCode) error {
 
 // Start starts the instance.
 func (d *qemu) Start(stateful bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	return d.start(stateful, nil)
 }
 
@@ -1342,10 +1345,20 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 	}()
 
 	// Snapshot if needed.
-	err = d.startupSnapshot(d)
+	snapName, expiry, err := d.getStartupSnapNameAndExpiry(d)
 	if err != nil {
+		err = fmt.Errorf("Failed getting startup snapshot info: %w", err)
 		op.Done(err)
 		return err
+	}
+
+	if snapName != "" && expiry != nil {
+		err := d.snapshot(snapName, *expiry, false)
+		if err != nil {
+			err = fmt.Errorf("Failed taking startup snapshot: %w", err)
+			op.Done(err)
+			return err
+		}
 	}
 
 	// Get CPU information.
@@ -4392,8 +4405,8 @@ func (d *qemu) IsPrivileged() bool {
 	return false
 }
 
-// Snapshot takes a new snapshot.
-func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
+// snapshot creates a snapshot of the instance.
+func (d *qemu) snapshot(name string, expiry time.Time, stateful bool) error {
 	var err error
 	var monitor *qmp.Monitor
 
@@ -4443,6 +4456,14 @@ func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
 	}
 
 	return nil
+}
+
+// Snapshot takes a new snapshot.
+func (d *qemu) Snapshot(name string, expiry time.Time, stateful bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
+	return d.snapshot(name, expiry, stateful)
 }
 
 // Restore restores an instance snapshot.
@@ -4567,6 +4588,9 @@ func (d *qemu) Restore(source instance.Instance, stateful bool) error {
 
 // Rename the instance. Accepts an argument to enable applying deferred TemplateTriggerRename.
 func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	oldName := d.Name()
 	ctxMap := logger.Ctx{
 		"created":   d.creationDate,
@@ -4731,6 +4755,9 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 
 // Update the instance config.
 func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	// Setup a new operation.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionUpdate, []operationlock.Action{operationlock.ActionRestart, operationlock.ActionRestore}, false, false)
 	if err != nil {
@@ -5380,6 +5407,9 @@ func (d *qemu) init() error {
 
 // Delete the instance.
 func (d *qemu) Delete(force bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	// Setup a new operation.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionDelete, nil, false, false)
 	if err != nil {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -146,7 +146,7 @@ func qemuInstantiate(s *state.State, args db.InstanceArgs, expandedDevices devic
 			node:         args.Node,
 			profiles:     args.Profiles,
 			project:      p,
-			snapshot:     args.Snapshot,
+			isSnapshot:   args.Snapshot,
 			stateful:     args.Stateful,
 		},
 	}
@@ -204,7 +204,7 @@ func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.I
 			node:         args.Node,
 			profiles:     args.Profiles,
 			project:      p,
-			snapshot:     args.Snapshot,
+			isSnapshot:   args.Snapshot,
 			stateful:     args.Stateful,
 		},
 	}
@@ -294,13 +294,13 @@ func qemuCreate(s *state.State, args db.InstanceArgs, p api.Project) (instance.I
 		revert.Add(cleanup)
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.logger.Info("Created instance snapshot", logger.Ctx{"ephemeral": d.ephemeral})
 	} else {
 		d.logger.Info("Created instance", logger.Ctx{"ephemeral": d.ephemeral})
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotCreated.Event(d, nil))
 	} else {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceCreated.Event(d, map[string]any{
@@ -4719,7 +4719,7 @@ func (d *qemu) Rename(newName string, applyTemplateTrigger bool) error {
 
 	d.logger.Info("Renamed instance", ctxMap)
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotRenamed.Event(d, map[string]any{"old_name": oldName}))
 	} else {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRenamed.Event(d, map[string]any{"old_name": oldName}))
@@ -5166,7 +5166,7 @@ func (d *qemu) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	if userRequested {
-		if d.snapshot {
+		if d.isSnapshot {
 			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotUpdated.Event(d, nil))
 		} else {
 			d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceUpdated.Event(d, nil))
@@ -5402,7 +5402,7 @@ func (d *qemu) delete(force bool) error {
 		"ephemeral": d.ephemeral,
 		"used":      d.lastUsedDate}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.logger.Info("Deleting instance snapshot", ctxMap)
 	} else {
 		d.logger.Info("Deleting instance", ctxMap)
@@ -5498,13 +5498,13 @@ func (d *qemu) delete(force bool) error {
 		}
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.logger.Info("Deleted instance snapshot", ctxMap)
 	} else {
 		d.logger.Info("Deleted instance", ctxMap)
 	}
 
-	if d.snapshot {
+	if d.isSnapshot {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceSnapshotDeleted.Event(d, nil))
 	} else {
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceDeleted.Event(d, nil))


### PR DESCRIPTION
closes #11538 

Here is an test script : 

```go
package main

import (
	"fmt"
	"sync"
	"time"

	lxd "github.com/lxc/lxd/client"
	"github.com/lxc/lxd/shared/api"
)

const LxdSock = "/var/snap/lxd/common/lxd/unix.socket"

func main() {
	fmt.Println("Trying to connect to LXD...")
	if srv, err := lxd.ConnectLXDUnix(LxdSock, nil); err == nil {
		fmt.Println("LXD server connection acquired")
		imageServer, err := lxd.ConnectSimpleStreams("https://images.linuxcontainers.org/", nil)
		if err != nil {
			panic(err)
		}

		fmt.Println("Connected to image server")

		alias, _, err := imageServer.GetImageAlias("alpine/3.17/cloud/amd64")
		if err != nil {
			panic(err)
		}

		fmt.Println("Got image alias")

		image, _, err := imageServer.GetImage(alias.Target)
		if err != nil {
			panic(err)
		}

		fmt.Println("Got image")

		req := api.InstancesPost{
			Name: "snap-del-api-race",
			Type: api.InstanceType("container"),
			Source: api.InstanceSource{
				Type:        "image",
				Fingerprint: image.Fingerprint,
				Project:     "default",
			},
		}

		op, err := srv.CreateInstanceFromImage(imageServer, *image, req)
		if err != nil {
			panic(err)
		}
		op.Wait()

		fmt.Println("Instance created")

		start := api.InstanceStatePut{
			Action:  "start",
			Timeout: 5,
			Force:   true,
		}

		upd, err := srv.UpdateInstanceState("snap-del-api-race", start, "")
		if err != nil {
			panic(err)
		}
		upd.Wait()

		fmt.Println("Instance started")

		// Create a lot of snapshots for an instance
		var wg sync.WaitGroup
		for i := 0; i < 100; i++ {
			go func(i int) {
				wg.Add(1)
				fmt.Println(fmt.Sprintf("Creating snapshot snap-%d", i))
				snap := api.InstanceSnapshotsPost{
					Name: fmt.Sprintf("snap-%d", i),
				}

				opCreate, err := srv.CreateInstanceSnapshot("snap-del-api-race", snap)
				if err != nil {
					panic(err)
				}

				err = opCreate.Wait()
				if err != nil {
					panic(err)
				}

				wg.Done()
				fmt.Println(fmt.Sprintf("snap-%d created", i))
			}(i)
		}

		wg.Wait()
		fmt.Println("All snapshots created")

		// Trigger 50 parallel delete snapshot requests on that instance via the HTTP API
		tasks := make([]lxd.Operation, 0)
		tasksMu := sync.Mutex{}
		for i := 0; i < 50; i++ {
			go func(i int) {
				opDel, err := srv.DeleteInstanceSnapshot("snap-del-api-race", fmt.Sprintf("snap-%d", i))
				if err != nil {
					panic(err)
				}

				fmt.Println(fmt.Sprintf("Deleting snapshot snap-%d", i))
				tasksMu.Lock()
				tasks = append(tasks, opDel)
				tasksMu.Unlock()
			}(i)
		}

		// created a ticker of 100ms
		// every 100ms, we check if the instance is running
		ticker := time.NewTicker(100 * time.Millisecond)
		longTicker := time.NewTicker(20 * time.Second)
		wait := make(chan struct{})
		// ...And fetch the operations for all 50 delete requests via the HTTP API at the same time
		// and check that we don't have "Instance snapshot record count doesn't match instance snapshot volume record count"
		go func() {
			for {
				select {
				case <-ticker.C:
					tasksMu.Lock()
					for i, task := range tasks {
						status := task.Get()
						fmt.Println(fmt.Sprintf("Snapshot snap-%d status: %s", i, status.Status))
					}

					tasksMu.Unlock()
				case <-longTicker.C:
					fmt.Println("Timeout")
					ticker.Stop()
					longTicker.Stop()
					wait <- struct{}{}
					return
				}
			}
		}()

		<-wait
		fmt.Println("Done")
	} else {
		fmt.Println(err)
	}
}

```