### PR TITLE
Instance: Fixes deadlock when deleting a VM that has snapshots 

### DIFF
--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -7973,21 +7973,15 @@ func (d *lxc) LockExclusive() (*operationlock.InstanceOperation, error) {
 		return nil, fmt.Errorf("Instance is running")
 	}
 
-	revert := revert.New()
-	defer revert.Fail()
-
 	// Prevent concurrent operations the instance.
 	op, err := operationlock.Create(d.Project().Name, d.Name(), operationlock.ActionCreate, false, false)
 	if err != nil {
 		return nil, err
 	}
 
-	revert.Add(func() { op.Done(err) })
-
 	// Stop forkfile as otherwise it will hold the root volume open preventing unmount.
 	d.stopForkfile(false)
 
-	revert.Success()
 	return op, err
 }
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3641,6 +3641,9 @@ func (d *lxc) cleanup() {
 
 // Delete deletes the instance.
 func (d *lxc) Delete(force bool) error {
+	unlock := d.updateBackupFileLock(context.Background())
+	defer unlock()
+
 	// Setup a new operation.
 	op, err := operationlock.CreateWaitGet(d.Project().Name, d.Name(), operationlock.ActionDelete, nil, false, false)
 	if err != nil {

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -3702,9 +3702,11 @@ func (d *lxc) delete(force bool) error {
 			}
 		} else {
 			// Remove all snapshots.
-			err := instance.DeleteSnapshots(d)
+			err := d.deleteSnapshots(func(snapInst instance.Instance) error {
+				return snapInst.(*lxc).delete(true) // Internal delete function that doesn't lock.
+			})
 			if err != nil {
-				return fmt.Errorf("Failed deleting instance snapshots; %w", err)
+				return fmt.Errorf("Failed deleting instance snapshots: %w", err)
 			}
 
 			// Remove the storage volume and database records.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -5462,9 +5462,11 @@ func (d *qemu) delete(force bool) error {
 			}
 		} else {
 			// Remove all snapshots.
-			err := instance.DeleteSnapshots(d)
+			err := d.deleteSnapshots(func(snapInst instance.Instance) error {
+				return snapInst.(*qemu).delete(true) // Internal delete function that doesn't lock.
+			})
 			if err != nil {
-				return fmt.Errorf("Failed deleting instance snapshots; %w", err)
+				return fmt.Errorf("Failed deleting instance snapshots: %w", err)
 			}
 
 			// Remove the storage volume and database records.

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -458,27 +458,6 @@ func LoadFromBackup(s *state.State, projectName string, instancePath string, app
 	return inst, nil
 }
 
-// DeleteSnapshots calls the Delete() function on each of the supplied instance's snapshots.
-func DeleteSnapshots(inst Instance) error {
-	snapInsts, err := inst.Snapshots()
-	if err != nil {
-		return err
-	}
-
-	snapInstsCount := len(snapInsts)
-
-	for k := range snapInsts {
-		// Delete the snapshots in reverse order.
-		k = snapInstsCount - 1 - k
-		err = snapInsts[k].Delete(true)
-		if err != nil {
-			return fmt.Errorf("Failed deleting snapshot %q, %w", snapInsts[k].Name(), err)
-		}
-	}
-
-	return nil
-}
-
 // DeviceNextInterfaceHWAddr generates a random MAC address.
 func DeviceNextInterfaceHWAddr() (string, error) {
 	// Generate a new random MAC address using the usual prefix


### PR DESCRIPTION
Fixes regression introduced by https://github.com/lxc/lxd/pull/11586 that prevented deleting VMs with snapshots.

Also adds missing call to `d.updateBackupFileLock` in `Stop` for `lxc` driver to bring in line with `qemu` driver.
This would have flagged up the issue earlier as the jenkins test suite would have failed on the same problem.

Finally, adds an optimisation to avoid updating the backup file as each snapshot is removed as part of an overall instance delete operation, as it is wasteful to potentially update the file multiple times only to then delete it at the end of the instance delete operation.
