### PR TITLE
lxc/export: Rename backup file based on compression type

### DIFF
--- a/doc/howto/storage_backup_volume.md
+++ b/doc/howto/storage_backup_volume.md
@@ -107,10 +107,10 @@ Use the following command to export a custom storage volume to a compressed file
 
     lxc storage volume export <pool_name> <volume_name> [<file_path>]
 
-If you do not specify a file path, the export file is saved as `backup.tar.gz` in the working directory.
+If you do not specify a file path, the export file is saved as `<instance name>.<extension>` in the working directory (for example, `my-container.tar.gz`).
 
 ```{warning}
-If the output file (`backup.tar.gz` or the specified file path) already exists, the command overwrites the existing file without warning.
+If the output file (`<instance name>.<extension>`, `<instance name>.backup`, or the specified file path) already exists, the command overwrites the existing file without warning.
 ```
 
 You can add any of the following flags to the command:

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
-	lxd "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/utils"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"


### PR DESCRIPTION
Fixes #11543

With this patch, running `lxc export` without an explicit file name will no longer fallback to the hardcoded file name `backup.tar.gz`. Instead, the backup is named based on the instance name combined with appropriate file extension for the detected compression type for the tarball.