### PR TITLE
doc/storage/buckets: add info on configuring the S3 address

### DIFF
--- a/doc/howto/storage_buckets.md
+++ b/doc/howto/storage_buckets.md
@@ -6,6 +6,16 @@
 
 See the following sections for instructions on how to create, configure, view and resize {ref}`storage-buckets` and how to manage storage bucket keys.
 
+## Configure the S3 address
+
+If you want to use storage buckets on local storage (thus in a `dir`, `btrfs`, `lvm`, or `zfs` pool), you must configure the S3 address for your LXD server.
+This is the address that you can then use to access the buckets through the S3 protocol.
+
+To configure the S3 address, set the [`core.storage_buckets_address`](server-options-core) server configuration option.
+For example:
+
+    lxc config set core.storage_buckets_address :8555
+
 ## Manage storage buckets
 
 Storage buckets provide access to object storage exposed using the S3 protocol.


### PR DESCRIPTION
This is mentioned in the explanation, but should be part of the how to.