### PR TITLE
Add `--reuse` flag for `publish` command

### DIFF
--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -23,6 +23,7 @@ type cmdPublish struct {
 	flagExpiresAt            string
 	flagMakePublic           bool
 	flagForce                bool
+	flagReuse                bool
 }
 
 func (c *cmdPublish) Command() *cobra.Command {
@@ -38,6 +39,7 @@ func (c *cmdPublish) Command() *cobra.Command {
 	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Stop the instance if currently running"))
 	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Compression algorithm to use (`none` for uncompressed)"))
 	cmd.Flags().StringVar(&c.flagExpiresAt, "expire", "", i18n.G("Image expiration date (format: rfc3339)")+"``")
+	cmd.Flags().BoolVar(&c.flagReuse, "reuse", false, i18n.G("If the image alias already exists, delete and create a new one"))
 
 	return cmd
 }
@@ -225,6 +227,57 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		req.ExpiresAt = expiresAt
+	}
+
+	existingAliases, err := GetCommonAliases(d, aliases...)
+	if err != nil {
+		return fmt.Errorf(i18n.G("Error retrieving aliases: %w"), err)
+	}
+
+	if !c.flagReuse && len(existingAliases) > 0 {
+		names := []string{}
+		for _, alias := range existingAliases {
+			names = append(names, alias.Name)
+		}
+
+		return fmt.Errorf(i18n.G("Aliases already exists: %s"), strings.Join(names, ", "))
+	}
+
+	if c.flagReuse && len(existingAliases) > 0 {
+		visitedImages := make(map[string]interface{})
+		for _, alias := range existingAliases {
+			image, _, _ := d.GetImage(alias.Target)
+
+			// If the image has already been visited then continue
+			if image != nil {
+				_, found := visitedImages[image.Fingerprint]
+				if found {
+					continue
+				}
+
+				visitedImages[image.Fingerprint] = nil
+			}
+
+			// An image can have multiple aliases. If an image being published
+			// reuses all the aliases from an existing image then that existing image is removed.
+			// In other case only specific aliases should be removed. E.g.
+			// 1. If image with 'foo' and 'bar' aliases already exists and new image is published
+			//    with aliases 'foo' and 'bar' (and flag '--reuse'). Old image should be removed.
+			// 2. If image with 'foo' and 'bar' aliases already exists and new image is published
+			//    with alias 'foo' (and flag '--reuse'). Old image should be kept with alias 'bar'
+			//    and new image will have 'foo' alias.
+			if image != nil && IsAliasesSubset(image.Aliases, aliases) {
+				op, err := d.DeleteImage(alias.Target)
+				if err != nil {
+					return err
+				}
+
+				err = op.Wait()
+				if err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	op, err := s.CreateImage(req, nil)

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -40,6 +40,34 @@ func (s *utilsTestSuite) Test_stringList_empty_strings() {
 	s.Equal([][]string{{"foo", "baz"}, {"", "bar"}}, data)
 }
 
+func (s *utilsTestSuite) TestIsAliasesSubsetTrue() {
+	a1 := []api.ImageAlias{
+		{Name: "foo"},
+	}
+
+	a2 := []api.ImageAlias{
+		{Name: "foo"},
+		{Name: "bar"},
+		{Name: "baz"},
+	}
+
+	s.Exactly(IsAliasesSubset(a1, a2), true)
+}
+
+func (s *utilsTestSuite) TestIsAliasesSubsetFalse() {
+	a1 := []api.ImageAlias{
+		{Name: "foo"},
+		{Name: "bar"},
+	}
+
+	a2 := []api.ImageAlias{
+		{Name: "foo"},
+		{Name: "baz"},
+	}
+
+	s.Exactly(IsAliasesSubset(a1, a2), false)
+}
+
 func (s *utilsTestSuite) TestGetExistingAliases() {
 	images := []api.ImageAliasesEntry{
 		{Name: "foo"},

--- a/po/ber.po
+++ b/po/ber.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Berber <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Bulgarian <https://hosted.weblate.org/projects/linux-"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/ca.po
+++ b/po/ca.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Catalan <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/cs.po
+++ b/po/cs.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Czech <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Krombel <krombel@krombel.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -871,6 +871,11 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "Alias name missing"
 msgstr "Aliasname fehlt"
 
+#: lxc/publish.go:237
+#, fuzzy, c-format
+msgid "Aliases already exists: %s"
+msgstr "entfernte Instanz %s existiert bereits"
+
 #: lxc/image.go:975
 #, fuzzy
 msgid "Aliases:"
@@ -1018,7 +1023,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1137,7 +1142,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1342,7 +1347,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1874,7 +1879,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2208,6 +2213,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr "Flüchtiger Container"
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
@@ -2336,12 +2346,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2415,7 +2425,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2445,7 +2455,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Akzeptiere Zertifikat"
@@ -2765,6 +2775,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2800,7 +2814,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2892,7 +2906,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2905,7 +2919,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -2959,7 +2973,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid instance path: %q"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Alternatives config Verzeichnis."
@@ -3504,7 +3518,7 @@ msgstr ""
 msgid "Make image public"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 #, fuzzy
 msgid "Make the image public"
 msgstr "Veröffentliche Abbild"
@@ -3684,8 +3698,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -4205,7 +4219,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network zone record %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4561,12 +4575,12 @@ msgstr ""
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -5493,11 +5507,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -5679,7 +5693,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5728,7 +5742,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -6651,7 +6665,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -7690,8 +7704,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -607,6 +607,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -743,7 +748,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -852,7 +857,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1052,7 +1057,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1554,7 +1559,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1868,6 +1873,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1983,12 +1993,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "  Χρήση δικτύου:"
@@ -2062,7 +2072,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2091,7 +2101,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2399,6 +2409,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2433,7 +2447,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2521,7 +2535,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2534,7 +2548,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2587,7 +2601,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3092,7 +3106,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3253,8 +3267,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3756,7 +3770,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "Network zone record %s deleted"
 msgstr "  Χρήση δικτύου:"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4100,11 +4114,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4986,11 +5000,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5161,7 +5175,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5207,7 +5221,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5873,7 +5887,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6558,8 +6572,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/eo.po
+++ b/po/eo.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Esperanto <https://hosted.weblate.org/projects/linux-"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -851,6 +851,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, fuzzy, c-format
+msgid "Aliases already exists: %s"
+msgstr "El dispostivo ya existe: %s"
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Aliases:"
@@ -989,7 +994,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1099,7 +1104,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "No se peude leer desde stdin: %s"
@@ -1301,7 +1306,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1812,7 +1817,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2128,6 +2133,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2247,12 +2257,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nombre del Miembro del Cluster"
@@ -2326,7 +2336,7 @@ msgstr "Nombre del Miembro del Cluster"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Acepta certificado"
@@ -2356,7 +2366,7 @@ msgstr "Acepta certificado"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Acepta certificado"
@@ -2668,6 +2678,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2702,7 +2716,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2792,7 +2806,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
@@ -2806,7 +2820,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Contenedor publicado con huella digital: %s"
@@ -2859,7 +2873,7 @@ msgstr "Nombre del contenedor es: %s"
 msgid "Invalid instance path: %q"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -3375,7 +3389,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3536,8 +3550,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -4047,7 +4061,7 @@ msgstr "Perfil %s creado"
 msgid "Network zone record %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4395,11 +4409,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr "Público: %s"
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -5288,11 +5302,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5465,7 +5479,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5511,7 +5525,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -6233,7 +6247,7 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -7001,8 +7015,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Persian <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Finnish <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Wivik <seb+weblate@zedas.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -877,6 +877,11 @@ msgstr "le serveur distant %s n'existe pas"
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, fuzzy, c-format
+msgid "Aliases already exists: %s"
+msgstr "le serveur distant %s existe déjà"
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Alias :"
@@ -1022,7 +1027,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1133,7 +1138,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible de lire depuis stdin : %s"
@@ -1343,7 +1348,7 @@ msgstr ""
 "commandes ci-dessous.\n"
 "Pour de l'aide avec l'une des commandes, simplement les utiliser avec --help."
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 #, fuzzy
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1899,7 +1904,7 @@ msgstr "Récupération de l'image : %s"
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2229,6 +2234,11 @@ msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 msgid "Ephemeral instance"
 msgstr "Conteneur éphémère"
 
+#: lxc/publish.go:234
+#, fuzzy, c-format
+msgid "Error retrieving aliases: %w"
+msgstr "Récupération de l'image : %s"
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2368,12 +2378,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2448,7 +2458,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to create %q: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2478,7 +2488,7 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
@@ -2801,6 +2811,10 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2839,7 +2853,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2935,7 +2949,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
@@ -2949,7 +2963,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
@@ -3002,7 +3016,7 @@ msgstr "Le nom du conteneur est : %s"
 msgid "Invalid instance path: %q"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Clé de configuration invalide"
@@ -3585,7 +3599,7 @@ msgstr ""
 msgid "Make image public"
 msgstr "Rendre l'image publique"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr "Rendre l'image publique"
 
@@ -3763,8 +3777,8 @@ msgstr "Copie de l'image : %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -4291,7 +4305,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Network zone record %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
@@ -4659,12 +4673,12 @@ msgstr "Serveur d'images public"
 msgid "Public: %s"
 msgstr "Public : %s"
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 #, fuzzy
 msgid "Publish instances as images"
 msgstr "Création du conteneur"
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -5623,12 +5637,12 @@ msgstr "État : %s"
 msgid "Stop instances"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 #, fuzzy
 msgid "Stop the instance if currently running"
 msgstr "Arrêter le conteneur s'il est en cours d'exécution"
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -5809,7 +5823,7 @@ msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 "Le conteneur est en cours d'exécution, l'arrêter d'abord ou ajouter --force."
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 #, fuzzy
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
@@ -5861,7 +5875,7 @@ msgstr "Le périphérique indiqué n'existe pas"
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr "Il n'existe pas d'\"image\".  Vouliez-vous un alias ?"
 
@@ -6845,7 +6859,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -7954,8 +7968,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/he.po
+++ b/po/he.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hebrew <https://hosted.weblate.org/projects/linux-containers/"
@@ -606,6 +606,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -742,7 +747,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -850,7 +855,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1050,7 +1055,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1545,7 +1550,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1850,6 +1855,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1965,12 +1975,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2044,7 +2054,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2073,7 +2083,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2374,6 +2384,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2408,7 +2422,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2496,7 +2510,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2509,7 +2523,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2562,7 +2576,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3065,7 +3079,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3216,8 +3230,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3710,7 +3724,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4053,11 +4067,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4916,11 +4930,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5091,7 +5105,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5137,7 +5151,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5793,7 +5807,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6478,8 +6492,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Hindi <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Indonesian <https://hosted.weblate.org/projects/linux-"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -845,6 +845,11 @@ msgstr "il remote %s non esiste"
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
+#: lxc/publish.go:237
+#, fuzzy, c-format
+msgid "Aliases already exists: %s"
+msgstr "il remote %s esiste già"
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Alias:"
@@ -983,7 +988,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1092,7 +1097,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Impossible leggere da stdin: %s"
@@ -1293,7 +1298,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1803,7 +1808,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2119,6 +2124,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2237,12 +2247,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Il nome del container è: %s"
@@ -2316,7 +2326,7 @@ msgstr "Il nome del container è: %s"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Accetta certificato"
@@ -2345,7 +2355,7 @@ msgstr "Accetta certificato"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Accetta certificato"
@@ -2655,6 +2665,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2690,7 +2704,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2780,7 +2794,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2793,7 +2807,7 @@ msgstr "Il nome del container è: %s"
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2846,7 +2860,7 @@ msgstr "Il nome del container è: %s"
 msgid "Invalid instance path: %q"
 msgstr "Il nome del container è: %s"
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Proprietà errata: %s"
@@ -3365,7 +3379,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3530,8 +3544,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -4039,7 +4053,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4387,11 +4401,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Creazione del container in corso"
@@ -5281,11 +5295,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5458,7 +5472,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5505,7 +5519,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -6228,7 +6242,7 @@ msgstr "Creazione del container in corso"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "Creazione del container in corso"
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "Creazione del container in corso"
@@ -6996,8 +7010,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2023-03-10 15:14+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -851,6 +851,11 @@ msgstr "エイリアス %s は存在しません"
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
+#: lxc/publish.go:237
+#, fuzzy, c-format
+msgid "Aliases already exists: %s"
+msgstr "エイリアス %s は既に存在します"
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "エイリアス:"
@@ -994,7 +999,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1103,7 +1108,7 @@ msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr "標準入力から読み込めません: %w"
@@ -1313,7 +1318,7 @@ msgstr ""
 "LXD の機能のすべてが、以下の色々なコマンドから操作できます。\n"
 "コマンドのヘルプは、--help をコマンドに付けて実行するだけです。"
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "圧縮アルゴリズムを指定します: (圧縮しない場合は `none`)"
 
@@ -1827,7 +1832,7 @@ msgstr "警告を削除します"
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2151,6 +2156,11 @@ msgstr "環境変数を設定します (例: HOME=/home/foo)"
 msgid "Ephemeral instance"
 msgstr "Ephemeral インスタンス"
 
+#: lxc/publish.go:234
+#, fuzzy, c-format
+msgid "Error retrieving aliases: %w"
+msgstr "イメージの取得中: %s"
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2281,12 +2291,12 @@ msgstr "クライアント %q との SSH ハンドシェイクに失敗しまし
 msgid "Failed accepting channel client %q: %v"
 msgstr "クライアント %q のチャンネルの受け入れに失敗しました: %v"
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "インスタンスの存在確認に失敗しました \"%s:%s\": %w"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "インスタンスのスナップショットの存在確認に失敗しました \"%s:%s\": %w"
@@ -2360,7 +2370,7 @@ msgstr "クラスタメンバへの接続に失敗しました: %w"
 msgid "Failed to create %q: %w"
 msgstr "%q の作成に失敗しました: %w"
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "エイリアス %s の作成に失敗しました: %w"
@@ -2389,7 +2399,7 @@ msgstr "コネクションのリッスンに失敗しました: %w"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr "コピー先のインスタンス '%s' のリフレッシュに失敗しました: %v"
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "エイリアス %s の削除に失敗しました: %w"
@@ -2705,6 +2715,13 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr "ISSUE DATE"
 
+#: lxc/publish.go:42
+#, fuzzy
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+"存在するスナップショット名の場合は既存のスナップショットを削除したあとに新し"
+"いスナップショットを作成します"
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2741,7 +2758,7 @@ msgstr "イメージは更新済みです。"
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr "イメージの失効日（フォーマット: rfc3339）"
 
@@ -2836,7 +2853,7 @@ msgstr "インスタンスが切断されました"
 msgid "Instance disconnected for client %q"
 msgstr "クライアント %q に対するインスタンスが切断されました"
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr "インスタンス名を指定する必要があります"
 
@@ -2849,7 +2866,7 @@ msgstr "インスタンス名: %s"
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr "SSH SFTP リスナーモードではインスタンスのパスを使用できません"
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "インスタンスは以下のフィンガープリントで publish されます: %s"
@@ -2903,7 +2920,7 @@ msgstr "不正なインスタンス名: %s"
 msgid "Invalid instance path: %q"
 msgstr "不正なインスタンスのパス: %q"
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "不適切な キー=値 の設定: %s"
@@ -3552,7 +3569,7 @@ msgstr "MTU: %d"
 msgid "Make image public"
 msgstr "イメージを public にする"
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr "イメージを public にする"
 
@@ -3716,8 +3733,8 @@ msgstr "ストレージボリュームを管理します"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 "ストレージボリュームを管理します\n"
 "\n"
@@ -4234,7 +4251,7 @@ msgstr "ネットワークゾーンレコード %s を作成しました"
 msgid "Network zone record %s deleted"
 msgstr "ネットワークゾーンレコード %s を削除しました"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
@@ -4580,11 +4597,11 @@ msgstr "Public なイメージサーバとして設定します"
 msgid "Public: %s"
 msgstr "パブリック: %s"
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr "インスタンスをイメージとして出力します"
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr "インスタンスの出力中: %s"
@@ -5508,11 +5525,11 @@ msgstr "状態: %s"
 msgid "Stop instances"
 msgstr "インスタンスを停止します"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr "実行中の場合、インスタンスを停止します"
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr "インスタンスの停止に失敗しました！"
 
@@ -5683,7 +5700,7 @@ msgstr "direction 引数は次のいずれかでなければなりません: ing
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr "インスタンスは実行中です。先に停止させるか、--force を指定してください"
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5734,7 +5751,7 @@ msgstr "指定したデバイスが存在しません"
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 "publish 先にはイメージ名は指定できません。\"--alias\" オプションを使ってくだ"
@@ -6420,7 +6437,7 @@ msgstr "[<remote>:]<instance>[/<path>] [<target path>]"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 
@@ -7260,8 +7277,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 "lxc storage volume show default data\n"
 "    \"default\" プール内のカスタムボリューム \"data\" のプロパティを表示しま"
@@ -8977,8 +8994,8 @@ msgstr "yes"
 #~ "lxc storage volume move [<pool>/]<volume> [<pool>/]<volume>\n"
 #~ "    Move an existing volume to the specified pool.\n"
 #~ "\n"
-#~ "Unless specified through a prefix, all volume operations affect \"custom"
-#~ "\" (user created) volumes.\n"
+#~ "Unless specified through a prefix, all volume operations affect "
+#~ "\"custom\" (user created) volumes.\n"
 #~ "\n"
 #~ "*Examples*\n"
 #~ "cat pool.yaml | lxc storage edit [<remote>:]<pool>\n"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Korean <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2023-04-14 15:06-0400\n"
+        "POT-Creation-Date: 2023-04-25 18:53+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -571,6 +571,11 @@ msgstr  ""
 msgid   "Alias name missing"
 msgstr  ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid   "Aliases already exists: %s"
+msgstr  ""
+
 #: lxc/image.go:975
 msgid   "Aliases:"
 msgstr  ""
@@ -704,7 +709,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178 lxc/storage.go:131 lxc/storage_volume.go:569
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180 lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -811,7 +816,7 @@ msgstr  ""
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid   "Can't read from stdin: %w"
 msgstr  ""
@@ -980,7 +985,7 @@ msgid   "Command line client for LXD\n"
         "For help with any of those, simply call them with --help."
 msgstr  ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid   "Compression algorithm to use (`none` for uncompressed)"
 msgstr  ""
 
@@ -1381,7 +1386,7 @@ msgstr  ""
 msgid   "Delete warning"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207 lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404 lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651 lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023 lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351 lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581 lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504 lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896 lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110 lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665 lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:525 lxc/storage_volume.go:604 lxc/storage_volume.go:679 lxc/storage_volume.go:761 lxc/storage_volume.go:842 lxc/storage_volume.go:1046 lxc/storage_volume.go:1134 lxc/storage_volume.go:1274 lxc/storage_volume.go:1358 lxc/storage_volume.go:1564 lxc/storage_volume.go:1597 lxc/storage_volume.go:1710 lxc/storage_volume.go:1798 lxc/storage_volume.go:1897 lxc/storage_volume.go:1931 lxc/storage_volume.go:2028 lxc/storage_volume.go:2095 lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:57 lxc/alias.go:103 lxc/alias.go:148 lxc/alias.go:199 lxc/cluster.go:30 lxc/cluster.go:123 lxc/cluster.go:207 lxc/cluster.go:256 lxc/cluster.go:305 lxc/cluster.go:352 lxc/cluster.go:404 lxc/cluster.go:433 lxc/cluster.go:483 lxc/cluster.go:566 lxc/cluster.go:651 lxc/cluster.go:766 lxc/cluster.go:842 lxc/cluster.go:944 lxc/cluster.go:1023 lxc/cluster.go:1130 lxc/cluster.go:1151 lxc/cluster_group.go:30 lxc/cluster_group.go:79 lxc/cluster_group.go:150 lxc/cluster_group.go:205 lxc/cluster_group.go:255 lxc/cluster_group.go:368 lxc/cluster_group.go:440 lxc/cluster_group.go:511 lxc/cluster_group.go:557 lxc/cluster_role.go:22 lxc/cluster_role.go:48 lxc/cluster_role.go:102 lxc/config.go:30 lxc/config.go:92 lxc/config.go:372 lxc/config.go:464 lxc/config.go:622 lxc/config.go:742 lxc/config_device.go:24 lxc/config_device.go:78 lxc/config_device.go:204 lxc/config_device.go:281 lxc/config_device.go:352 lxc/config_device.go:446 lxc/config_device.go:544 lxc/config_device.go:551 lxc/config_device.go:664 lxc/config_device.go:737 lxc/config_metadata.go:27 lxc/config_metadata.go:55 lxc/config_metadata.go:180 lxc/config_template.go:28 lxc/config_template.go:68 lxc/config_template.go:111 lxc/config_template.go:153 lxc/config_template.go:241 lxc/config_template.go:301 lxc/config_trust.go:35 lxc/config_trust.go:88 lxc/config_trust.go:237 lxc/config_trust.go:351 lxc/config_trust.go:433 lxc/config_trust.go:535 lxc/config_trust.go:581 lxc/config_trust.go:652 lxc/console.go:36 lxc/copy.go:41 lxc/delete.go:31 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:79 lxc/file.go:119 lxc/file.go:168 lxc/file.go:238 lxc/file.go:460 lxc/file.go:968 lxc/image.go:38 lxc/image.go:146 lxc/image.go:313 lxc/image.go:364 lxc/image.go:491 lxc/image.go:652 lxc/image.go:885 lxc/image.go:1020 lxc/image.go:1339 lxc/image.go:1419 lxc/image.go:1478 lxc/image.go:1530 lxc/image.go:1586 lxc/image_alias.go:25 lxc/image_alias.go:61 lxc/image_alias.go:108 lxc/image_alias.go:153 lxc/image_alias.go:256 lxc/import.go:29 lxc/info.go:34 lxc/init.go:41 lxc/launch.go:25 lxc/list.go:50 lxc/main.go:79 lxc/manpage.go:22 lxc/monitor.go:33 lxc/move.go:37 lxc/network.go:33 lxc/network.go:132 lxc/network.go:217 lxc/network.go:290 lxc/network.go:369 lxc/network.go:419 lxc/network.go:504 lxc/network.go:589 lxc/network.go:715 lxc/network.go:773 lxc/network.go:896 lxc/network.go:989 lxc/network.go:1060 lxc/network.go:1110 lxc/network.go:1180 lxc/network.go:1242 lxc/network_acl.go:30 lxc/network_acl.go:95 lxc/network_acl.go:166 lxc/network_acl.go:219 lxc/network_acl.go:265 lxc/network_acl.go:314 lxc/network_acl.go:397 lxc/network_acl.go:457 lxc/network_acl.go:484 lxc/network_acl.go:615 lxc/network_acl.go:664 lxc/network_acl.go:713 lxc/network_acl.go:728 lxc/network_acl.go:849 lxc/network_forward.go:30 lxc/network_forward.go:87 lxc/network_forward.go:168 lxc/network_forward.go:232 lxc/network_forward.go:328 lxc/network_forward.go:383 lxc/network_forward.go:461 lxc/network_forward.go:488 lxc/network_forward.go:630 lxc/network_forward.go:692 lxc/network_forward.go:707 lxc/network_forward.go:772 lxc/network_load_balancer.go:30 lxc/network_load_balancer.go:91 lxc/network_load_balancer.go:170 lxc/network_load_balancer.go:234 lxc/network_load_balancer.go:330 lxc/network_load_balancer.go:385 lxc/network_load_balancer.go:463 lxc/network_load_balancer.go:490 lxc/network_load_balancer.go:633 lxc/network_load_balancer.go:694 lxc/network_load_balancer.go:709 lxc/network_load_balancer.go:773 lxc/network_load_balancer.go:859 lxc/network_load_balancer.go:874 lxc/network_load_balancer.go:935 lxc/network_peer.go:29 lxc/network_peer.go:82 lxc/network_peer.go:159 lxc/network_peer.go:216 lxc/network_peer.go:330 lxc/network_peer.go:385 lxc/network_peer.go:454 lxc/network_peer.go:481 lxc/network_peer.go:606 lxc/network_zone.go:29 lxc/network_zone.go:86 lxc/network_zone.go:157 lxc/network_zone.go:210 lxc/network_zone.go:259 lxc/network_zone.go:340 lxc/network_zone.go:400 lxc/network_zone.go:427 lxc/network_zone.go:546 lxc/network_zone.go:594 lxc/network_zone.go:651 lxc/network_zone.go:721 lxc/network_zone.go:771 lxc/network_zone.go:819 lxc/network_zone.go:899 lxc/network_zone.go:955 lxc/network_zone.go:982 lxc/network_zone.go:1100 lxc/network_zone.go:1149 lxc/network_zone.go:1164 lxc/network_zone.go:1210 lxc/operation.go:24 lxc/operation.go:56 lxc/operation.go:105 lxc/operation.go:185 lxc/profile.go:29 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:249 lxc/profile.go:310 lxc/profile.go:364 lxc/profile.go:414 lxc/profile.go:540 lxc/profile.go:589 lxc/profile.go:650 lxc/profile.go:726 lxc/profile.go:776 lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94 lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394 lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651 lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34 lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665 lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34 lxc/storage.go:97 lxc/storage.go:171 lxc/storage.go:221 lxc/storage.go:343 lxc/storage.go:403 lxc/storage.go:559 lxc/storage.go:636 lxc/storage.go:710 lxc/storage.go:794 lxc/storage_bucket.go:30 lxc/storage_bucket.go:84 lxc/storage_bucket.go:184 lxc/storage_bucket.go:245 lxc/storage_bucket.go:376 lxc/storage_bucket.go:442 lxc/storage_bucket.go:517 lxc/storage_bucket.go:594 lxc/storage_bucket.go:661 lxc/storage_bucket.go:692 lxc/storage_bucket.go:733 lxc/storage_bucket.go:811 lxc/storage_bucket.go:889 lxc/storage_bucket.go:953 lxc/storage_bucket.go:1088 lxc/storage_volume.go:42 lxc/storage_volume.go:164 lxc/storage_volume.go:239 lxc/storage_volume.go:330 lxc/storage_volume.go:525 lxc/storage_volume.go:604 lxc/storage_volume.go:679 lxc/storage_volume.go:761 lxc/storage_volume.go:842 lxc/storage_volume.go:1046 lxc/storage_volume.go:1134 lxc/storage_volume.go:1274 lxc/storage_volume.go:1358 lxc/storage_volume.go:1564 lxc/storage_volume.go:1597 lxc/storage_volume.go:1710 lxc/storage_volume.go:1798 lxc/storage_volume.go:1897 lxc/storage_volume.go:1931 lxc/storage_volume.go:2028 lxc/storage_volume.go:2095 lxc/storage_volume.go:2239 lxc/version.go:22 lxc/warning.go:30 lxc/warning.go:72 lxc/warning.go:263 lxc/warning.go:304 lxc/warning.go:358
 msgid   "Description"
 msgstr  ""
 
@@ -1649,6 +1654,11 @@ msgstr  ""
 msgid   "Ephemeral instance"
 msgstr  ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid   "Error retrieving aliases: %w"
+msgstr  ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid   "Error updating template file: %s"
@@ -1759,12 +1769,12 @@ msgstr  ""
 msgid   "Failed accepting channel client %q: %v"
 msgstr  ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid   "Failed checking instance exists \"%s:%s\": %w"
 msgstr  ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid   "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr  ""
@@ -1838,7 +1848,7 @@ msgstr  ""
 msgid   "Failed to create %q: %w"
 msgstr  ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid   "Failed to create alias %s: %w"
 msgstr  ""
@@ -1867,7 +1877,7 @@ msgstr  ""
 msgid   "Failed to refresh target instance '%s': %v"
 msgstr  ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid   "Failed to remove alias %s: %w"
 msgstr  ""
@@ -2153,6 +2163,10 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
+#: lxc/publish.go:42
+msgid   "If the image alias already exists, delete and create a new one"
+msgstr  ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid   "If the snapshot name already exists, delete and create a new one"
 msgstr  ""
@@ -2185,7 +2199,7 @@ msgstr  ""
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid   "Image expiration date (format: rfc3339)"
 msgstr  ""
 
@@ -2272,7 +2286,7 @@ msgstr  ""
 msgid   "Instance disconnected for client %q"
 msgstr  ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid   "Instance name is mandatory"
 msgstr  ""
 
@@ -2285,7 +2299,7 @@ msgstr  ""
 msgid   "Instance path cannot be used in SSH SFTP listener mode"
 msgstr  ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid   "Instance published with fingerprint: %s"
 msgstr  ""
@@ -2338,7 +2352,7 @@ msgstr  ""
 msgid   "Invalid instance path: %q"
 msgstr  ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid   "Invalid key=value configuration: %s"
 msgstr  ""
@@ -2823,7 +2837,7 @@ msgstr  ""
 msgid   "Make image public"
 msgstr  ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid   "Make the image public"
 msgstr  ""
 
@@ -3386,7 +3400,7 @@ msgstr  ""
 msgid   "Network zone record %s deleted"
 msgstr  ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid   "New alias to define at target"
 msgstr  ""
 
@@ -3721,11 +3735,11 @@ msgstr  ""
 msgid   "Public: %s"
 msgstr  ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid   "Publish instances as images"
 msgstr  ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid   "Publishing instance: %s"
 msgstr  ""
@@ -4551,11 +4565,11 @@ msgstr  ""
 msgid   "Stop instances"
 msgstr  ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid   "Stop the instance if currently running"
 msgstr  ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid   "Stopping instance failed!"
 msgstr  ""
 
@@ -4724,7 +4738,7 @@ msgstr  ""
 msgid   "The instance is currently running, stop it first or pass --force"
 msgstr  ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid   "The instance is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
@@ -4767,7 +4781,7 @@ msgstr  ""
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
@@ -5394,7 +5408,7 @@ msgstr  ""
 msgid   "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid   "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 

--- a/po/mr.po
+++ b/po/mr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Marathi <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Norwegian Bokmål <https://hosted.weblate.org/projects/linux-"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@fastmail.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -822,6 +822,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -958,7 +963,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1066,7 +1071,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1266,7 +1271,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1761,7 +1766,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2066,6 +2071,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2181,12 +2191,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2260,7 +2270,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2289,7 +2299,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2590,6 +2600,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2624,7 +2638,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2712,7 +2726,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2725,7 +2739,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2778,7 +2792,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3281,7 +3295,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3432,8 +3446,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3926,7 +3940,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4269,11 +4283,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -5132,11 +5146,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5307,7 +5321,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5353,7 +5367,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -6009,7 +6023,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6694,8 +6708,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Punjabi <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -856,6 +856,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -992,7 +997,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1100,7 +1105,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1300,7 +1305,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1795,7 +1800,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2100,6 +2105,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2215,12 +2225,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2294,7 +2304,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2323,7 +2333,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2624,6 +2634,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2658,7 +2672,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2746,7 +2760,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2759,7 +2773,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2812,7 +2826,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3315,7 +3329,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3466,8 +3480,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3960,7 +3974,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4303,11 +4317,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -5166,11 +5180,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5341,7 +5355,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5387,7 +5401,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -6043,7 +6057,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6728,8 +6742,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:08+0000\n"
 "Last-Translator: Renato dos Santos <renato.santos@wplex.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -864,6 +864,11 @@ msgstr "Alias %s não existe"
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
+#: lxc/publish.go:237
+#, fuzzy, c-format
+msgid "Aliases already exists: %s"
+msgstr "Alias %s já existe"
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Aliases:"
@@ -1009,7 +1014,7 @@ msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1118,7 +1123,7 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Não é possível ler stdin: %s"
@@ -1325,7 +1330,7 @@ msgstr ""
 "abaixo.\n"
 "Para obter ajuda com qualquer um desses, simplesmente use-os com --help."
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 #, fuzzy
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -1853,7 +1858,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2179,6 +2184,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2295,12 +2305,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Nome de membro do cluster"
@@ -2374,7 +2384,7 @@ msgstr "Nome de membro do cluster"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Aceitar certificado"
@@ -2403,7 +2413,7 @@ msgstr "Aceitar certificado"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Aceitar certificado"
@@ -2717,6 +2727,10 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2752,7 +2766,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2841,7 +2855,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2854,7 +2868,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, fuzzy, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
@@ -2907,7 +2921,7 @@ msgstr "Editar arquivos no container"
 msgid "Invalid instance path: %q"
 msgstr "Editar arquivos no container"
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "par de chave=valor inválido %s"
@@ -3420,7 +3434,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3590,8 +3604,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -4099,7 +4113,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4448,11 +4462,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Editar arquivos no container"
@@ -5364,11 +5378,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5545,7 +5559,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5591,7 +5605,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -6290,7 +6304,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -7013,8 +7027,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:06+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -865,6 +865,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr "Псевдонимы:"
@@ -1006,7 +1011,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -1116,7 +1121,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, fuzzy, c-format
 msgid "Can't read from stdin: %w"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
@@ -1317,7 +1322,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1839,7 +1844,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -2157,6 +2162,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
@@ -2281,12 +2291,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, fuzzy, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, fuzzy, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr "Копирование образа: %s"
@@ -2360,7 +2370,7 @@ msgstr "Копирование образа: %s"
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, fuzzy, c-format
 msgid "Failed to create alias %s: %w"
 msgstr "Принять сертификат"
@@ -2389,7 +2399,7 @@ msgstr "Принять сертификат"
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, fuzzy, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr "Принять сертификат"
@@ -2699,6 +2709,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2734,7 +2748,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2826,7 +2840,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 #, fuzzy
 msgid "Instance name is mandatory"
 msgstr "Имя контейнера является обязательным"
@@ -2840,7 +2854,7 @@ msgstr "Имя контейнера: %s"
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2893,7 +2907,7 @@ msgstr "Имя контейнера: %s"
 msgid "Invalid instance path: %q"
 msgstr "Имя контейнера: %s"
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, fuzzy, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr "Имя контейнера: %s"
@@ -3414,7 +3428,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3586,8 +3600,8 @@ msgstr "Копирование образа: %s"
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -4101,7 +4115,7 @@ msgstr " Использование сети:"
 msgid "Network zone record %s deleted"
 msgstr " Использование сети:"
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4447,11 +4461,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, fuzzy, c-format
 msgid "Publishing instance: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5353,11 +5367,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 #, fuzzy
 msgid "Stopping instance failed!"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -5530,7 +5544,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5576,7 +5590,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -6457,7 +6471,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 #, fuzzy
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
@@ -7474,8 +7488,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/si.po
+++ b/po/si.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Sinhala <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Slovenian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n"
-"%100==4 ? 2 : 3;\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || "
+"n%100==4 ? 2 : 3;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -606,6 +606,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -742,7 +747,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -850,7 +855,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1050,7 +1055,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1545,7 +1550,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1850,6 +1855,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1965,12 +1975,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2044,7 +2054,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2073,7 +2083,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2374,6 +2384,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2408,7 +2422,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2496,7 +2510,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2509,7 +2523,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2562,7 +2576,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3065,7 +3079,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3216,8 +3230,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3710,7 +3724,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4053,11 +4067,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4916,11 +4930,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5091,7 +5105,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5137,7 +5151,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5793,7 +5807,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6478,8 +6492,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Serbian <https://hosted.weblate.org/projects/linux-containers/"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -606,6 +606,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -742,7 +747,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -850,7 +855,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1050,7 +1055,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1545,7 +1550,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1850,6 +1855,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1965,12 +1975,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2044,7 +2054,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2073,7 +2083,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2374,6 +2384,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2408,7 +2422,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2496,7 +2510,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2509,7 +2523,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2562,7 +2576,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3065,7 +3079,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3216,8 +3230,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3710,7 +3724,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4053,11 +4067,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4916,11 +4930,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5091,7 +5105,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5137,7 +5151,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5793,7 +5807,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6478,8 +6492,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Swedish <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Telugu <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/th.po
+++ b/po/th.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -602,6 +602,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -738,7 +743,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -846,7 +851,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1046,7 +1051,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1541,7 +1546,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1846,6 +1851,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1961,12 +1971,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2040,7 +2050,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2069,7 +2079,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2370,6 +2380,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2404,7 +2418,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2492,7 +2506,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2505,7 +2519,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2558,7 +2572,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3061,7 +3075,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3212,8 +3226,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3706,7 +3720,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4049,11 +4063,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4912,11 +4926,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5087,7 +5101,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5133,7 +5147,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5789,7 +5803,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6474,8 +6488,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Turkish <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/tzm.po
+++ b/po/tzm.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Tamazight (Central Atlas) <https://hosted.weblate.org/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/ug.po
+++ b/po/ug.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:10+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Uyghur <https://hosted.weblate.org/projects/linux-containers/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:09+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Ukrainian <https://hosted.weblate.org/projects/linux-"
@@ -16,8 +16,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
-"%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 4.12-dev\n"
 
 #: lxc/storage_bucket.go:256 lxc/storage_bucket.go:964
@@ -606,6 +606,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -742,7 +747,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -850,7 +855,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1050,7 +1055,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1545,7 +1550,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1850,6 +1855,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1965,12 +1975,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2044,7 +2054,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2073,7 +2083,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2374,6 +2384,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2408,7 +2422,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2496,7 +2510,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2509,7 +2523,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2562,7 +2576,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3065,7 +3079,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3216,8 +3230,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3710,7 +3724,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4053,11 +4067,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4916,11 +4930,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5091,7 +5105,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5137,7 +5151,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5793,7 +5807,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6478,8 +6492,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:07+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -719,6 +719,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -855,7 +860,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -963,7 +968,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1163,7 +1168,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1658,7 +1663,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1963,6 +1968,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -2078,12 +2088,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2157,7 +2167,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2186,7 +2196,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2487,6 +2497,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2521,7 +2535,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2609,7 +2623,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2622,7 +2636,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2675,7 +2689,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3178,7 +3192,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3329,8 +3343,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3823,7 +3837,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4166,11 +4180,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -5029,11 +5043,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5204,7 +5218,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5250,7 +5264,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5906,7 +5920,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6591,8 +6605,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/po/zh_Hant.po
+++ b/po/zh_Hant.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2023-04-13 23:31-0400\n"
+"POT-Creation-Date: 2023-04-25 18:53+0200\n"
 "PO-Revision-Date: 2022-03-10 15:11+0000\n"
 "Last-Translator: Anonymous <noreply@weblate.org>\n"
 "Language-Team: Chinese (Traditional) <https://hosted.weblate.org/projects/"
@@ -605,6 +605,11 @@ msgstr ""
 msgid "Alias name missing"
 msgstr ""
 
+#: lxc/publish.go:237
+#, c-format
+msgid "Aliases already exists: %s"
+msgstr ""
+
 #: lxc/image.go:975
 msgid "Aliases:"
 msgstr ""
@@ -741,7 +746,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:178
+#: lxc/copy.go:136 lxc/init.go:215 lxc/project.go:129 lxc/publish.go:180
 #: lxc/storage.go:131 lxc/storage_volume.go:569
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -849,7 +854,7 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:170 lxc/utils.go:190
+#: lxc/utils.go:213 lxc/utils.go:233
 #, c-format
 msgid "Can't read from stdin: %w"
 msgstr ""
@@ -1049,7 +1054,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/publish.go:39
+#: lxc/publish.go:40
 msgid "Compression algorithm to use (`none` for uncompressed)"
 msgstr ""
 
@@ -1544,7 +1549,7 @@ msgstr ""
 #: lxc/profile.go:835 lxc/profile.go:889 lxc/project.go:30 lxc/project.go:94
 #: lxc/project.go:159 lxc/project.go:222 lxc/project.go:344 lxc/project.go:394
 #: lxc/project.go:507 lxc/project.go:562 lxc/project.go:622 lxc/project.go:651
-#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:32 lxc/query.go:34
+#: lxc/project.go:704 lxc/project.go:763 lxc/publish.go:33 lxc/query.go:34
 #: lxc/remote.go:34 lxc/remote.go:89 lxc/remote.go:629 lxc/remote.go:665
 #: lxc/remote.go:753 lxc/remote.go:825 lxc/remote.go:880 lxc/remote.go:918
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:28 lxc/storage.go:34
@@ -1849,6 +1854,11 @@ msgstr ""
 msgid "Ephemeral instance"
 msgstr ""
 
+#: lxc/publish.go:234
+#, c-format
+msgid "Error retrieving aliases: %w"
+msgstr ""
+
 #: lxc/config_template.go:206
 #, c-format
 msgid "Error updating template file: %s"
@@ -1964,12 +1974,12 @@ msgstr ""
 msgid "Failed accepting channel client %q: %v"
 msgstr ""
 
-#: lxc/utils.go:227
+#: lxc/utils.go:270
 #, c-format
 msgid "Failed checking instance exists \"%s:%s\": %w"
 msgstr ""
 
-#: lxc/utils.go:219
+#: lxc/utils.go:262
 #, c-format
 msgid "Failed checking instance snapshot exists \"%s:%s\": %w"
 msgstr ""
@@ -2043,7 +2053,7 @@ msgstr ""
 msgid "Failed to create %q: %w"
 msgstr ""
 
-#: lxc/utils.go:145
+#: lxc/utils.go:188
 #, c-format
 msgid "Failed to create alias %s: %w"
 msgstr ""
@@ -2072,7 +2082,7 @@ msgstr ""
 msgid "Failed to refresh target instance '%s': %v"
 msgstr ""
 
-#: lxc/utils.go:134
+#: lxc/utils.go:177
 #, c-format
 msgid "Failed to remove alias %s: %w"
 msgstr ""
@@ -2373,6 +2383,10 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
+#: lxc/publish.go:42
+msgid "If the image alias already exists, delete and create a new one"
+msgstr ""
+
 #: lxc/snapshot.go:40 lxc/storage_volume.go:1936
 msgid "If the snapshot name already exists, delete and create a new one"
 msgstr ""
@@ -2407,7 +2421,7 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/publish.go:40
+#: lxc/publish.go:41
 msgid "Image expiration date (format: rfc3339)"
 msgstr ""
 
@@ -2495,7 +2509,7 @@ msgstr ""
 msgid "Instance disconnected for client %q"
 msgstr ""
 
-#: lxc/publish.go:78
+#: lxc/publish.go:80
 msgid "Instance name is mandatory"
 msgstr ""
 
@@ -2508,7 +2522,7 @@ msgstr ""
 msgid "Instance path cannot be used in SSH SFTP listener mode"
 msgstr ""
 
-#: lxc/publish.go:293
+#: lxc/publish.go:324
 #, c-format
 msgid "Instance published with fingerprint: %s"
 msgstr ""
@@ -2561,7 +2575,7 @@ msgstr ""
 msgid "Invalid instance path: %q"
 msgstr ""
 
-#: lxc/utils.go:184
+#: lxc/utils.go:227
 #, c-format
 msgid "Invalid key=value configuration: %s"
 msgstr ""
@@ -3064,7 +3078,7 @@ msgstr ""
 msgid "Make image public"
 msgstr ""
 
-#: lxc/publish.go:36
+#: lxc/publish.go:37
 msgid "Make the image public"
 msgstr ""
 
@@ -3215,8 +3229,8 @@ msgstr ""
 msgid ""
 "Manage storage volumes\n"
 "\n"
-"Unless specified through a prefix, all volume operations affect \"custom"
-"\" (user created) volumes."
+"Unless specified through a prefix, all volume operations affect "
+"\"custom\" (user created) volumes."
 msgstr ""
 
 #: lxc/remote.go:33 lxc/remote.go:34
@@ -3709,7 +3723,7 @@ msgstr ""
 msgid "Network zone record %s deleted"
 msgstr ""
 
-#: lxc/publish.go:37
+#: lxc/publish.go:38
 msgid "New alias to define at target"
 msgstr ""
 
@@ -4052,11 +4066,11 @@ msgstr ""
 msgid "Public: %s"
 msgstr ""
 
-#: lxc/publish.go:31 lxc/publish.go:32
+#: lxc/publish.go:32 lxc/publish.go:33
 msgid "Publish instances as images"
 msgstr ""
 
-#: lxc/publish.go:237
+#: lxc/publish.go:268
 #, c-format
 msgid "Publishing instance: %s"
 msgstr ""
@@ -4915,11 +4929,11 @@ msgstr ""
 msgid "Stop instances"
 msgstr ""
 
-#: lxc/publish.go:38
+#: lxc/publish.go:39
 msgid "Stop the instance if currently running"
 msgstr ""
 
-#: lxc/publish.go:140
+#: lxc/publish.go:142
 msgid "Stopping instance failed!"
 msgstr ""
 
@@ -5090,7 +5104,7 @@ msgstr ""
 msgid "The instance is currently running, stop it first or pass --force"
 msgstr ""
 
-#: lxc/publish.go:109
+#: lxc/publish.go:111
 msgid ""
 "The instance is currently running. Use --force to have it stopped and "
 "restarted"
@@ -5136,7 +5150,7 @@ msgstr ""
 msgid "The specified device doesn't match the network"
 msgstr ""
 
-#: lxc/publish.go:82
+#: lxc/publish.go:84
 msgid "There is no \"image name\".  Did you want an alias?"
 msgstr ""
 
@@ -5792,7 +5806,7 @@ msgstr ""
 msgid "[<remote>:]<instance>[/<snapshot>] <instance>[/<snapshot>]"
 msgstr ""
 
-#: lxc/publish.go:30
+#: lxc/publish.go:31
 msgid "[<remote>:]<instance>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr ""
 
@@ -6477,8 +6491,8 @@ msgid ""
 "\"default\" pool.\n"
 "\n"
 "lxc storage volume show default container/data\n"
-"    Will show the properties of the filesystem for a container called \"data"
-"\" in the \"default\" pool."
+"    Will show the properties of the filesystem for a container called "
+"\"data\" in the \"default\" pool."
 msgstr ""
 
 #: lxc/remote.go:453

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -2756,7 +2756,7 @@ test_clustering_image_refresh() {
   # Modify public testimage
   old_fingerprint="$(LXD_DIR="${LXD_REMOTE_DIR}" lxc image ls testimage -c f --format csv)"
   dd if=/dev/urandom count=32 | LXD_DIR="${LXD_REMOTE_DIR}" lxc file push - c1/foo
-  LXD_DIR="${LXD_REMOTE_DIR}" lxc publish c1 --alias testimage --public
+  LXD_DIR="${LXD_REMOTE_DIR}" lxc publish c1 --alias testimage --reuse --public
   new_fingerprint="$(LXD_DIR="${LXD_REMOTE_DIR}" lxc image ls testimage -c f --format csv)"
 
   pids=""
@@ -2828,7 +2828,7 @@ test_clustering_image_refresh() {
 
   # Modify public testimage
   dd if=/dev/urandom count=32 | LXD_DIR="${LXD_REMOTE_DIR}" lxc file push - c1/foo
-  LXD_DIR="${LXD_REMOTE_DIR}" lxc publish c1 --alias testimage --public
+  LXD_DIR="${LXD_REMOTE_DIR}" lxc publish c1 --alias testimage --reuse --public
   new_fingerprint="$(LXD_DIR="${LXD_REMOTE_DIR}" lxc image ls testimage -c f --format csv)"
 
   pids=""

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -147,7 +147,7 @@ test_image_refresh() {
   # Change image and publish it
   lxc init l2:testimage l2:c1
   echo test | lxc file push - l2:c1/tmp/testfile
-  lxc publish l2:c1 l2: --alias testimage --public
+  lxc publish l2:c1 l2: --alias testimage --reuse --public
   new_fp="$(lxc image info l2:testimage | awk '/Fingerprint: / {print $2}')"
 
   # Ensure the images differ


### PR DESCRIPTION
- Fail the publish by default if the alias already exists
- Add `--reuse` flag as a way to override that which will lead to the current image being deleted and replaced

Fixes: #11489