### PR TITLE
Storage: Disable safety checks when shrinking a ext4 filesystem volumes created from an image

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -826,7 +826,9 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 
 	// Resize volume to the size specified. Only uses volume "size" property and does not use pool/defaults
 	// to give the caller more control over the size being used.
-	err = d.SetVolumeQuota(vol, vol.config["size"], false, op)
+	// Pass allowUnsafeResize as true because if the resize fails we will delete the volume anyway so don't
+	// have to worry about it being left in an inconsistent state.
+	err = d.SetVolumeQuota(vol, vol.config["size"], true, op)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -630,6 +630,9 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		_ = unfreezeFS()
 	}
 
+	// Delete the volume created on failure.
+	revert.Add(func() { _ = d.DeleteVolume(vol, op) })
+
 	// If zfs.clone_copy is disabled or source volume has snapshots, then use full copy mode.
 	if shared.IsFalse(d.config["zfs.clone_copy"]) || len(snapshots) > 0 {
 		snapName := strings.SplitN(srcSnapshot, "@", 2)[1]
@@ -754,9 +757,6 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		if err != nil {
 			return err
 		}
-
-		// Delete on revert.
-		revert.Add(func() { _ = d.DeleteVolume(vol, op) })
 	}
 
 	// Apply the properties.


### PR DESCRIPTION
This allows for shrinking the volume to a smaller size. Disabling the pre-resize safety checks isn't an issue because if the resize fails we are going to delete the new volume anyway, so it doesn't matter if its left in an inconsistent state.

Fixes #11506 