### PR TITLE
Update return type of GetStoragePoolVolumeNamesAllProjects.

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -352,7 +352,7 @@ type InstanceServer interface {
 
 	// Storage volume functions ("storage" API extension)
 	GetStoragePoolVolumeNames(pool string) (names []string, err error)
-	GetStoragePoolVolumeNamesAllProjects(pool string) (names []string, err error)
+	GetStoragePoolVolumeNamesAllProjects(pool string) (names map[string][]string, err error)
 	GetStoragePoolVolumes(pool string) (volumes []api.StorageVolume, err error)
 	GetStoragePoolVolumesAllProjects(pool string) (volumes []api.StorageVolume, err error)
 	GetStoragePoolVolumesWithFilter(pool string, filters []string) (volumes []api.StorageVolume, err error)

--- a/client/util.go
+++ b/client/util.go
@@ -210,12 +210,12 @@ func urlsToResourceNames(matchPathPrefix string, urls ...string) ([]string, erro
 			return nil, fmt.Errorf("Failed parsing URL %q: %w", urlRaw, err)
 		}
 
-		fields := strings.Split(u.Path, fmt.Sprintf("%s/", matchPathPrefix))
-		if len(fields) != 2 {
+		_, after, found := strings.Cut(u.Path, fmt.Sprintf("%s/", matchPathPrefix))
+		if !found {
 			return nil, fmt.Errorf("Unexpected URL path %q", u)
 		}
 
-		resourceNames = append(resourceNames, fields[len(fields)-1])
+		resourceNames = append(resourceNames, after)
 	}
 
 	return resourceNames, nil


### PR DESCRIPTION
Fixes the method (previously failed with "Unexpected URL Path ...") and changes the return type to easily differentiate between resources in different projects.

Closes #11607 