### PR TITLE
oidc: Return and handle Unauthorized error

### DIFF
--- a/client/lxd_oidc.go
+++ b/client/lxd_oidc.go
@@ -19,6 +19,8 @@ import (
 	httphelper "github.com/zitadel/oidc/v2/pkg/http"
 	"github.com/zitadel/oidc/v2/pkg/oidc"
 	"golang.org/x/oauth2"
+
+	"github.com/lxc/lxd/shared/api"
 )
 
 func (r *ProtocolLXD) setupOIDCClient(token *oidc.Tokens[*oidc.IDTokenClaims]) {
@@ -112,6 +114,11 @@ func (o *oidcClient) do(req *http.Request) (*http.Response, error) {
 	if err == nil {
 		resp.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 		return resp, nil
+	}
+
+	// Return immediately if the error is not HTTP status unauthorized.
+	if !api.StatusErrorCheck(err, http.StatusUnauthorized) {
+		return nil, err
 	}
 
 	issuer := resp.Header.Get("X-LXD-OIDC-issuer")

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -549,3 +549,13 @@ func (r *manualResponse) Render(w http.ResponseWriter) error {
 func (r *manualResponse) String() string {
 	return "unknown"
 }
+
+// Unauthorized return an unauthorized response (401) with the given error.
+func Unauthorized(err error) Response {
+	message := "unauthorized"
+	if err != nil {
+		message = err.Error()
+	}
+
+	return &errorResponse{http.StatusUnauthorized, message}
+}


### PR DESCRIPTION
This changes the behaviour of OIDC in that it only tries to authenticate if the server returns Unauthorized (401). All other errors will be returned immediately.
