### PR TITLE
lxd: Prevent any authenticated user from editing project config

### DIFF
--- a/lxd/api_project.go
+++ b/lxd/api_project.go
@@ -44,9 +44,9 @@ var projectCmd = APIEndpoint{
 
 	Delete: APIEndpointAction{Handler: projectDelete},
 	Get:    APIEndpointAction{Handler: projectGet, AccessHandler: allowAuthenticated},
-	Patch:  APIEndpointAction{Handler: projectPatch, AccessHandler: allowAuthenticated},
+	Patch:  APIEndpointAction{Handler: projectPatch},
 	Post:   APIEndpointAction{Handler: projectPost},
-	Put:    APIEndpointAction{Handler: projectPut, AccessHandler: allowAuthenticated},
+	Put:    APIEndpointAction{Handler: projectPut},
 }
 
 var projectStateCmd = APIEndpoint{


### PR DESCRIPTION
Changing a project's configuration shouldn't be allowed to be done by
any authenticated user. This fix restricts project configuration edits
to the admin only.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
