### PR TITLE
Add support for browser OIDC login

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -75,6 +75,34 @@ func restServer(d *Daemon) *http.Server {
 		mux.PathPrefix("/ui/").Handler(http.StripPrefix("/ui/", http.FileServer(uiHttpDir)))
 	}
 
+	// OIDC browser login (code flow).
+	mux.HandleFunc("/oidc/login", func(w http.ResponseWriter, r *http.Request) {
+		if d.oidcVerifier == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		d.oidcVerifier.Login(w, r)
+	})
+
+	mux.HandleFunc("/oidc/callback", func(w http.ResponseWriter, r *http.Request) {
+		if d.oidcVerifier == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		d.oidcVerifier.Callback(w, r)
+	})
+
+	mux.HandleFunc("/oidc/logout", func(w http.ResponseWriter, r *http.Request) {
+		if d.oidcVerifier == nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		d.oidcVerifier.Logout(w, r)
+	})
+
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
+	"github.com/pborman/uuid"
 	"github.com/zitadel/oidc/v2/pkg/client"
 	"github.com/zitadel/oidc/v2/pkg/client/rp"
+	httphelper "github.com/zitadel/oidc/v2/pkg/http"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
 	"github.com/zitadel/oidc/v2/pkg/op"
 
@@ -19,30 +22,173 @@ type Verifier struct {
 	keySet   oidc.KeySet
 	verifier op.AccessTokenVerifier
 
-	clientID string
-	issuer   string
-	audience string
+	clientID  string
+	issuer    string
+	audience  string
+	cookieKey []byte
 }
 
 // Auth extracts the token, validates it and returns the user information.
-func (o *Verifier) Auth(ctx context.Context, r *http.Request) (string, error) {
-	// When a client wants to authenticate, it needs to set the Authorization HTTP header like this:
-	//    Authorization Bearer <access_token>
-	// If set correctly, LXD will attempt to verify the access token, and grant access if it's valid.
-	// If the verification fails, LXD will return an InvalidToken error. The client should then either use its refresh token to get a new valid access token, or log in again.
-	// If the Authorization header is missing, LXD returns an AuthenticationRequired error.
-	// Both returned errors contain information which are needed for the client to authenticate.
-	parts := strings.Split(r.Header.Get("Authorization"), "Bearer ")
-	if len(parts) != 2 {
-		return "", fmt.Errorf("Bad authorization token, expected a Bearer token")
+func (o *Verifier) Auth(ctx context.Context, w http.ResponseWriter, r *http.Request) (string, error) {
+	var token string
+
+	auth := r.Header.Get("Authorization")
+	if auth != "" {
+		// When a client wants to authenticate, it needs to set the Authorization HTTP header like this:
+		//    Authorization Bearer <access_token>
+		// If set correctly, LXD will attempt to verify the access token, and grant access if it's valid.
+		// If the verification fails, LXD will return an InvalidToken error. The client should then either use its refresh token to get a new valid access token, or log in again.
+		// If the Authorization header is missing, LXD returns an AuthenticationRequired error.
+		// Both returned errors contain information which are needed for the client to authenticate.
+		parts := strings.Split(auth, "Bearer ")
+		if len(parts) != 2 {
+			return "", fmt.Errorf("Bad authorization token, expected a Bearer token")
+		}
+
+		token = parts[1]
+	} else {
+		// When not using a Bearer token, fetch the equivalent from a cookie and move on with it.
+		cookie, err := r.Cookie("oidc_access")
+		if err != nil {
+			return "", err
+		}
+
+		token = cookie.Value
 	}
 
-	claims, err := o.VerifyAccessToken(ctx, parts[1])
+	claims, err := o.VerifyAccessToken(ctx, token)
 	if err != nil {
-		return "", err
+		// See if we can refresh the access token.
+		cookie, cookieErr := r.Cookie("oidc_refresh")
+		if cookieErr != nil {
+			return "", err
+		}
+
+		// Get the provider.
+		provider, err := o.getProvider(r)
+		if err != nil {
+			return "", err
+		}
+
+		// Attempt the refresh.
+		tokens, err := rp.RefreshAccessToken(provider, cookie.Value, "", "")
+		if err != nil {
+			return "", err
+		}
+
+		// Validate the refreshed token.
+		claims, err = o.VerifyAccessToken(ctx, tokens.AccessToken)
+		if err != nil {
+			return "", err
+		}
+
+		// Update the access token cookie.
+		accessCookie := http.Cookie{
+			Name:     "oidc_access",
+			Value:    tokens.AccessToken,
+			Path:     "/",
+			Secure:   true,
+			HttpOnly: false,
+			SameSite: http.SameSiteStrictMode,
+		}
+
+		http.SetCookie(w, &accessCookie)
+
+		// Update the refresh token cookie.
+		if tokens.RefreshToken != "" {
+			refreshCookie := http.Cookie{
+				Name:     "oidc_refresh",
+				Value:    tokens.RefreshToken,
+				Path:     "/",
+				Secure:   true,
+				HttpOnly: false,
+				SameSite: http.SameSiteStrictMode,
+			}
+
+			http.SetCookie(w, &refreshCookie)
+		}
 	}
 
 	return claims.Subject, nil
+}
+
+func (o *Verifier) Login(w http.ResponseWriter, r *http.Request) {
+	// Get the provider.
+	provider, err := o.getProvider(r)
+	if err != nil {
+		return
+	}
+
+	handler := rp.AuthURLHandler(func() string { return uuid.New() }, provider, rp.WithURLParam("audience", o.audience))
+	handler(w, r)
+}
+
+func (o *Verifier) Logout(w http.ResponseWriter, r *http.Request) {
+	// Access token.
+	accessCookie := http.Cookie{
+		Name:     "oidc_access",
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: false,
+		SameSite: http.SameSiteStrictMode,
+		Expires:  time.Unix(0, 0),
+	}
+
+	http.SetCookie(w, &accessCookie)
+
+	// Refresh token.
+	refreshCookie := http.Cookie{
+		Name:     "oidc_refresh",
+		Path:     "/",
+		Secure:   true,
+		HttpOnly: false,
+		SameSite: http.SameSiteStrictMode,
+		Expires:  time.Unix(0, 0),
+	}
+
+	http.SetCookie(w, &refreshCookie)
+}
+
+func (o *Verifier) Callback(w http.ResponseWriter, r *http.Request) {
+	// Get the provider.
+	provider, err := o.getProvider(r)
+	if err != nil {
+		return
+	}
+
+	handler := rp.CodeExchangeHandler(func(w http.ResponseWriter, r *http.Request, tokens *oidc.Tokens[*oidc.IDTokenClaims], state string, rp rp.RelyingParty) {
+		// Access token.
+		accessCookie := http.Cookie{
+			Name:     "oidc_access",
+			Value:    tokens.AccessToken,
+			Path:     "/",
+			Secure:   true,
+			HttpOnly: false,
+			SameSite: http.SameSiteStrictMode,
+		}
+
+		http.SetCookie(w, &accessCookie)
+
+		// Refresh token.
+		if tokens.RefreshToken != "" {
+			refreshCookie := http.Cookie{
+				Name:     "oidc_refresh",
+				Value:    tokens.RefreshToken,
+				Path:     "/",
+				Secure:   true,
+				HttpOnly: false,
+				SameSite: http.SameSiteStrictMode,
+			}
+
+			http.SetCookie(w, &refreshCookie)
+		}
+
+		// Send to the UI.
+		// NOTE: Once the UI does the redirection on its own, we may be able to use the referer here instead.
+		http.Redirect(w, r, "/ui/", 301)
+	}, provider)
+
+	handler(w, r)
 }
 
 // VerifyAccessToken is a wrapper around op.VerifyAccessToken which avoids having to deal with Go generics elsewhere. It validates the access token (issuer, signature and expiration).
@@ -72,7 +218,34 @@ func (o *Verifier) WriteHeaders(w http.ResponseWriter) error {
 
 // IsRequest checks if the request is using OIDC authentication.
 func (o *Verifier) IsRequest(r *http.Request) bool {
-	return r.Header.Get("Authorization") != ""
+	if r.Header.Get("Authorization") != "" {
+		return true
+	}
+
+	cookie, err := r.Cookie("oidc_access")
+	if err == nil && cookie != nil {
+		return true
+	}
+
+	return false
+}
+
+func (o *Verifier) getProvider(r *http.Request) (rp.RelyingParty, error) {
+	cookieHandler := httphelper.NewCookieHandler(o.cookieKey, o.cookieKey, httphelper.WithUnsecure())
+	options := []rp.Option{
+		rp.WithCookieHandler(cookieHandler),
+		rp.WithVerifierOpts(rp.WithIssuedAtOffset(5 * time.Second)),
+		rp.WithPKCE(cookieHandler),
+	}
+
+	oidcScopes := []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess}
+
+	provider, err := rp.NewRelyingPartyOIDC(o.issuer, o.clientID, "", fmt.Sprintf("https://%s/oidc/callback", r.Host), oidcScopes, options...)
+	if err != nil {
+		return nil, err
+	}
+
+	return provider, nil
 }
 
 // NewVerifier returns a Verifier. It calls the OIDC discovery endpoint in order to get the issuer's remote keys which are needed to verify an issued access token.
@@ -84,6 +257,7 @@ func NewVerifier(issuer string, clientid string, audience string) (*Verifier, er
 
 	keySet := rp.NewRemoteKeySet(http.DefaultClient, discoveryConfig.JwksURI)
 	verifier := op.NewAccessTokenVerifier(issuer, keySet)
+	cookieKey := []byte(uuid.New())[0:16]
 
-	return &Verifier{keySet: keySet, verifier: verifier, issuer: issuer, clientID: clientid, audience: audience}, nil
+	return &Verifier{keySet: keySet, verifier: verifier, issuer: issuer, clientID: clientid, audience: audience, cookieKey: cookieKey}, nil
 }

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -329,7 +329,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	}
 
 	if d.oidcVerifier != nil && d.oidcVerifier.IsRequest(r) {
-		userName, err := d.oidcVerifier.Auth(d.shutdownCtx, r)
+		userName, err := d.oidcVerifier.Auth(d.shutdownCtx, w, r)
 		if err != nil {
 			return false, "", "", err
 		}


### PR DESCRIPTION
This introduces a few API routes:
 - /oidc/login
 - /oidc/callback (internal)
 - /oidc/logout

And effectively allows someone to navigate to `/oidc/login`, go through the OIDC login flow and then get back to LXD with a valid set of cookies used to authenticate against LXD.

Code changes are relatively minimal on the LXD side, effectively keeping most of it in the OIDC auth package.