### PR TITLE
lxd: Use protobuf helpers to avoid panics with invalid client responses

### DIFF
--- a/lxc-to-lxd/utils.go
+++ b/lxc-to-lxd/utils.go
@@ -65,8 +65,8 @@ func transferRootfs(dst lxd.ContainerServer, op lxd.Operation, rootfs string, rs
 		return err
 	}
 
-	if !*msg.Success {
-		return fmt.Errorf(*msg.Message)
+	if !msg.GetSuccess() {
+		return fmt.Errorf(msg.GetMessage())
 	}
 
 	return nil

--- a/lxd-migrate/utils.go
+++ b/lxd-migrate/utils.go
@@ -132,8 +132,8 @@ func transferRootfs(ctx context.Context, dst lxd.InstanceServer, op lxd.Operatio
 		return err
 	}
 
-	if !*msg.Success {
-		return fmt.Errorf(*msg.Message)
+	if !msg.GetSuccess() {
+		return fmt.Errorf(msg.GetMessage())
 	}
 
 	return nil

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -191,9 +191,9 @@ func (s *migrationSourceWs) DoStorage(state *state.State, projectName string, po
 		return err
 	}
 
-	if !*msg.Success {
+	if !msg.GetSuccess() {
 		logger.Errorf("Failed to send storage volume")
-		return fmt.Errorf(*msg.Message)
+		return fmt.Errorf(msg.GetMessage())
 	}
 
 	logger.Debugf("Migration source finished transferring storage volume")
@@ -465,16 +465,16 @@ func (c *migrationSink) DoStorage(state *state.State, projectName string, poolNa
 				return fmt.Errorf("Got error reading migration source: %w", msg.Err)
 			}
 
-			if !*msg.Success {
+			if !msg.GetSuccess() {
 				c.disconnect()
 
-				return fmt.Errorf(*msg.Message)
+				return fmt.Errorf(msg.GetMessage())
 			}
 
 			// The source can only tell us it failed (e.g. if
 			// checkpointing failed). We have to tell the source
 			// whether or not the restore was successful.
-			logger.Warn("Unknown message from migration source", logger.Ctx{"message": *msg.Message})
+			logger.Warn("Unknown message from migration source", logger.Ctx{"message": msg.GetMessage()})
 		}
 	}
 }


### PR DESCRIPTION
@edlerd was experimenting with the migration API and managed to crash LXD by sending a success response without a message.

```
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: panic: runtime error: invalid memory address or nil pointer dereference
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x184e16c]
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: goroutine 2025 [running]:
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: main.(*migrationSink).DoStorage(0xc001fde900, 0xc000cc5f20?, {0xc000fd3e77, 0x7}, {0xc000aaa478, 0x5}, 0xc0011aafc0, 0xc0010d9560)
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: #011/build/lxd/parts/lxd/src/lxd/migrate_storage_volumes.go:477 +0xf8c
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: main.doVolumeMigration.func1(0xc00007c0e0?)
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: #011/build/lxd/parts/lxd/src/lxd/storage_volumes.go:897 +0xaa
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: github.com/lxc/lxd/lxd/operations.(*Operation).Start.func1(0xc0010d9560)
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: #011/build/lxd/parts/lxd/src/lxd/operations/operations.go:281 +0x2c
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: created by github.com/lxc/lxd/lxd/operations.(*Operation).Start
Apr 27 14:40:08 EDLERD-T14 lxd.daemon[592325]: #011/build/lxd/parts/lxd/src/lxd/operations/operations.go:280 +0xf7
```