### PR TITLE
cluster: Disable cluster group creation by anyone authenticated

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -108,7 +108,7 @@ var clusterGroupsCmd = APIEndpoint{
 	Path: "cluster/groups",
 
 	Get:  APIEndpointAction{Handler: clusterGroupsGet, AccessHandler: allowAuthenticated},
-	Post: APIEndpointAction{Handler: clusterGroupsPost, AccessHandler: allowAuthenticated},
+	Post: APIEndpointAction{Handler: clusterGroupsPost},
 }
 
 var clusterGroupCmd = APIEndpoint{


### PR DESCRIPTION
This removes the ability to create cluster groups when simply
authenticated. This action should be reserved for admins only.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
