### PR TITLE
oidc: Use email scope/claim

### DIFF
--- a/client/lxd_oidc.go
+++ b/client/lxd_oidc.go
@@ -61,7 +61,7 @@ func (o *oidcTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 }
 
 var errRefreshAccessToken = fmt.Errorf("Failed refreshing access token")
-var oidcScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess}
+var oidcScopes = []string{oidc.ScopeOpenID, oidc.ScopeOfflineAccess, oidc.ScopeEmail}
 
 type oidcClient struct {
 	httpClient    *http.Client

--- a/lxd/auth/oidc/oidc.go
+++ b/lxd/auth/oidc/oidc.go
@@ -42,6 +42,11 @@ func (o *Verifier) Auth(ctx context.Context, r *http.Request) (string, error) {
 		return "", err
 	}
 
+	user, ok := claims.Claims["email"]
+	if ok && user != nil && user.(string) != "" {
+		return user.(string), nil
+	}
+
 	return claims.Subject, nil
 }
 


### PR DESCRIPTION
This makes use of the email scope/claim which makes it easier to identify the user.
