### PR TITLE
doc: restructure the Manage LXD and Internals sections

### DIFF
--- a/.sphinx/.wordlist.txt
+++ b/.sphinx/.wordlist.txt
@@ -119,6 +119,7 @@ LTS
 LV
 LVM
 LXC
+LXC's
 LXCFS
 LXD
 LXD's
@@ -221,6 +222,7 @@ stdout
 STP
 struct
 structs
+subcommand
 subcommands
 subitem
 subnet

--- a/doc/container-environment.md
+++ b/doc/container-environment.md
@@ -1,28 +1,13 @@
+(container-runtime-environment)=
 # Container runtime environment
 
-LXD attempts to present a consistent environment to the container it runs.
+LXD attempts to present a consistent environment to all containers it runs.
 
-The exact environment will differ slightly based on kernel features and user
-configuration but will otherwise be identical for all containers.
-
-## PID1
-
-LXD spawns whatever is located at `/sbin/init` as the initial process of the container (PID 1).
-This binary should act as a proper init system, including handling re-parented processes.
-
-LXD's communication with PID1 in the container is limited to two signals:
-
-- `SIGINT` to trigger a reboot of the container
-- `SIGPWR` (or alternatively `SIGRTMIN`+3) to trigger a clean shutdown of the container
-
-The initial environment of PID1 is blank except for `container=lxc` which can
-be used by the init system to detect the runtime.
-
-All file descriptors above the default 3 are closed prior to PID1 being spawned.
+The exact environment will differ slightly based on kernel features and user configuration, but otherwise, it is identical for all containers.
 
 ## File system
 
-LXD assumes that any image it uses to create a new container from will come with at least:
+LXD assumes that any image it uses to create a new container comes with at least the following root-level directories:
 
 - `/dev` (empty)
 - `/proc` (empty)
@@ -32,9 +17,9 @@ LXD assumes that any image it uses to create a new container from will come with
 ## Devices
 
 LXD containers have a minimal and ephemeral `/dev` based on a `tmpfs` file system.
-Since this is a `tmpfs` and not a `devtmpfs`, device nodes will only appear if manually created.
+Since this is a `tmpfs` and not a `devtmpfs` file system, device nodes appear only if manually created.
 
-The standard set of device nodes will be set up:
+The following standard set of device nodes is set up automatically:
 
 - `/dev/console`
 - `/dev/fd`
@@ -50,21 +35,32 @@ The standard set of device nodes will be set up:
 - `/dev/urandom`
 - `/dev/zero`
 
-On top of the standard set of devices, the following are also set up for convenience:
+In addition to the standard set of devices, the following devices are also set up for convenience:
 
 - `/dev/fuse`
 - `/dev/net/tun`
 - `/dev/mqueue`
 
+### Network
+
+LXD containers may have any number of network devices attached to them.
+The naming for those (unless overridden by the user) is `ethX`, where `X` is an incrementing number.
+
+### Container-to-host communication
+
+LXD sets up a socket at `/dev/lxd/sock` that the root user in the container can use to communicate with LXD on the host.
+
+See {doc}`dev-lxd` for the API documentation.
+
 ## Mounts
 
-The following mounts are set up by default under LXD:
+The following mounts are set up by default:
 
 - `/proc` ({spellexception}`proc`)
 - `/sys` (`sysfs`)
-- `/sys/fs/cgroup/*` (`cgroupfs`) (only on kernels lacking cgroup namespace support)
+- `/sys/fs/cgroup/*` (`cgroupfs`) (only on kernels that lack cgroup namespace support)
 
-The following paths will also be automatically mounted if present on the host:
+If they are present on the host, the following paths will also automatically be mounted:
 
 - `/proc/sys/fs/binfmt_misc`
 - `/sys/firmware/efi/efivars`
@@ -73,27 +69,28 @@ The following paths will also be automatically mounted if present on the host:
 - `/sys/kernel/debug`
 - `/sys/kernel/security`
 
-The reason for passing all of those is legacy init systems which require
-those to be mounted or be mountable inside the container.
+The reason for passing all of those paths is that legacy init systems require them to be mounted, or be mountable, inside the container.
 
-The majority of those will not be writable (or even readable) from inside an
-unprivileged container and will be blocked by our AppArmor policy inside
-privileged containers.
+The majority of those paths will not be writable (or even readable) from inside an unprivileged container.
+In privileged containers, they will be blocked by the AppArmor policy.
 
-## Network
+### LXCFS
 
-LXD containers may have any number of network devices attached to them.
-The naming for those unless overridden by the user is `ethX` where X is an incrementing number.
-
-## Container to host communication
-
-LXD sets up a socket at `/dev/lxd/sock` which root in the container can use to communicate with LXD on the host.
-
-The API is [documented here](dev-lxd.md).
-
-## LXCFS
-
-If LXCFS is present on the host, it will automatically be set up for the container.
+If LXCFS is present on the host, it is automatically set up for the container.
 
 This normally results in a number of `/proc` files being overridden through bind-mounts.
-On older kernels a virtual version of `/sys/fs/cgroup` may also be set up by LXCFS.
+On older kernels, a virtual version of `/sys/fs/cgroup` might also be set up by LXCFS.
+
+## PID1
+
+LXD spawns whatever is located at `/sbin/init` as the initial process of the container (PID 1).
+This binary should act as a proper init system, including handling re-parented processes.
+
+LXD's communication with PID1 in the container is limited to two signals:
+
+- `SIGINT` to trigger a reboot of the container
+- `SIGPWR` (or alternatively `SIGRTMIN`+3) to trigger a clean shutdown of the container
+
+The initial environment of PID1 is blank except for `container=lxc`, which can be used by the init system to detect the runtime.
+
+All file descriptors above the default three are closed prior to PID1 being spawned.

--- a/doc/daemon-behavior.md
+++ b/doc/daemon-behavior.md
@@ -1,21 +1,18 @@
 (daemon-behavior)=
 # Daemon behavior
 
-## Introduction
-
-This specification covers some of the daemon's behavior, such as
-reaction to given signals, crashes, ...
+This specification covers some of the {ref}`lxd-daemon`'s behavior.
 
 ## Startup
 
 On every start, LXD checks that its directory structure exists. If it
-doesn't, it'll create the required directories, generate a key pair and
-initialize the database.
+doesn't, it creates the required directories, generates a key pair and
+initializes the database.
 
-Once the daemon is ready for work, LXD will scan the instances table
+Once the daemon is ready for work, LXD scans the instances table
 for any instance for which the stored power state differs from the
 current one. If an instance's power state was recorded as running and the
-instance isn't running, LXD will start it.
+instance isn't running, LXD starts it.
 
 ## Signal handling
 
@@ -31,12 +28,11 @@ exit cleanly.
 
 Indicates to LXD that the host is going down.
 
-LXD will attempt a clean shutdown of all the instances. After 30s, it
-will kill any remaining instance.
+LXD will attempt a clean shutdown of all the instances. After 30 seconds, it
+kills any remaining instance.
 
 The instance `power_state` in the instances table is kept as it was so
-that LXD after the host is done rebooting can restore the instances as
-they were.
+that LXD can restore the instances as they were after the host is done rebooting.
 
 ### `SIGUSR1`
 

--- a/doc/daemon-behavior.md
+++ b/doc/daemon-behavior.md
@@ -1,3 +1,4 @@
+(daemon-behavior)=
 # Daemon behavior
 
 ## Introduction

--- a/doc/database.md
+++ b/doc/database.md
@@ -2,7 +2,7 @@
 relatedlinks: https://github.com/canonical/dqlite
 ---
 
-# Database
+# About the LXD database
 
 ## Introduction
 
@@ -35,55 +35,5 @@ Even when using LXD as single non-clustered node, the global database will still
 be used, although in that case it effectively behaves like a regular SQLite
 database.
 
-The files of the global database are stored under the `./database/global`
-sub-directory of your LXD data directory (e.g. `/var/lib/lxd/database/global` or
-`/var/snap/lxd/common/lxd/database/global` for snap users).
-
-Since each member of the cluster also needs to keep some data which is specific
-to that member, LXD also uses a plain SQLite database (the "local" database),
-which you can find in `./database/local.db`.
-
 Backups of the global database directory and of the local database file are made
-before upgrades, and are tagged with the `.bak` suffix. You can use those if
-you need to revert the state as it was before the upgrade.
-
-## Dumping the database content or schema
-
-If you want to get a SQL text dump of the content or the schema of the databases,
-use the `lxd sql <local|global> [.dump|.schema]` command, which produces the
-equivalent output of the `.dump` or `.schema` directives of the `sqlite3`
-command line tool.
-
-## Running custom queries from the console
-
-If you need to perform SQL queries (e.g. `SELECT`, `INSERT`, `UPDATE`)
-against the local or global database, you can use the `lxd sql` command (run
-`lxd sql --help` for details).
-
-You should only need to do that in order to recover from broken updates or bugs.
-Please consult the LXD team first (creating a [GitHub
-issue](https://github.com/lxc/lxd/issues/new) or
-[forum](https://discuss.linuxcontainers.org/) post).
-
-## Running custom queries at LXD daemon startup
-
-In case the LXD daemon fails to start after an upgrade because of SQL data
-migration bugs or similar problems, it's possible to recover the situation by
-creating `.sql` files containing queries that repair the broken update.
-
-To perform repairs against the local database, write a
-`./database/patch.local.sql` file containing the relevant queries, and
-similarly a `./database/patch.global.sql` for global database repairs.
-
-Those files will be loaded very early in the daemon startup sequence and deleted
-if the queries were successful (if they fail, no state will change as they are
-run in a SQL transaction).
-
-As above, please consult the LXD team first.
-
-## Syncing the cluster database to disk
-
-If you want to flush the content of the cluster database to disk, use the `lxd
-sql global .sync` command, that will write a plain SQLite database file into
-`./database/global/db.bin`, which you can then inspect with the `sqlite3`
-command line tool.
+before upgrades.

--- a/doc/database.md
+++ b/doc/database.md
@@ -2,6 +2,7 @@
 relatedlinks: https://dqlite.io/, https://github.com/canonical/dqlite
 ---
 
+(database)=
 # About the LXD database
 
 LXD uses a distributed database to store the server configuration and state, which allows for quicker queries than if the configuration was stored inside each instance's directory (as it is done by LXC, for example).

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -1,4 +1,4 @@
-# Debugging
+# How to debug LXD
 
 For information on debugging instance issues, see {ref}`instances-troubleshoot`.
 
@@ -79,3 +79,58 @@ openssl pkcs12 -clcerts -inkey client.key -in client.crt -export -out client.pfx
 ```
 
 After that, opening [`https://127.0.0.1:8443/1.0`](https://127.0.0.1:8443/1.0) should work as expected.
+
+## Debug the LXD database
+
+The files of the global database are stored under the `./database/global`
+sub-directory of your LXD data directory (e.g. `/var/lib/lxd/database/global` or
+`/var/snap/lxd/common/lxd/database/global` for snap users).
+
+Since each member of the cluster also needs to keep some data which is specific
+to that member, LXD also uses a plain SQLite database (the "local" database),
+which you can find in `./database/local.db`.
+
+Backups of the global database directory and of the local database file are made
+before upgrades, and are tagged with the `.bak` suffix. You can use those if
+you need to revert the state as it was before the upgrade.
+
+### Dumping the database content or schema
+
+If you want to get a SQL text dump of the content or the schema of the databases,
+use the `lxd sql <local|global> [.dump|.schema]` command, which produces the
+equivalent output of the `.dump` or `.schema` directives of the `sqlite3`
+command line tool.
+
+### Running custom queries from the console
+
+If you need to perform SQL queries (e.g. `SELECT`, `INSERT`, `UPDATE`)
+against the local or global database, you can use the `lxd sql` command (run
+`lxd sql --help` for details).
+
+You should only need to do that in order to recover from broken updates or bugs.
+Please consult the LXD team first (creating a [GitHub
+issue](https://github.com/lxc/lxd/issues/new) or
+[forum](https://discuss.linuxcontainers.org/) post).
+
+### Running custom queries at LXD daemon startup
+
+In case the LXD daemon fails to start after an upgrade because of SQL data
+migration bugs or similar problems, it's possible to recover the situation by
+creating `.sql` files containing queries that repair the broken update.
+
+To perform repairs against the local database, write a
+`./database/patch.local.sql` file containing the relevant queries, and
+similarly a `./database/patch.global.sql` for global database repairs.
+
+Those files will be loaded very early in the daemon startup sequence and deleted
+if the queries were successful (if they fail, no state will change as they are
+run in a SQL transaction).
+
+As above, please consult the LXD team first.
+
+### Syncing the cluster database to disk
+
+If you want to flush the content of the cluster database to disk, use the `lxd
+sql global .sync` command, that will write a plain SQLite database file into
+`./database/global/db.bin`, which you can then inspect with the `sqlite3`
+command line tool.

--- a/doc/debugging.md
+++ b/doc/debugging.md
@@ -82,7 +82,7 @@ After that, opening [`https://127.0.0.1:8443/1.0`](https://127.0.0.1:8443/1.0) s
 
 ## Debug the LXD database
 
-The files of the global database are stored under the `./database/global`
+The files of the global {ref}`database <database>` are stored under the `./database/global`
 sub-directory of your LXD data directory (e.g. `/var/lib/lxd/database/global` or
 `/var/snap/lxd/common/lxd/database/global` for snap users).
 

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -1,11 +1,11 @@
 # Environment variables
 
-- doesn't work for snap users
-
-## Introduction
-
 The LXD client and daemon respect some environment variables to adapt to
 the user's environment and to turn some advanced features on and off.
+
+```{note}
+These environment variables are not available if you use the LXD snap.
+```
 
 ## Common
 

--- a/doc/environment.md
+++ b/doc/environment.md
@@ -1,5 +1,7 @@
 # Environment variables
 
+- doesn't work for snap users
+
 ## Introduction
 
 The LXD client and daemon respect some environment variables to adapt to

--- a/doc/explanation/lxd_lxc.md
+++ b/doc/explanation/lxd_lxc.md
@@ -1,0 +1,8 @@
+# About `lxd` and `lxc`
+
+- Explain difference between daemon and client
+- different commands, `lxc` is not LXC
+- `lxc` is optional
+- command aliases (from Advanced Guide)
+- link to daemon-behavior
+- ?

--- a/doc/explanation/lxd_lxc.md
+++ b/doc/explanation/lxd_lxc.md
@@ -21,7 +21,8 @@ LXD provides a superset of the features that LXC supports, and it is easier to u
 Therefore, if you are unsure which of the tools to use, you should go for LXD.
 LXC should be seen as an alternative for experienced users that want to run Linux containers on distributions that don't support LXD.
 
-## The LXD daemon
+(lxd-daemon)=
+## LXD daemon
 
 The central part of LXD is its daemon.
 It runs persistently in the background, manages the instances, and handles all requests.

--- a/doc/explanation/lxd_lxc.md
+++ b/doc/explanation/lxd_lxc.md
@@ -1,8 +1,50 @@
+---
+discourse: 24
+---
+
 # About `lxd` and `lxc`
 
-- Explain difference between daemon and client
-- different commands, `lxc` is not LXC
-- `lxc` is optional
-- command aliases (from Advanced Guide)
-- link to daemon-behavior
-- ?
+LXD is frequently confused with LXC, and the fact that LXD provides both a `lxd` command and a `lxc` command doesn't make things easier.
+
+## LXD vs. LXC
+
+LXD and LXC are two distinct implementations of Linux containers.
+
+[LXC](https://linuxcontainers.org/lxc/introduction/) is a low-level user space interface for the Linux kernel containment features.
+It consists of tools (`lxc-*` commands), templates, and library and language bindings.
+
+[LXD](https://linuxcontainers.org/lxd/introduction/) is a more intuitive and user-friendly tool aimed at making it easy to work with Linux containers.
+It is an alternative to LXC's tools and distribution template system, with the added features that come from being controllable over the network.
+Under the hood, LXD uses LXC to create and manage the containers.
+
+LXD provides a superset of the features that LXC supports, and it is easier to use.
+Therefore, if you are unsure which of the tools to use, you should go for LXD.
+LXC should be seen as an alternative for experienced users that want to run Linux containers on distributions that don't support LXD.
+
+## The LXD daemon
+
+The central part of LXD is its daemon.
+It runs persistently in the background, manages the instances, and handles all requests.
+The daemon provides a REST API that you can access directly or through a client (for example, the default command-line client that comes with LXD).
+
+See {ref}`daemon-behavior` for more information about the LXD daemon.
+
+## `lxd` vs. `lxc`
+
+To control LXD, you typically use two different commands: `lxd` and `lxc`.
+
+LXD daemon
+: The `lxd` command controls the LXD daemon.
+  Since the daemon is typically started automatically, you hardly ever need to use the `lxd` command.
+  An exception is the `lxd init` subcommand that you run to {ref}`initialize LXD <initialize>`.
+
+  There are also some subcommands for debugging and administrating the daemon, but they are intended for advanced users only.
+  See `lxd --help` for an overview of all available subcommands.
+
+LXD client
+: The `lxc` command is a command-line client for LXD, which you can use to interact with the LXD daemon.
+  You use the `lxc` command to manage your instances, the server settings, and overall the entities you create in LXD.
+  See `lxc --help` for an overview of all available subcommands.
+
+  The `lxc` tool is not the only client you can use to interact with the LXD daemon.
+  You can also use the API, the UI, or a custom LXD client.

--- a/doc/howto/images_remote.md
+++ b/doc/howto/images_remote.md
@@ -6,6 +6,7 @@ See {ref}`remote-image-servers` for an overview.
 
 ## List configured remotes
 
+<!-- Include start list remotes -->
 To see all configured remote servers, enter the following command:
 
     lxc remote list
@@ -13,6 +14,7 @@ To see all configured remote servers, enter the following command:
 Remote servers that use the [simple streams format](https://git.launchpad.net/simplestreams/tree/) are pure image servers.
 Servers that use the `lxd` format are LXD servers, which either serve solely as image servers or might provide some images in addition to serving as regular LXD servers.
 See {ref}`remote-image-server-types` for more information.
+<!-- Include end list remotes -->
 
 ## List available images on a remote
 
@@ -37,18 +39,20 @@ The URL must use HTTPS.
 
 ### Add a remote LXD server
 
+<!-- Include start add remotes -->
 To add a LXD server as a remote, enter the following command:
 
     lxc remote add <remote_name> <IP|FQDN|URL> [flags]
 
 Some authentication methods require specific flags (for example, use `lxc remote add <remote_name> <IP|FQDN|URL> --auth-type=candid` for Candid authentication).
-See {ref}`authentication` for more information.
+See {ref}`server-authenticate` and {ref}`authentication` for more information.
 
 For example, enter the following command to add a remote through an IP address:
 
     lxc remote add my-remote 192.0.2.10
 
 You are prompted to confirm the remote server fingerprint and then asked for the password or token, depending on the authentication method used by the remote.
+<!-- Include end add remotes -->
 
 ## Reference an image
 

--- a/doc/howto/lxc_alias.md
+++ b/doc/howto/lxc_alias.md
@@ -1,0 +1,14 @@
+(lxc-alias)=
+# How to add command aliases
+
+The LXD command-line client supports adding aliases for commands that you use frequently.
+You can use aliases as shortcuts for longer commands, or to automatically add flags to existing commands.
+
+To manage command aliases, you use the `lxc alias` command.
+
+For example, to always ask for confirmation when deleting an instance, create an alias for `lxc delete` that always runs `lxc delete -i`:
+
+    lxc alias add delete "delete -i"
+
+To see all configured aliases, run `lxc alias list`.
+Run `lxc alias --help` to see all available subcommands.

--- a/doc/howto/server_configure.md
+++ b/doc/howto/server_configure.md
@@ -1,14 +1,38 @@
+(server-configure)=
 # How to configure the LXD server
 
-- Check configuration
-- Update configuration options
-- Edit full configuration
+See {ref}`server` for all configuration options that are available for the LXD server.
+
+If the LXD server is part of a cluster, some of the options apply to the cluster, while others apply only to the local server, thus the cluster member.
+In the {ref}`server` option tables, options that apply to the cluster are marked with a `global` scope, while options that apply to the local server are marked with a `local` scope.
+
+## Configure server options
 
 You can configure a server option with the following command:
 
     lxc config set <key> <value>
 
-If the LXD server is part of a cluster, some of the options apply to the cluster, while others apply only to the local server, thus the cluster member.
-Options marked with a `global` scope in the following tables are immediately applied to all cluster members.
-Options with a `local` scope must be set on a per-member basis.
-To do so, add the `--target` flag to the `lxc config set` command.
+For example, to allow remote access to the LXD server on port 8443, enter the following command:
+
+    lxc config set core.https_address :8443
+
+In a cluster setup, to configure a server option for a cluster member only, add the `--target` flag.
+For example, to configure where to store image tarballs on a specific cluster member, enter a command similar to the following:
+
+    lxc config set storage.images_volume my-pool/my-volume --target member02
+
+## Display the server configuration
+
+To display the current server configuration, enter the following command:
+
+    lxc config show
+
+In a cluster setup, to show the local configuration for a specific cluster member, add the `--target` flag.
+
+## Edit the full server configuration
+
+To edit the full server configuration as a YAML file, enter the following command:
+
+    lxc config edit
+
+In a cluster setup, to edit the local configuration for a specific cluster member, add the `--target` flag.

--- a/doc/howto/server_configure.md
+++ b/doc/howto/server_configure.md
@@ -1,0 +1,14 @@
+# How to configure the LXD server
+
+- Check configuration
+- Update configuration options
+- Edit full configuration
+
+You can configure a server option with the following command:
+
+    lxc config set <key> <value>
+
+If the LXD server is part of a cluster, some of the options apply to the cluster, while others apply only to the local server, thus the cluster member.
+Options marked with a `global` scope in the following tables are immediately applied to all cluster members.
+Options with a `local` scope must be set on a per-member basis.
+To do so, add the `--target` flag to the `lxc config set` command.

--- a/doc/index.md
+++ b/doc/index.md
@@ -51,6 +51,7 @@ The LXD project is sponsored by [Canonical Ltd](https://www.canonical.com).
 
 self
 getting_started
+Server and client <operation>
 security
 instances
 images
@@ -59,7 +60,7 @@ networks
 projects
 clustering
 production-setup
-operation
+migration
 restapi_landing
 internals
 external_resources

--- a/doc/installing.md
+++ b/doc/installing.md
@@ -124,6 +124,7 @@ sudo -E PATH=${PATH} LD_LIBRARY_PATH=${LD_LIBRARY_PATH} $(go env GOPATH)/bin/lxd
 If `newuidmap/newgidmap` tools are present on your system and `/etc/subuid`, `etc/subgid` exist, they must be configured to allow the root user a contiguous range of at least 10M UID/GID.
 ```
 
+(installing-upgrade)=
 ## Upgrade LXD
 
 After upgrading LXD to a newer version, LXD might need to update its database to a new schema.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -16,4 +16,5 @@ Access the console <howto/instances_console.md>
 Access files <howto/instances_access_files.md>
 Troubleshoot errors <howto/instances_troubleshoot.md>
 explanation/instance_config.md
+Container environment <container-environment>
 ```

--- a/doc/internals.md
+++ b/doc/internals.md
@@ -3,10 +3,8 @@
 ```{toctree}
 :maxdepth: 1
 
-Container environment <container-environment>
 daemon-behavior
-database
-debugging
+Debug LXD <debugging>
 environment
 syscall-interception
 User namespace setup <userns-idmap>

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -8,6 +8,7 @@ explanation/lxd_lxc
 database
 Configure the LXD server <howto/server_configure>
 Add remote servers <remotes>
+Add command aliases <howto/lxc_alias>
 server
 architectures
 ```

--- a/doc/operation.md
+++ b/doc/operation.md
@@ -1,10 +1,13 @@
-# Manage LXD
+(lxd-server)=
+# LXD server and client
 
 ```{toctree}
 :maxdepth: 1
 
+explanation/lxd_lxc
+database
+Configure the LXD server <howto/server_configure>
+Add remote servers <remotes>
 server
-remotes
-migration
 architectures
 ```

--- a/doc/remotes.md
+++ b/doc/remotes.md
@@ -1,66 +1,81 @@
 # How to add remote servers
 
-- concept of the client, not the server
-- list remotes
-- add a remote
-- add a global remote
-- switch to a remote
-- some explanation as below
-- link to info about remote image servers
+Remote servers are a concept in the LXD command-line client.
+By default, the command-line client interacts with the local LXD daemon, but you can add other servers or clusters to interact with.
 
-## Introduction
+One use case for remote servers is to distribute images that can be used to create instances on local servers.
+See {ref}`remote-image-servers` for more information.
 
-Remotes are a concept in the LXD command line client which are used to refer to various LXD servers or clusters.
-A remote is effectively a name pointing to the URL of a particular LXD server as well as needed credentials to login and authenticate the server.
-LXD has four types of remotes:
+You can also add a full LXD server as a remote server to your client.
+In this case, you can interact with the remote server in the same way as with your local daemon.
+For example, you can manage instances or update the server configuration on the remote server.
 
-- Static
-- Default
-- Global (per-system)
-- Local (per-user)
+## Authentication
 
-### Static
+To be able to add a LXD server as a remote server, the server's API must be exposed, which means that its [`core.https_address`](server-options-core) server configuration option must be set.
 
-Static remotes are:
+When adding the server, you must then authenticate with it using the chosen method for {ref}`authentication`.
 
-- `local` (default)
-- `ubuntu`
-- `ubuntu-daily`
+See {ref}`server-expose` for more information.
 
-They are hardcoded and can't be modified by the user.
+## List configured remotes
 
-### Default
+% Include parts of the content from file [howto/images_remote.md](howto/images_remote.md)
+```{include} howto/images_remote.md
+   :start-after: <!-- Include start list remotes -->
+   :end-before: <!-- Include end list remotes -->
+```
 
-Automatically added on first use.
+## Add a remote LXD server
 
-### Global (per-system)
+% Include parts of the content from file [howto/images_remote.md](howto/images_remote.md)
+```{include} howto/images_remote.md
+   :start-after: <!-- Include start add remotes -->
+   :end-before: <!-- Include end add remotes -->
+```
 
-By default the global configuration file is kept in either `/etc/lxd/config.yml`, or `/var/snap/lxd/common/global-conf/` for the snap version, or in `LXD_GLOBAL_CONF` if defined.
-The configuration file can be manually edited to add global remotes. Certificates for those remotes should be stored inside the `servercerts` directory (e.g. `/etc/lxd/servercerts/`) and match the remote name (e.g. `foo.crt`).
+## Select a default remote
 
-An example configuration is below:
+The LXD command-line client is pre-configured with the `local` remote, which is the local LXD daemon.
+
+To select a different remote as the default remote, enter the following command:
+
+    lxc remote switch <remote_name>
+
+To see which server is configured as the default remote, enter the following command:
+
+    lxc remote get-default
+
+## Configure a global remote
+
+You can configure remotes on a global, per-system basis.
+These remotes are available for every user of the LXD server for which you add the configuration.
+
+Users can override these system remotes (for example, by running `lxc remote rename` or `lxc remote set-url`), which results in the remote and its associated certificates being copied to the user configuration.
+
+To configure a global remote, edit the `config.yml` file that is located in one of the following directories:
+
+- the directory specified by `LXD_GLOBAL_CONF` (if defined)
+- `/var/snap/lxd/common/global-conf/` (if you use the snap)
+- `/etc/lxd/` (otherwise)
+
+Certificates for the remotes must be stored in the `servercerts` directory in the same location (for example, `/etc/lxd/servercerts/`).
+They must match the remote name (for example, `foo.crt`).
+
+See the following example configuration:
 
 ```
 remotes:
   foo:
-    addr: https://10.0.2.4:8443
+    addr: https://192.0.2.4:8443
     auth_type: tls
     project: default
     protocol: lxd
     public: false
   bar:
-    addr: https://10.0.2.5:8443
+    addr: https://192.0.2.5:8443
     auth_type: tls
     project: default
     protocol: lxd
     public: false
 ```
-
-### Local (per-user)
-
-Local level remotes are managed from the CLI (`lxc`) with:
-`lxc remote [command]`
-
-By default the configuration file is kept in `~/.config/lxc/config.yml`, or `~/snap/lxd/common/config/config.yml` for the snap version, or in `LXD_CONF` if defined.
-Users have the possibility to override system remotes (e.g. by running `lxc remote rename` or `lxc remote set-url`)
-which results in the remote being copied to their own configuration, including any associated certificates.

--- a/doc/remotes.md
+++ b/doc/remotes.md
@@ -1,4 +1,12 @@
-# Remotes
+# How to add remote servers
+
+- concept of the client, not the server
+- list remotes
+- add a remote
+- add a global remote
+- switch to a remote
+- some explanation as below
+- link to info about remote image servers
 
 ## Introduction
 

--- a/doc/server.md
+++ b/doc/server.md
@@ -3,15 +3,6 @@
 
 The LXD server can be configured through a set of key/value configuration options.
 
-You can configure a server option with the following command:
-
-    lxc config set <key> <value>
-
-If the LXD server is part of a cluster, some of the options apply to the cluster, while others apply only to the local server, thus the cluster member.
-Options marked with a `global` scope in the following tables are immediately applied to all cluster members.
-Options with a `local` scope must be set on a per-member basis.
-To do so, add the `--target` flag to the `lxc config set` command.
-
 The key/value configuration is namespaced.
 The following options are available:
 

--- a/doc/server.md
+++ b/doc/server.md
@@ -14,6 +14,13 @@ The following options are available:
 - {ref}`server-options-loki`
 - {ref}`server-options-misc`
 
+See {ref}`server-configure` for instructions on how to set the configuration options.
+
+```{note}
+Options marked with a `global` scope in the following tables are immediately applied to all cluster members.
+Options with a `local` scope must be set on a per-member basis.
+```
+
 (server-options-core)=
 ## Core configuration
 

--- a/doc/syscall-interception.md
+++ b/doc/syscall-interception.md
@@ -1,7 +1,7 @@
 # System call interception
 
 LXD supports intercepting some specific system calls from unprivileged
-containers and if they're considered to be safe, will executed with
+containers. If they're considered to be safe, it executes them with
 elevated privileges on the host.
 
 Doing so comes with a performance impact for the syscall in question and
@@ -108,7 +108,7 @@ The `setxattr` system call is used to set extended attributes on files.
 
 The attributes which are handled by this currently are:
 
-- trusted.overlay.opaque (overlayfs directory whiteout)
+- `trusted.overlay.opaque` (overlayfs directory whiteout)
 
 Note that because the mediation must happen on a number of character
 strings, there is no easy way at present to only intercept the few

--- a/doc/userns-idmap.md
+++ b/doc/userns-idmap.md
@@ -1,7 +1,5 @@
 # Idmaps for user namespace
 
-## Introduction
-
 LXD runs safe containers. This is achieved mostly through the use of
 user namespaces which make it possible to run containers unprivileged,
 greatly limiting the attack surface.


### PR DESCRIPTION
A draft PR to review the planned structure.
Does it make sense to move most of the internal information under a new "Server and client" section?
Also, is all of that information still correct and relevant, or should some of it just be removed? If so, I'd rather remove it before I clean it up. ;)

This commit does not add or update any content, but only moves existing content into new sections.
Cleanup will be done later.