### PR TITLE
lxc/storage_volume: Set target before getting storage volume

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -374,6 +374,10 @@ func (c *cmdStorageVolumeCopy) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("No storage pool for source volume specified"))
 	}
 
+	if c.storage.flagTarget != "" {
+		srcServer = srcServer.UseTarget(c.storage.flagTarget)
+	}
+
 	// Check if requested storage volume exists.
 	srcVolParentName, srcVolSnapName, srcIsSnapshot := api.GetParentAndSnapshotName(srcVolName)
 	srcVol, _, err := srcServer.GetStoragePoolVolume(srcVolPool, "custom", srcVolParentName)


### PR DESCRIPTION
This sets the target before attempting to retrieve the storage pool
volume. It fixes an issue where copying/refreshing a local storage
pool volume in a cluster from one member to another would fail.

Fixes #11500

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
