### PR TITLE
Instance: Fix incorrect vm vsock listener certificate for lxd-agent /dev/lxd when setting up a cluster

### DIFF
--- a/lxd-agent/devlxd.go
+++ b/lxd-agent/devlxd.go
@@ -59,7 +59,7 @@ func getVsockClient(d *Daemon) (lxd.InstanceServer, error) {
 var devlxdConfigGet = devLxdHandler{"/1.0/config", func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
 	}
 
 	defer client.Disconnect()
@@ -73,7 +73,7 @@ var devlxdConfigGet = devLxdHandler{"/1.0/config", func(d *Daemon, w http.Respon
 
 	err = resp.MetadataAsStruct(&config)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed parsing response from LXD: %w", err))
 	}
 
 	filtered := []string{}
@@ -97,7 +97,7 @@ var devlxdConfigKeyGet = devLxdHandler{"/1.0/config/{key}", func(d *Daemon, w ht
 
 	client, err := getVsockClient(d)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
 	}
 
 	defer client.Disconnect()
@@ -111,7 +111,7 @@ var devlxdConfigKeyGet = devLxdHandler{"/1.0/config/{key}", func(d *Daemon, w ht
 
 	err = resp.MetadataAsStruct(&value)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed parsing response from LXD: %w", err))
 	}
 
 	return okResponse(value, "raw")
@@ -131,7 +131,7 @@ var devlxdMetadataGet = devLxdHandler{"/1.0/meta-data", func(d *Daemon, w http.R
 	}
 
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
 	}
 
 	defer client.Disconnect()
@@ -145,7 +145,7 @@ var devlxdMetadataGet = devLxdHandler{"/1.0/meta-data", func(d *Daemon, w http.R
 
 	err = resp.MetadataAsStruct(&metaData)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed parsing response from LXD: %w", err))
 	}
 
 	return okResponse(metaData, "raw")
@@ -163,7 +163,7 @@ var devLxdEventsGet = devLxdHandler{"/1.0/events", func(d *Daemon, w http.Respon
 var devlxdAPIGet = devLxdHandler{"/1.0", func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
 	}
 
 	defer client.Disconnect()
@@ -178,7 +178,7 @@ var devlxdAPIGet = devLxdHandler{"/1.0", func(d *Daemon, w http.ResponseWriter, 
 
 		err = resp.MetadataAsStruct(&instanceData)
 		if err != nil {
-			return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+			return smartResponse(fmt.Errorf("Failed parsing response from LXD: %w", err))
 		}
 
 		return okResponse(instanceData, "json")
@@ -197,7 +197,7 @@ var devlxdAPIGet = devLxdHandler{"/1.0", func(d *Daemon, w http.ResponseWriter, 
 var devlxdDevicesGet = devLxdHandler{"/1.0/devices", func(d *Daemon, w http.ResponseWriter, r *http.Request) *devLxdResponse {
 	client, err := getVsockClient(d)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed connecting to LXD over vsock: %w", err))
 	}
 
 	defer client.Disconnect()
@@ -211,7 +211,7 @@ var devlxdDevicesGet = devLxdHandler{"/1.0/devices", func(d *Daemon, w http.Resp
 
 	err = resp.MetadataAsStruct(&devices)
 	if err != nil {
-		return &devLxdResponse{"internal server error", http.StatusInternalServerError, "raw"}
+		return smartResponse(fmt.Errorf("Failed parsing response from LXD: %w", err))
 	}
 
 	return okResponse(devices, "json")

--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -137,15 +137,12 @@ func (e *Endpoints) NetworkUpdateCert(cert *shared.CertInfo) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.cert = cert
-	listener, ok := e.listeners[network]
-	if ok {
-		listener.(*listeners.FancyTLSListener).Config(cert)
-	}
 
-	// Update the cluster listener too, if enabled.
-	listener, ok = e.listeners[cluster]
-	if ok {
-		listener.(*listeners.FancyTLSListener).Config(cert)
+	for _, listenerKey := range []kind{network, cluster, vmvsock, storageBuckets, metrics} {
+		listener, found := e.listeners[listenerKey]
+		if found {
+			listener.(*listeners.FancyTLSListener).Config(cert)
+		}
 	}
 }
 

--- a/lxd/endpoints/vsock.go
+++ b/lxd/endpoints/vsock.go
@@ -1,7 +1,6 @@
 package endpoints
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"math"
@@ -11,7 +10,7 @@ import (
 	"github.com/mdlayher/vsock"
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/lxd/endpoints/listeners"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -31,7 +30,7 @@ func createVsockListener(cert *shared.CertInfo) (net.Listener, error) {
 			return nil, err
 		}
 
-		return tls.NewListener(listener, util.ServerTLSConfig(cert)), nil
+		return listeners.NewFancyTLSListener(listener, cert), nil
 	}
 
 	return nil, fmt.Errorf("Failed finding free listen port for vsock listener")


### PR DESCRIPTION
The VM lxd-agent /dev/lxd service was not working for VMs launched on the first member of a cluster after it had been initially switched to a cluster member after the cluster was created. This is because the vm vsock listener was still using the old server certificate and not the new cluster certificate.

Also fixes same issue for storage buckets and metrics API listeners.