### PR TITLE
Generated marshaling/unmarshaling of non-native database types

### DIFF
--- a/lxd/db/cluster/certificate_projects.mapper.go
+++ b/lxd/db/cluster/certificate_projects.mapper.go
@@ -67,7 +67,7 @@ func getCertificateProjects(ctx context.Context, stmt *sql.Stmt, args ...any) ([
 	return objects, nil
 }
 
-// getCertificateProjects can be used to run handwritten query strings to return a slice of objects.
+// getCertificateProjectsRaw can be used to run handwritten query strings to return a slice of objects.
 func getCertificateProjectsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]CertificateProject, error) {
 	objects := make([]CertificateProject, 0)
 

--- a/lxd/db/cluster/certificates.mapper.go
+++ b/lxd/db/cluster/certificates.mapper.go
@@ -92,7 +92,7 @@ func getCertificates(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Certif
 	return objects, nil
 }
 
-// getCertificates can be used to run handwritten query strings to return a slice of objects.
+// getCertificatesRaw can be used to run handwritten query strings to return a slice of objects.
 func getCertificatesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Certificate, error) {
 	objects := make([]Certificate, 0)
 

--- a/lxd/db/cluster/cluster_groups.mapper.go
+++ b/lxd/db/cluster/cluster_groups.mapper.go
@@ -85,7 +85,7 @@ func getClusterGroups(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Clust
 	return objects, nil
 }
 
-// getClusterGroups can be used to run handwritten query strings to return a slice of objects.
+// getClusterGroupsRaw can be used to run handwritten query strings to return a slice of objects.
 func getClusterGroupsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]ClusterGroup, error) {
 	objects := make([]ClusterGroup, 0)
 

--- a/lxd/db/cluster/config.mapper.go
+++ b/lxd/db/cluster/config.mapper.go
@@ -55,7 +55,7 @@ func getConfig(ctx context.Context, stmt *sql.Stmt, parent string, args ...any) 
 	return objects, nil
 }
 
-// getConfig can be used to run handwritten query strings to return a slice of objects.
+// getConfigRaw can be used to run handwritten query strings to return a slice of objects.
 func getConfigRaw(ctx context.Context, tx *sql.Tx, sql string, parent string, args ...any) ([]Config, error) {
 	objects := make([]Config, 0)
 

--- a/lxd/db/cluster/devices.mapper.go
+++ b/lxd/db/cluster/devices.mapper.go
@@ -55,7 +55,7 @@ func getDevices(ctx context.Context, stmt *sql.Stmt, parent string, args ...any)
 	return objects, nil
 }
 
-// getDevices can be used to run handwritten query strings to return a slice of objects.
+// getDevicesRaw can be used to run handwritten query strings to return a slice of objects.
 func getDevicesRaw(ctx context.Context, tx *sql.Tx, sql string, parent string, args ...any) ([]Device, error) {
 	objects := make([]Device, 0)
 

--- a/lxd/db/cluster/images.mapper.go
+++ b/lxd/db/cluster/images.mapper.go
@@ -110,7 +110,7 @@ func getImages(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Image, error
 	return objects, nil
 }
 
-// getImages can be used to run handwritten query strings to return a slice of objects.
+// getImagesRaw can be used to run handwritten query strings to return a slice of objects.
 func getImagesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Image, error) {
 	objects := make([]Image, 0)
 

--- a/lxd/db/cluster/instance_profiles.mapper.go
+++ b/lxd/db/cluster/instance_profiles.mapper.go
@@ -108,7 +108,7 @@ func getInstanceProfiles(ctx context.Context, stmt *sql.Stmt, args ...any) ([]In
 	return objects, nil
 }
 
-// getInstanceProfiles can be used to run handwritten query strings to return a slice of objects.
+// getInstanceProfilesRaw can be used to run handwritten query strings to return a slice of objects.
 func getInstanceProfilesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]InstanceProfile, error) {
 	objects := make([]InstanceProfile, 0)
 

--- a/lxd/db/cluster/instances.mapper.go
+++ b/lxd/db/cluster/instances.mapper.go
@@ -225,7 +225,7 @@ func getInstances(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Instance,
 	return objects, nil
 }
 
-// getInstances can be used to run handwritten query strings to return a slice of objects.
+// getInstancesRaw can be used to run handwritten query strings to return a slice of objects.
 func getInstancesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Instance, error) {
 	objects := make([]Instance, 0)
 

--- a/lxd/db/cluster/nodes_cluster_groups.mapper.go
+++ b/lxd/db/cluster/nodes_cluster_groups.mapper.go
@@ -77,7 +77,7 @@ func getNodeClusterGroups(ctx context.Context, stmt *sql.Stmt, args ...any) ([]N
 	return objects, nil
 }
 
-// getNodeClusterGroups can be used to run handwritten query strings to return a slice of objects.
+// getNodeClusterGroupsRaw can be used to run handwritten query strings to return a slice of objects.
 func getNodeClusterGroupsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]NodeClusterGroup, error) {
 	objects := make([]NodeClusterGroup, 0)
 

--- a/lxd/db/cluster/operations.mapper.go
+++ b/lxd/db/cluster/operations.mapper.go
@@ -91,7 +91,7 @@ func getOperations(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Operatio
 	return objects, nil
 }
 
-// getOperations can be used to run handwritten query strings to return a slice of objects.
+// getOperationsRaw can be used to run handwritten query strings to return a slice of objects.
 func getOperationsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Operation, error) {
 	objects := make([]Operation, 0)
 

--- a/lxd/db/cluster/profiles.mapper.go
+++ b/lxd/db/cluster/profiles.mapper.go
@@ -149,7 +149,7 @@ func getProfiles(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Profile, e
 	return objects, nil
 }
 
-// getProfiles can be used to run handwritten query strings to return a slice of objects.
+// getProfilesRaw can be used to run handwritten query strings to return a slice of objects.
 func getProfilesRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Profile, error) {
 	objects := make([]Profile, 0)
 

--- a/lxd/db/cluster/projects.mapper.go
+++ b/lxd/db/cluster/projects.mapper.go
@@ -92,7 +92,7 @@ func getProjects(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Project, e
 	return objects, nil
 }
 
-// getProjects can be used to run handwritten query strings to return a slice of objects.
+// getProjectsRaw can be used to run handwritten query strings to return a slice of objects.
 func getProjectsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Project, error) {
 	objects := make([]Project, 0)
 

--- a/lxd/db/cluster/snapshots.mapper.go
+++ b/lxd/db/cluster/snapshots.mapper.go
@@ -103,7 +103,7 @@ func getInstanceSnapshots(ctx context.Context, stmt *sql.Stmt, args ...any) ([]I
 	return objects, nil
 }
 
-// getInstanceSnapshots can be used to run handwritten query strings to return a slice of objects.
+// getInstanceSnapshotsRaw can be used to run handwritten query strings to return a slice of objects.
 func getInstanceSnapshotsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]InstanceSnapshot, error) {
 	objects := make([]InstanceSnapshot, 0)
 

--- a/lxd/db/cluster/warnings.mapper.go
+++ b/lxd/db/cluster/warnings.mapper.go
@@ -123,7 +123,7 @@ func getWarnings(ctx context.Context, stmt *sql.Stmt, args ...any) ([]Warning, e
 	return objects, nil
 }
 
-// getWarnings can be used to run handwritten query strings to return a slice of objects.
+// getWarningsRaw can be used to run handwritten query strings to return a slice of objects.
 func getWarningsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]Warning, error) {
 	objects := make([]Warning, 0)
 

--- a/lxd/db/generate/README.md
+++ b/lxd/db/generate/README.md
@@ -85,6 +85,7 @@ Tag                         | Description
 `primary=yes`               | Assigns column associated with the field to be sufficient for returning a row from the table. Will default to `Name` if unspecified. Fields with this key will be included in the default 'ORDER BY' clause.
 `omit=<Stmt Types>`         | Omits a given field from consideration for the comma separated list of statement types (`create`, `objects-by-Name`, `update`).
 `ignore=yes`                | Outright ignore the struct field as though it does not exist.
+`marshal=yes`               | Marshal/Unmarshal data into the field. The column must be a TEXT column and the type must implement both `query.Marshal` and `query.Unmarshal`. This works for entity tables only, and not for association or mapping tables.
 
 ### Go Function Generation
 

--- a/lxd/db/generate/db/mapping.go
+++ b/lxd/db/generate/db/mapping.go
@@ -229,6 +229,26 @@ func (m *Mapping) FieldParams(fields []*Field) string {
 	return strings.Join(args, ", ")
 }
 
+// FieldParamsMarshal converts the given fields to function parameters, rendering their
+// name. If the field is configured to marshal input/output, the name will be `marshaled{name}`.
+func (m *Mapping) FieldParamsMarshal(fields []*Field) string {
+	args := make([]string, len(fields))
+	for i, field := range fields {
+		name := lex.Minuscule(field.Name)
+		if name == "type" {
+			name = lex.Minuscule(m.Name) + field.Name
+		}
+
+		if shared.IsTrue(field.Config.Get("marshal")) {
+			name = fmt.Sprintf("marshaled%s", field.Name)
+		}
+
+		args[i] = name
+	}
+
+	return strings.Join(args, ", ")
+}
+
 // Field holds all information about a field in a Go struct that is relevant
 // for database code generation.
 type Field struct {

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -1038,7 +1038,13 @@ func (m *Method) update(buf *file.Buffer) error {
 		params := make([]string, len(fields))
 
 		for i, field := range fields {
-			params[i] = fmt.Sprintf("object.%s", field.Name)
+			if shared.IsTrue(field.Config.Get("marshal")) {
+				buf.L("marshaled%s, err := query.Marshal(object.%s)", field.Name, field.Name)
+				m.ifErrNotNil(buf, true, "err")
+				params[i] = fmt.Sprintf("marshaled%s", field.Name)
+			} else {
+				params[i] = fmt.Sprintf("object.%s", field.Name)
+			}
 		}
 
 		buf.L("id, err := Get%sID(ctx, tx, %s)", lex.Camel(m.entity), mapping.FieldParams(nk))

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -761,7 +761,13 @@ func (m *Method) create(buf *file.Buffer, replace bool) error {
 
 		buf.L("// Populate the statement arguments. ")
 		for i, field := range fields {
-			buf.L("args[%d] = object.%s", i, field.Name)
+			if shared.IsTrue(field.Config.Get("marshal")) {
+				buf.L("marshaled%s, err := query.Marshal(object.%s)", field.Name, field.Name)
+				m.ifErrNotNil(buf, true, "-1", "err")
+				buf.L("args[%d] = marshaled%s", i, field.Name)
+			} else {
+				buf.L("args[%d] = object.%s", i, field.Name)
+			}
 		}
 
 		buf.N()

--- a/lxd/db/generate/db/method.go
+++ b/lxd/db/generate/db/method.go
@@ -1547,7 +1547,7 @@ func (m *Method) getManyTemplateFuncs(buf *file.Buffer, mapping *Mapping) error 
 	buf.N()
 
 	// Create a function supporting raw queries.
-	buf.L("// get%s can be used to run handwritten query strings to return a slice of objects.", lex.Plural(mapping.Name))
+	buf.L("// get%sRaw can be used to run handwritten query strings to return a slice of objects.", lex.Plural(mapping.Name))
 	if mapping.Type != ReferenceTable && mapping.Type != MapTable {
 		buf.L("func get%sRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]%s, error) {", lex.Plural(mapping.Name), mapping.Name)
 	} else {

--- a/lxd/db/query/marshal.go
+++ b/lxd/db/query/marshal.go
@@ -1,0 +1,35 @@
+package query
+
+import (
+	"fmt"
+)
+
+type Marshaler interface {
+	MarshalDB() (string, error)
+}
+
+type Unmarshaler interface {
+	UnmarshalDB(string) error
+}
+
+func Marshal(v any) (string, error) {
+	marshaller, ok := v.(Marshaler)
+	if !ok {
+		return "", fmt.Errorf("Cannot marshal data, type does not implement DBMarshaler")
+	}
+
+	return marshaller.MarshalDB()
+}
+
+func Unmarshal(data string, v any) error {
+	if v == nil {
+		return fmt.Errorf("Cannot unmarshal data into nil value")
+	}
+
+	unmarshaler, ok := v.(Unmarshaler)
+	if !ok {
+		return fmt.Errorf("Cannot marshal data, type does not implement DBUnmarshaler")
+	}
+
+	return unmarshaler.UnmarshalDB(data)
+}


### PR DESCRIPTION
@tomponline @stgraber @masnax Following from the chat in IRC I've written this simple implementation of database marshalling/unmarshalling. This allows us to add any type to the database in a TEXT column, the type should implement `query.MarshalDB` and `query.UnmarshalDB`, and should be added to the database type representation with `marshal=true` in the struct tag for the field.

I have implemented this only for the methods it seemed necessary, and only for simple tables (no reference or association tables).

There are no changes to generation for LXD (save for a quick fix on a comment). I'll submit a draft PR for LXD Cloud shortly to show what this looks like in practice.

