### PR TITLE
oidc: Always set OIDC headers if needed in case of an error

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -457,6 +457,11 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c APIEndpoint) {
 			// If not a macaroon discharge request, return the error
 			_, ok := err.(*bakery.DischargeRequiredError)
 			if !ok {
+				// Ensure the OIDC headers are set if needed.
+				if d.oidcVerifier != nil {
+					_ = d.oidcVerifier.WriteHeaders(w)
+				}
+
 				_ = response.InternalError(err).Render(w)
 				return
 			}


### PR DESCRIPTION
This fixes a bug where the client would be unable to refresh the access
token as the server failed to send any OIDC information.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
