### PR TITLE
Instance: Remove automatic timeout concept from operation locks

### DIFF
--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -937,7 +937,7 @@ func (d *common) onStopOperationSetup(target string) (*operationlock.InstanceOpe
 	op := operationlock.Get(d.Project().Name, d.Name())
 	if op != nil && !op.ActionMatch(operationlock.ActionStart, operationlock.ActionRestart, operationlock.ActionStop, operationlock.ActionRestore) {
 		d.logger.Debug("Waiting for existing operation lock to finish before running hook", logger.Ctx{"action": op.Action()})
-		_ = op.Wait()
+		_ = op.Wait(context.Background())
 		op = nil
 	}
 

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2819,24 +2819,7 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 
 // Restart restart the instance.
 func (d *lxc) Restart(timeout time.Duration) error {
-	ctxMap := logger.Ctx{
-		"action":    "shutdown",
-		"created":   d.creationDate,
-		"ephemeral": d.ephemeral,
-		"used":      d.lastUsedDate,
-		"timeout":   timeout}
-
-	d.logger.Info("Restarting instance", ctxMap)
-
-	err := d.restartCommon(d, timeout)
-	if err != nil {
-		return err
-	}
-
-	d.logger.Info("Restarted instance", ctxMap)
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
-
-	return nil
+	return d.restartCommon(d, timeout)
 }
 
 // onStopNS is triggered by LXC's stop hook once a container is shutdown but before the container's

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -2631,7 +2631,7 @@ func (d *lxc) Stop(stateful bool) error {
 			return err
 		}
 
-		err = op.Wait()
+		err = op.Wait(context.Background())
 		if err != nil && d.IsRunning() {
 			return err
 		}
@@ -2685,7 +2685,7 @@ func (d *lxc) Stop(stateful bool) error {
 	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
 	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
 	// However if the operation has failed for another reason we will collect the error here.
-	err = op.Wait()
+	err = op.Wait(context.Background())
 	status := d.statusCode()
 	if status != api.Stopped {
 		errPrefix := fmt.Errorf("Failed stopping instance, status is %q", status)
@@ -2788,21 +2788,13 @@ func (d *lxc) Shutdown(timeout time.Duration) error {
 
 	d.logger.Debug("Shutdown request sent to instance")
 
-	// Use default operation timeout if not specified (negatively or positively).
-	if timeout == 0 {
-		timeout = operationlock.TimeoutDefault
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
-	// Extend operation lock for the requested timeout.
-	err = op.ResetTimeout(timeout)
-	if err != nil {
-		return err
-	}
-
-	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
-	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
-	// However if the operation has failed for another reason we will collect the error here.
-	err = op.Wait()
+	// Wait for operation lock to be Done or context to timeout. The operation lock is normally completed by
+	// onStop which picks up the same lock and then marks it as Done after the instance stops and the devices
+	// have been cleaned up. However if the operation has failed for another reason we collect the error here.
+	err = op.Wait(ctx)
 	status := d.statusCode()
 	if status != api.Stopped {
 		errPrefix := fmt.Errorf("Failed shutting down instance, status is %q", status)
@@ -2860,12 +2852,10 @@ func (d *lxc) onStopNS(args map[string]string) error {
 	}
 
 	// Create/pick up operation, but don't complete it as we leave operation running for the onStop hook below.
-	op, err := d.onStopOperationSetup(target)
+	_, err := d.onStopOperationSetup(target)
 	if err != nil {
 		return err
 	}
-
-	_ = op.Reset()
 
 	// Clean up devices.
 	d.cleanupDevices(false, netns)
@@ -2890,8 +2880,6 @@ func (d *lxc) onStop(args map[string]string) error {
 		return err
 	}
 
-	_ = op.Reset()
-
 	// Make sure we can't call go-lxc functions by mistake
 	d.fromHook = true
 
@@ -2911,8 +2899,6 @@ func (d *lxc) onStop(args map[string]string) error {
 
 		// Unlock on return
 		defer op.Done(nil)
-
-		_ = op.ResetTimeout(operationlock.TimeoutShutdown)
 
 		d.logger.Debug("Instance stopped, cleaning up")
 
@@ -6645,7 +6631,7 @@ func (d *lxc) FileSFTPConn() (net.Conn, error) {
 	// volume when the instance is running, so there should be no reason to wait for the operation to finish.
 	op := operationlock.Get(d.Project().Name, d.Name())
 	if op.Action() != operationlock.ActionUpdate || !d.IsRunning() {
-		_ = op.Wait()
+		_ = op.Wait(context.Background())
 	}
 
 	// Setup reverter.

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -561,10 +561,6 @@ func (d *qemu) pidWait(timeout time.Duration, op *operationlock.InstanceOperatio
 			return false
 		}
 
-		if op != nil {
-			_ = op.Reset() // Reset timeout to default.
-		}
-
 		time.Sleep(time.Millisecond * time.Duration(250))
 	}
 
@@ -586,17 +582,15 @@ func (d *qemu) onStop(target string) error {
 	defer op.Done(nil)
 
 	// Wait for QEMU process to end (to avoiding racing start when restarting).
-	// Wait up to operationlock.TimeoutShutdown to allow for flushing any pending data to disk.
+	// Wait up to 5 minutes to allow for flushing any pending data to disk.
 	d.logger.Debug("Waiting for VM process to finish")
-	waitTimeout := operationlock.TimeoutShutdown
+	waitTimeout := time.Minute * 5
 	if d.pidWait(waitTimeout, op) {
 		d.logger.Debug("VM process finished")
 	} else {
 		// Log a warning, but continue clean up as best we can.
 		d.logger.Error("VM process failed to stop", logger.Ctx{"timeout": waitTimeout})
 	}
-
-	_ = op.Reset() // Reset timeout to default.
 
 	// Record power state.
 	err = d.VolatileSet(map[string]string{
@@ -614,7 +608,6 @@ func (d *qemu) onStop(target string) error {
 	_ = os.Remove(d.monitorPath())
 
 	// Stop the storage for the instance.
-	_ = op.ResetTimeout(waitTimeout)
 	err = d.unmount()
 	if err != nil && !errors.Is(err, storageDrivers.ErrInUse) {
 		err = fmt.Errorf("Failed unmounting instance: %w", err)
@@ -636,8 +629,6 @@ func (d *qemu) onStop(target string) error {
 
 	// Reboot the instance.
 	if target == "reboot" {
-		_ = op.Reset() // Reset timeout to default.
-
 		err = d.Start(false)
 		if err != nil {
 			op.Done(err)
@@ -646,8 +637,6 @@ func (d *qemu) onStop(target string) error {
 
 		d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
 	} else if d.ephemeral {
-		_ = op.Reset() // Reset timeout to default.
-
 		// Destroy ephemeral virtual machines.
 		err = d.delete(true)
 		if err != nil {
@@ -718,21 +707,13 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 
 	d.logger.Debug("Shutdown request sent to instance")
 
-	// Use default operation timeout if not specified (negatively or positively).
-	if timeout == 0 {
-		timeout = operationlock.TimeoutDefault
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
 
-	// Extend operation lock for the requested timeout.
-	err = op.ResetTimeout(timeout)
-	if err != nil {
-		return err
-	}
-
-	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
-	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
-	// However if the operation has failed for another reason we will collect the error here.
-	err = op.Wait()
+	// Wait for operation lock to be Done or context to timeout. The operation lock is normally completed by
+	// onStop which picks up the same lock and then marks it as Done after the instance stops and the devices
+	// have been cleaned up. However if the operation has failed for another reason we collect the error here.
+	err = op.Wait(ctx)
 	status := d.statusCode()
 	if status != api.Stopped {
 		errPrefix := fmt.Errorf("Failed shutting down instance, status is %q", status)
@@ -1556,8 +1537,6 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		return err
 	}
 
-	_ = op.Reset() // Reset timeout to default.
-
 	err = p.StartWithFiles(context.Background(), fdFiles)
 	if err != nil {
 		op.Done(err)
@@ -1664,8 +1643,6 @@ func (d *qemu) start(stateful bool, op *operationlock.InstanceOperation) error {
 		op.Done(err)
 		return fmt.Errorf("Failed setting reboot action: %w", err)
 	}
-
-	_ = op.Reset() // Reset timeout to default.
 
 	// Restore the state.
 	if stateful {
@@ -4351,7 +4328,7 @@ func (d *qemu) Stop(stateful bool) error {
 	// Wait for operation lock to be Done. This is normally completed by onStop which picks up the same
 	// operation lock and then marks it as Done after the instance stops and the devices have been cleaned up.
 	// However if the operation has failed for another reason we will collect the error here.
-	err = op.Wait()
+	err = op.Wait(context.Background())
 	status := d.statusCode()
 	if status != api.Stopped {
 		errPrefix := fmt.Errorf("Failed stopping instance, status is %q", status)

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -738,14 +738,7 @@ func (d *qemu) Shutdown(timeout time.Duration) error {
 
 // Restart restart the instance.
 func (d *qemu) Restart(timeout time.Duration) error {
-	err := d.restartCommon(d, timeout)
-	if err != nil {
-		return err
-	}
-
-	d.state.Events.SendLifecycle(d.project.Name, lifecycle.InstanceRestarted.Event(d, nil))
-
-	return nil
+	return d.restartCommon(d, timeout)
 }
 
 func (d *qemu) ovmfPath() string {

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -98,10 +98,6 @@ func Create(projectName string, instanceName string, action Action, createReusua
 
 	go func(op *InstanceOperation) {
 		timeout := TimeoutDefault
-		if action == ActionCreate {
-			timeout = -1
-		}
-
 		timer := time.NewTimer(timeout)
 		defer timer.Stop()
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/archive"
 	"github.com/lxc/lxd/lxd/backup"
-	"github.com/lxc/lxd/lxd/instance/operationlock"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/revert"
@@ -1943,7 +1942,7 @@ func (d *zfs) deactivateVolume(vol Volume) (bool, error) {
 
 		// We cannot wait longer than the operationlock.TimeoutShutdown to avoid continuing
 		// the unmount process beyond the ongoing request.
-		waitDuration := operationlock.TimeoutShutdown
+		waitDuration := time.Minute * 5
 		waitUntil := time.Now().Add(waitDuration)
 		i := 0
 		for {


### PR DESCRIPTION
Operation locks have previously had an automatic timeout of 30s.

However many of the tasks that used operation locks take an indeterminate amount of time, and so it required the task to periodically reset the operation lock so that it didn't lapse, because if it did, then it would open the door for conflicting tasks to be started whilst the original task was ongoing (which was the purpose of the lock to prevent this).

Most of the instance tasks that use locks are dependent on external factors (such as system load, image size and I/O performance) which varies the time they take, so the automatic timeout concept was not helpful, and in some cases damaging.

Rather than requiring tasks to keep resetting the lock timeout for an operation that takes an unknown amount of time, this PR removes the automatic timeout concept and instead requires the task to manage its own timeout (if appropriate) which will include cleaning up any ongoing commands and cancelling the operation lock.

If a task can get stuck indefinitely then that should be considered a bug in the task rather than in the operation lock itself.  

Fixes #11501