### PR TITLE
Instance: Fix VM /dev/lxd connections from lxd-agent to LXD on host when nesting

### DIFF
--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -8,10 +8,12 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/mdlayher/vsock"
+
 	"github.com/lxc/lxd/client"
 	agentAPI "github.com/lxc/lxd/lxd-agent/api"
 	"github.com/lxc/lxd/lxd/response"
-	"github.com/lxc/lxd/lxd/vsock"
+	lxdvsock "github.com/lxc/lxd/lxd/vsock"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -180,7 +182,7 @@ func getClient(CID int, port int, serverCertificate string) (*http.Client, error
 		return nil, err
 	}
 
-	client, err := vsock.HTTPClient(CID, port, string(agentCert), string(agentKey), serverCertificate)
+	client, err := lxdvsock.HTTPClient(CID, port, string(agentCert), string(agentKey), serverCertificate)
 	if err != nil {
 		return nil, err
 	}
@@ -189,8 +191,8 @@ func getClient(CID int, port int, serverCertificate string) (*http.Client, error
 }
 
 func startHTTPServer(d *Daemon, debug bool) error {
-	// Setup the listener.
-	l, err := vsock.Listen(shared.HTTPSDefaultPort)
+	// Setup the listener on VM's context ID for inbound connections from LXD.
+	l, err := vsock.Listen(shared.HTTPSDefaultPort, nil)
 	if err != nil {
 		return fmt.Errorf("Failed to listen on vsock: %w", err)
 	}

--- a/lxd/endpoints/endpoints.go
+++ b/lxd/endpoints/endpoints.go
@@ -191,7 +191,7 @@ func (e *Endpoints) up(config *Config) error {
 		pprof:          pprofCreateServer(),
 		metrics:        config.MetricsServer,
 		storageBuckets: config.StorageBucketsServer,
-		vsock:          config.VsockServer,
+		vmvsock:        config.VsockServer,
 	}
 
 	e.cert = config.Cert
@@ -228,7 +228,7 @@ func (e *Endpoints) up(config *Config) error {
 
 	// Start the VM sock listener.
 	if config.VsockSupport {
-		e.listeners[vsock], err = createVsockListener(e.cert)
+		e.listeners[vmvsock], err = createVsockListener(e.cert)
 		if err != nil {
 			return err
 		}
@@ -334,8 +334,8 @@ func (e *Endpoints) up(config *Config) error {
 		e.serve(storageBuckets)
 	}
 
-	if e.listeners[vsock] != nil {
-		e.serve(vsock)
+	if e.listeners[vmvsock] != nil {
+		e.serve(vmvsock)
 	}
 
 	e.serve(devlxd)
@@ -398,8 +398,8 @@ func (e *Endpoints) Down() error {
 		}
 	}
 
-	if e.listeners[vsock] != nil {
-		err := e.closeListener(vsock)
+	if e.listeners[vmvsock] != nil {
+		err := e.closeListener(vmvsock)
 		if err != nil {
 			return err
 		}
@@ -494,7 +494,7 @@ const (
 	pprof
 	cluster
 	metrics
-	vsock
+	vmvsock
 	storageBuckets
 )
 
@@ -506,6 +506,6 @@ var descriptions = map[kind]string{
 	pprof:          "pprof socket",
 	cluster:        "cluster socket",
 	metrics:        "metrics socket",
-	vsock:          "VM socket",
+	vmvsock:        "VM socket",
 	storageBuckets: "Storage buckets socket",
 }

--- a/lxd/endpoints/vsock.go
+++ b/lxd/endpoints/vsock.go
@@ -8,10 +8,10 @@ import (
 	"math/rand"
 	"net"
 
+	"github.com/mdlayher/vsock"
 	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/lxd/util"
-	lxdvsock "github.com/lxc/lxd/lxd/vsock"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -20,7 +20,8 @@ func createVsockListener(cert *shared.CertInfo) (net.Listener, error) {
 		// Get random port between 1024 and 65535.
 		port := 1024 + rand.Int31n(math.MaxUint16-1024)
 
-		listener, err := lxdvsock.Listen(uint32(port))
+		// Setup listener on host context ID for inbound connections from lxd-agent running inside VMs.
+		listener, err := vsock.ListenContextID(vsock.Host, uint32(port), nil)
 		if err != nil {
 			// Try a different port.
 			if errors.Is(err, unix.EADDRINUSE) {

--- a/lxd/endpoints/vsock.go
+++ b/lxd/endpoints/vsock.go
@@ -41,7 +41,7 @@ func (e *Endpoints) VsockAddress() net.Addr {
 	e.mu.RLock()
 	defer e.mu.RUnlock()
 
-	listener := e.listeners[vsock]
+	listener := e.listeners[vmvsock]
 	if listener == nil {
 		return nil
 	}

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1797,7 +1797,7 @@ func (d *qemu) getAgentConnectionInfo() (*agentAPI.API10Put, error) {
 	req := agentAPI.API10Put{
 		Certificate: string(d.state.Endpoints.NetworkCert().PublicKey()),
 		Devlxd:      shared.IsTrueOrEmpty(d.expandedConfig["security.devlxd"]),
-		CID:         vsockaddr.ContextID,
+		CID:         vsock.Host, // Always tell lxd-agent to connect to LXD using Host Context ID to support nesting.
 		Port:        vsockaddr.Port,
 	}
 

--- a/lxd/vsock/vsock.go
+++ b/lxd/vsock/vsock.go
@@ -22,11 +22,6 @@ func Dial(cid, port uint32) (net.Conn, error) {
 	return vsock.Dial(cid, port, nil)
 }
 
-// Listen listens for a connection.
-func Listen(port uint32) (net.Listener, error) {
-	return vsock.Listen(port, nil)
-}
-
 // HTTPClient provides an HTTP client for using over vsock.
 func HTTPClient(vsockID int, port int, tlsClientCert string, tlsClientKey string, tlsServerCert string) (*http.Client, error) {
 	client := &http.Client{}


### PR DESCRIPTION
LXD will now always listen on the special "host" vsock context ID, even when nesting (rather than listening on the VM's context ID) which means that it will be reachable from the lxd-agent when nesting as well. 