### PR TITLE
Network: Skip `bridge` ovn/dhcp range overlap check when DHCP is off

### DIFF
--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -400,7 +400,7 @@ func (n *bridge) Validate(config map[string]string) error {
 	}
 
 	// Check IPv4 OVN ranges.
-	if config["ipv4.ovn.ranges"] != "" {
+	if config["ipv4.ovn.ranges"] != "" && shared.IsTrueOrEmpty(config["ipv4.dhcp"]) {
 		dhcpSubnet := n.DHCPv4Subnet()
 		allowedNets := []*net.IPNet{}
 
@@ -432,7 +432,7 @@ func (n *bridge) Validate(config map[string]string) error {
 	}
 
 	// Check IPv6 OVN ranges.
-	if config["ipv6.ovn.ranges"] != "" {
+	if config["ipv6.ovn.ranges"] != "" && shared.IsTrueOrEmpty(config["ipv6.dhcp"]) {
 		dhcpSubnet := n.DHCPv6Subnet()
 		allowedNets := []*net.IPNet{}
 


### PR DESCRIPTION
If the network config key {ipv4,ipv6}.ovn.ranges is set, LXD currently checks if these ranges overlap with configured {ipv4,ipv6}.dhcp.ranges. These leads to an erroneous validation of DHCP ranges if dhcp=false.