### PR TITLE
Add required=false option for nic devices with an unavailable parent

### DIFF
--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -52,6 +52,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string, instCo
 		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),
 		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
 		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
+		"required":                             validate.Optional(validate.IsBool),
 	}
 
 	validators := map[string]func(value string) error{}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -89,6 +89,7 @@ func (d *nicBridged) validateConfig(instConf instance.ConfigReader) error {
 		"maas.subnet.ipv6",
 		"boot.priority",
 		"vlan",
+		"required",
 	}
 
 	// checkWithManagedNetwork validates the device's settings against the managed network.
@@ -479,8 +480,19 @@ func (d *nicBridged) PreStartCheck() error {
 		return nil
 	}
 
+	required := true
+	var err error
+	val, present := d.config["required"]
+	if present {
+		required, err = strconv.ParseBool(val)
+		if err != nil {
+			required = true
+		}
+
+	}
+
 	// If managed network is not available, don't try and start instance.
-	if d.network.LocalStatus() == api.NetworkStatusUnavailable {
+	if required && d.network.LocalStatus() == api.NetworkStatusUnavailable {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -95,6 +95,7 @@ func (d *nicOVN) validateConfig(instConf instance.ConfigReader) error {
 		"acceleration",
 		"nested",
 		"vlan",
+		"required",
 	}
 
 	// The NIC's network may be a non-default project, so lookup project and get network's project name.
@@ -344,8 +345,19 @@ func (d *nicOVN) PreStartCheck() error {
 		return nil
 	}
 
+	required := true
+	var err error
+	val, present := d.config["required"]
+	if present {
+		required, err = strconv.ParseBool(val)
+		if err != nil {
+			required = true
+		}
+
+	}
+
 	// If managed network is not available, don't try and start instance.
-	if d.network.LocalStatus() == api.NetworkStatusUnavailable {
+	if required && d.network.LocalStatus() == api.NetworkStatusUnavailable {
 		return api.StatusErrorf(http.StatusServiceUnavailable, "Network %q unavailable on this server", d.network.Name())
 	}
 

--- a/lxd/network/driver_bridge.go
+++ b/lxd/network/driver_bridge.go
@@ -275,6 +275,7 @@ func (n *bridge) Validate(config map[string]string) error {
 		"security.acls.default.egress.action":  validate.Optional(validate.IsOneOf(acl.ValidActions...)),
 		"security.acls.default.ingress.logged": validate.Optional(validate.IsBool),
 		"security.acls.default.egress.logged":  validate.Optional(validate.IsBool),
+		"required":                             validate.Optional(validate.IsBool),
 	}
 
 	// Add dynamic validation rules.

--- a/lxd/network/driver_macvlan.go
+++ b/lxd/network/driver_macvlan.go
@@ -30,6 +30,7 @@ func (n *macvlan) Validate(config map[string]string) error {
 		"gvrp":             validate.Optional(validate.IsBool),
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,
+		"required":         validate.Optional(validate.IsBool),
 	}
 
 	err := n.validate(config, rules)

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -335,6 +335,7 @@ func (n *ovn) Validate(config map[string]string) error {
 		// Volatile keys populated automatically as needed.
 		ovnVolatileUplinkIPv4: validate.Optional(validate.IsNetworkAddressV4),
 		ovnVolatileUplinkIPv6: validate.Optional(validate.IsNetworkAddressV6),
+		"required":                             validate.Optional(validate.IsBool),
 	}
 
 	err := n.validate(config, rules)

--- a/lxd/network/driver_sriov.go
+++ b/lxd/network/driver_sriov.go
@@ -29,6 +29,7 @@ func (n *sriov) Validate(config map[string]string) error {
 		"vlan":             validate.Optional(validate.IsNetworkVLAN),
 		"maas.subnet.ipv4": validate.IsAny,
 		"maas.subnet.ipv6": validate.IsAny,
+		"required":         validate.Optional(validate.IsBool),
 	}
 
 	err := n.validate(config, rules)


### PR DESCRIPTION
Add required option to nic device interface that defaults to true. This option can be set using lxc network set <network_name> user.required={true/false}
