### PR TITLE
Pass state instead of daemon if possible

### DIFF
--- a/lxd/acme.go
+++ b/lxd/acme.go
@@ -126,7 +126,7 @@ func autoRenewCertificate(ctx context.Context, d *Daemon, force bool) error {
 				ClusterCertificateKey: string(newCert.PrivateKey),
 			}
 
-			err = updateClusterCertificate(d.shutdownCtx, d, nil, req)
+			err = updateClusterCertificate(d.shutdownCtx, s, d.gateway, nil, req)
 			if err != nil {
 				return err
 			}

--- a/lxd/api.go
+++ b/lxd/api.go
@@ -159,7 +159,7 @@ func restServer(d *Daemon) *http.Server {
 
 func hoistReqVM(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, r *http.Request) {
-		trusted, inst, err := authenticateAgentCert(d, r)
+		trusted, inst, err := authenticateAgentCert(d.State(), r)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -750,7 +750,7 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 		case "candid.api.url":
 			candidChanged = true
 		case "cluster.images_minimal_replica":
-			err := autoSyncImages(d.shutdownCtx, d)
+			err := autoSyncImages(d.shutdownCtx, s)
 			if err != nil {
 				logger.Warn("Could not auto-sync images", logger.Ctx{"err": err})
 			}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -802,7 +802,7 @@ func clusterPutJoin(d *Daemon, r *http.Request, req api.ClusterPut) response.Res
 		}
 
 		// Ensure all images are available after this node has joined.
-		err = autoSyncImages(d.shutdownCtx, d)
+		err = autoSyncImages(d.shutdownCtx, s)
 		if err != nil {
 			logger.Warn("Failed to sync images")
 		}
@@ -1996,7 +1996,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 
 	logger.Info("Deleting member from cluster", logger.Ctx{"name": name, "force": force})
 
-	err = autoSyncImages(d.shutdownCtx, d)
+	err = autoSyncImages(d.shutdownCtx, s)
 	if err != nil {
 		if force == 0 {
 			return response.SmartError(fmt.Errorf("Failed to sync images: %w", err))
@@ -2095,7 +2095,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	updateCertificateCache(d)
 
 	// Ensure all images are available after this node has been deleted.
-	err = autoSyncImages(d.shutdownCtx, d)
+	err = autoSyncImages(d.shutdownCtx, s)
 	if err != nil {
 		logger.Warn("Failed to sync images")
 	}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -1330,7 +1330,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 	// Remove any existing join tokens for the requested cluster member, this way we only ever have one active
 	// join token for each potential new member, and it has the most recent active members list for joining.
 	// This also ensures any historically unused (but potentially published) join tokens are removed.
-	ops, err := operationsGetByType(d, r, project.Default, operationtype.ClusterJoinToken)
+	ops, err := operationsGetByType(s, r, project.Default, operationtype.ClusterJoinToken)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed getting cluster join token operations: %w", err))
 	}
@@ -1348,7 +1348,7 @@ func clusterNodesPost(d *Daemon, r *http.Request) response.Response {
 		if opServerName == req.ServerName {
 			// Join token operation matches requested server name, so lets cancel it.
 			logger.Warn("Cancelling duplicate join token operation", logger.Ctx{"operation": op.ID, "serverName": opServerName})
-			err = operationCancel(d, r, project.Default, op)
+			err = operationCancel(s, r, project.Default, op)
 			if err != nil {
 				return response.InternalError(fmt.Errorf("Failed to cancel operation %q: %w", op.ID, err))
 			}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -579,12 +579,10 @@ func internalSQLExec(tx *sql.Tx, query string, result *internalSQLResult) error 
 
 // internalImportFromBackup creates instance, storage pool and volume DB records from an instance's backup file.
 // It expects the instance volume to be mounted so that the backup.yaml file is readable.
-func internalImportFromBackup(d *Daemon, projectName string, instName string, force bool, allowNameOverride bool) error {
+func internalImportFromBackup(s *state.State, projectName string, instName string, force bool, allowNameOverride bool) error {
 	if instName == "" {
 		return fmt.Errorf("The name of the instance is required")
 	}
-
-	s := d.State()
 
 	storagePoolsPath := shared.VarPath("storage-pools")
 	storagePoolsDir, err := os.Open(storagePoolsPath)
@@ -704,7 +702,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 
 	// Check if a storage volume entry for the instance already exists.
 	var dbVolume *db.StorageVolume
-	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, instanceDBVolType, backupConf.Container.Name, true)
 		if err != nil && !response.IsNotFoundError(err) {
 			return err
@@ -722,7 +720,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 	}
 
 	// Check if an entry for the instance already exists in the db.
-	_, instanceErr := d.db.Cluster.GetInstanceID(projectName, backupConf.Container.Name)
+	_, instanceErr := s.DB.Cluster.GetInstanceID(projectName, backupConf.Container.Name)
 	if instanceErr != nil && !response.IsNotFoundError(instanceErr) {
 		return instanceErr
 	}
@@ -746,7 +744,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 		}
 
 		// Remove the storage volume db entry for the instance since force was specified.
-		err := d.db.Cluster.RemoveStoragePoolVolume(projectName, backupConf.Container.Name, instanceDBVolType, pool.ID())
+		err := s.DB.Cluster.RemoveStoragePoolVolume(projectName, backupConf.Container.Name, instanceDBVolType, pool.ID())
 		if err != nil {
 			return err
 		}
@@ -754,7 +752,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 
 	if instanceErr == nil {
 		// Remove the storage volume db entry for the instance since force was specified.
-		err := d.db.Cluster.DeleteInstance(projectName, backupConf.Container.Name)
+		err := s.DB.Cluster.DeleteInstance(projectName, backupConf.Container.Name)
 		if err != nil {
 			return err
 		}
@@ -811,7 +809,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 		snapInstName := fmt.Sprintf("%s%s%s", backupConf.Container.Name, shared.SnapshotDelimiter, snap.Name)
 
 		// Check if an entry for the snapshot already exists in the db.
-		_, snapErr := d.db.Cluster.GetInstanceSnapshotID(projectName, backupConf.Container.Name, snap.Name)
+		_, snapErr := s.DB.Cluster.GetInstanceSnapshotID(projectName, backupConf.Container.Name, snap.Name)
 		if snapErr != nil && !response.IsNotFoundError(snapErr) {
 			return snapErr
 		}
@@ -823,7 +821,7 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 
 		// Check if a storage volume entry for the snapshot already exists.
 		var dbVolume *db.StorageVolume
-		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			dbVolume, err = tx.GetStoragePoolVolume(ctx, pool.ID(), projectName, instanceDBVolType, snapInstName, true)
 			if err != nil && !response.IsNotFoundError(err) {
 				return err
@@ -841,14 +839,14 @@ func internalImportFromBackup(d *Daemon, projectName string, instName string, fo
 		}
 
 		if snapErr == nil {
-			err := d.db.Cluster.DeleteInstance(projectName, snapInstName)
+			err := s.DB.Cluster.DeleteInstance(projectName, snapInstName)
 			if err != nil {
 				return err
 			}
 		}
 
 		if dbVolume != nil {
-			err := d.db.Cluster.RemoveStoragePoolVolume(projectName, snapInstName, instanceDBVolType, pool.ID())
+			err := s.DB.Cluster.RemoveStoragePoolVolume(projectName, snapInstName, instanceDBVolType, pool.ID())
 			if err != nil {
 				return err
 			}

--- a/lxd/api_internal_recover.go
+++ b/lxd/api_internal_recover.go
@@ -69,9 +69,7 @@ type internalRecoverImportPost struct {
 }
 
 // internalRecoverScan provides the discovery and import functionality for both recovery validate and import steps.
-func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOnly bool) response.Response {
-	s := d.State()
-
+func internalRecoverScan(s *state.State, userPools []api.StoragePoolsPost, validateOnly bool) response.Response {
 	var err error
 	var projects map[string]*api.Project
 	var projectProfiles map[string][]*api.Profile
@@ -130,7 +128,7 @@ func internalRecoverScan(d *Daemon, userPools []api.StoragePoolsPost, validateOn
 		return response.SmartError(fmt.Errorf("Failed getting validate dependency check info: %w", err))
 	}
 
-	isClustered, err := cluster.Enabled(d.db.Node)
+	isClustered, err := cluster.Enabled(s.DB.Node)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -571,7 +569,7 @@ func internalRecoverValidate(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	return internalRecoverScan(d, req.Pools, true)
+	return internalRecoverScan(d.State(), req.Pools, true)
 }
 
 // internalRecoverImport performs the pool volume recovery.
@@ -583,5 +581,5 @@ func internalRecoverImport(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	return internalRecoverScan(d, req.Pools, false)
+	return internalRecoverScan(d.State(), req.Pools, false)
 }

--- a/lxd/api_vsock.go
+++ b/lxd/api_vsock.go
@@ -9,12 +9,11 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
 )
 
-func authenticateAgentCert(d *Daemon, r *http.Request) (bool, instance.Instance, error) {
-	s := d.State()
-
+func authenticateAgentCert(s *state.State, r *http.Request) (bool, instance.Instance, error) {
 	var vsockID int
 	trusted := false
 

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -307,7 +307,7 @@ func updateCertificateCacheFromLocal(d *Daemon) error {
 // clusterMemberJoinTokenValid searches for cluster join token that matches the join token provided.
 // Returns matching operation if found and cancels the operation, otherwise returns nil.
 func clusterMemberJoinTokenValid(d *Daemon, r *http.Request, projectName string, joinToken *api.ClusterMemberJoinToken) (*api.Operation, error) {
-	ops, err := operationsGetByType(d, r, projectName, operationtype.ClusterJoinToken)
+	ops, err := operationsGetByType(d.State(), r, projectName, operationtype.ClusterJoinToken)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting cluster join token operations: %w", err)
 	}
@@ -340,7 +340,7 @@ func clusterMemberJoinTokenValid(d *Daemon, r *http.Request, projectName string,
 
 	if foundOp != nil {
 		// Token is single-use, so cancel it now.
-		err = operationCancel(d, r, projectName, foundOp)
+		err = operationCancel(d.State(), r, projectName, foundOp)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to cancel operation %q: %w", foundOp.ID, err)
 		}
@@ -372,7 +372,7 @@ func clusterMemberJoinTokenValid(d *Daemon, r *http.Request, projectName string,
 // certificateTokenValid searches for certificate token that matches the add token provided.
 // Returns matching operation if found and cancels the operation, otherwise returns nil.
 func certificateTokenValid(d *Daemon, r *http.Request, addToken *api.CertificateAddToken) (*api.Operation, error) {
-	ops, err := operationsGetByType(d, r, project.Default, operationtype.CertificateAddToken)
+	ops, err := operationsGetByType(d.State(), r, project.Default, operationtype.CertificateAddToken)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting certificate token operations: %w", err)
 	}
@@ -396,7 +396,7 @@ func certificateTokenValid(d *Daemon, r *http.Request, addToken *api.Certificate
 
 	if foundOp != nil {
 		// Token is single-use, so cancel it now.
-		err = operationCancel(d, r, project.Default, foundOp)
+		err = operationCancel(d.State(), r, project.Default, foundOp)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to cancel operation %q: %w", foundOp.ID, err)
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1638,7 +1638,7 @@ func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
 	if d.gateway != nil {
 		d.stopClusterTasks()
 
-		err := handoverMemberRole(d)
+		err := handoverMemberRole(d.State(), d.gateway)
 		if err != nil {
 			logger.Warn("Could not handover member's responsibilities", logger.Ctx{"err": err})
 			d.gateway.Kill()
@@ -2132,7 +2132,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		if isDegraded || onlineVoters < int(maxVoters) || onlineStandbys < int(maxStandBy) {
 			d.clusterMembershipMutex.Lock()
 			logger.Debug("Rebalancing member roles in heartbeat", logger.Ctx{"local": localClusterAddress})
-			err := rebalanceMemberRoles(d, nil, unavailableMembers)
+			err := rebalanceMemberRoles(d.State(), d.gateway, nil, unavailableMembers)
 			if err != nil && !errors.Is(err, cluster.ErrNotLeader) {
 				logger.Warn("Could not rebalance cluster member roles", logger.Ctx{"err": err, "local": localClusterAddress})
 			}
@@ -2143,7 +2143,7 @@ func (d *Daemon) nodeRefreshTask(heartbeatData *cluster.APIHeartbeat, isLeader b
 		if hasNodesNotPartOfRaft {
 			d.clusterMembershipMutex.Lock()
 			logger.Debug("Upgrading members without raft role in heartbeat", logger.Ctx{"local": localClusterAddress})
-			err := upgradeNodesWithoutRaftRole(d)
+			err := upgradeNodesWithoutRaftRole(d.State(), d.gateway)
 			if err != nil && !errors.Is(err, cluster.ErrNotLeader) {
 				logger.Warn("Failed upgrading raft roles:", logger.Ctx{"err": err, "local": localClusterAddress})
 			}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1426,7 +1426,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Cleanup leftover images.
-	pruneLeftoverImages(d)
+	pruneLeftoverImages(d.State())
 
 	var instances []instance.Instance
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1034,7 +1034,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			r.Body = post
-			resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+			resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
 			if err != nil {
 				cleanup(builddir, post)
 				return response.SmartError(err)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -192,9 +192,7 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
  * This function takes a container or snapshot from the local image server and
  * exports it as an image.
  */
-func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operations.Operation, builddir string, budget int64) (*api.Image, error) {
-	s := d.State()
-
+func imgPostInstanceInfo(s *state.State, r *http.Request, req api.ImagesPost, op *operations.Operation, builddir string, budget int64) (*api.Image, error) {
 	info := api.Image{}
 	info.Properties = map[string]string{}
 	projectName := projectParam(r)
@@ -287,7 +285,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 		compress = req.CompressionAlgorithm
 	} else {
 		var p *api.Project
-		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			project, err := dbCluster.GetProject(ctx, tx.Tx(), projectName)
 			if err != nil {
 				return err
@@ -368,7 +366,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	info.Fingerprint = fmt.Sprintf("%x", sha256.Sum(nil))
 	info.CreatedAt = time.Now().UTC()
 
-	_, _, err = d.db.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &projectName})
+	_, _, err = s.DB.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &projectName})
 	if !response.IsNotFoundError(err) {
 		if err != nil {
 			return nil, err
@@ -388,7 +386,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	info.Properties = meta.Properties
 
 	// Create the database entry
-	err = d.db.Cluster.CreateImage(c.Project().Name, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
+	err = s.DB.Cluster.CreateImage(c.Project().Name, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +394,7 @@ func imgPostInstanceInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *ope
 	return &info, nil
 }
 
-func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
+func imgPostRemoteInfo(s *state.State, r *http.Request, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
 	var err error
 	var hash string
 
@@ -407,8 +405,6 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 	} else {
 		return nil, fmt.Errorf("must specify one of alias or fingerprint for init from image")
 	}
-
-	s := d.State()
 
 	info, err := ImageDownload(r, s, op, &ImageDownloadArgs{
 		Server:            req.Source.Server,
@@ -427,7 +423,7 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 		return nil, err
 	}
 
-	id, info, err := d.db.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &project})
+	id, info, err := s.DB.Cluster.GetImage(info.Fingerprint, dbCluster.ImageFilter{Project: &project})
 	if err != nil {
 		return nil, err
 	}
@@ -444,7 +440,7 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 
 	profileIds := make([]int64, len(req.Profiles))
 	for i, profile := range req.Profiles {
-		profileID, _, err := d.db.Cluster.GetProfile(project, profile)
+		profileID, _, err := s.DB.Cluster.GetProfile(project, profile)
 		if response.IsNotFoundError(err) {
 			return nil, fmt.Errorf("Profile '%s' doesn't exist", profile)
 		} else if err != nil {
@@ -456,7 +452,7 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 
 	// Update the DB record if needed
 	if req.Public || req.AutoUpdate || req.Filename != "" || len(req.Properties) > 0 || len(req.Profiles) > 0 {
-		err = d.db.Cluster.UpdateImage(id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, project, profileIds)
+		err = s.DB.Cluster.UpdateImage(id, req.Filename, info.Size, req.Public, req.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, project, profileIds)
 		if err != nil {
 			return nil, err
 		}
@@ -465,16 +461,14 @@ func imgPostRemoteInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *opera
 	return info, nil
 }
 
-func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
-	s := d.State()
-
+func imgPostURLInfo(s *state.State, r *http.Request, req api.ImagesPost, op *operations.Operation, project string, budget int64) (*api.Image, error) {
 	var err error
 
 	if req.Source.URL == "" {
 		return nil, fmt.Errorf("Missing URL")
 	}
 
-	myhttp, err := util.HTTPClient("", d.proxy)
+	myhttp, err := util.HTTPClient("", s.Proxy)
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +480,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 	}
 
 	architectures := []string{}
-	for _, architecture := range d.os.Architectures {
+	for _, architecture := range s.OS.Architectures {
 		architectureName, err := osarch.ArchitectureName(architecture)
 		if err != nil {
 			return nil, err
@@ -548,7 +542,7 @@ func imgPostURLInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operatio
 	return info, nil
 }
 
-func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string, post *os.File, metadata map[string]any) (*api.Image, error) {
+func getImgPostInfo(s *state.State, r *http.Request, builddir string, project string, post *os.File, metadata map[string]any) (*api.Image, error) {
 	info := api.Image{}
 	var imageMeta *api.ImageMetadata
 	l := logger.AddContext(logger.Log, logger.Ctx{"function": "getImgPostInfo"})
@@ -745,7 +739,7 @@ func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string,
 		profileIds = make([]int64, len(p["profile"]))
 
 		for i, val := range p["profile"] {
-			profileID, _, err := d.db.Cluster.GetProfile(project, val)
+			profileID, _, err := s.DB.Cluster.GetProfile(project, val)
 			if response.IsNotFoundError(err) {
 				return nil, fmt.Errorf("Profile '%s' doesn't exist", val)
 			} else if err != nil {
@@ -757,7 +751,7 @@ func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string,
 	}
 
 	// Check if the image already exists
-	exists, err := d.db.Cluster.ImageExists(project, info.Fingerprint)
+	exists, err := s.DB.Cluster.ImageExists(project, info.Fingerprint)
 	if err != nil {
 		return nil, err
 	}
@@ -766,7 +760,7 @@ func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string,
 		// Do not create a database entry if the request is coming from the internal
 		// cluster communications for image synchronization
 		if isClusterNotification(r) {
-			err := d.db.Cluster.AddImageToLocalNode(project, info.Fingerprint)
+			err := s.DB.Cluster.AddImageToLocalNode(project, info.Fingerprint)
 			if err != nil {
 				return nil, err
 			}
@@ -780,7 +774,7 @@ func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string,
 		}
 
 		// Create the database entry
-		err = d.db.Cluster.CreateImage(project, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, profileIds)
+		err = s.DB.Cluster.CreateImage(project, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties, info.Type, profileIds)
 		if err != nil {
 			return nil, err
 		}
@@ -933,7 +927,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		return response.Forbidden(nil)
 	} else {
 		// We need to invalidate the secret whether the source is trusted or not.
-		op, err := imageValidSecret(d, r, projectName, fingerprint, secret)
+		op, err := imageValidSecret(s, r, projectName, fingerprint, secret)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1022,7 +1016,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 			"public":     req.Public,
 		}
 
-		return createTokenResponse(d, r, projectName, req.Source.Fingerprint, metadata)
+		return createTokenResponse(s, r, projectName, req.Source.Fingerprint, metadata)
 	}
 
 	if !imageUpload && !shared.StringInSlice(req.Source.Type, []string{"container", "instance", "virtual-machine", "snapshot", "image", "url"}) {
@@ -1063,18 +1057,18 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 
 		if imageUpload {
 			/* Processing image upload */
-			info, err = getImgPostInfo(d, r, builddir, projectName, post, imageMetadata)
+			info, err = getImgPostInfo(s, r, builddir, projectName, post, imageMetadata)
 		} else {
 			if req.Source.Type == "image" {
 				/* Processing image copy from remote */
-				info, err = imgPostRemoteInfo(d, r, req, op, projectName, budget)
+				info, err = imgPostRemoteInfo(s, r, req, op, projectName, budget)
 			} else if req.Source.Type == "url" {
 				/* Processing image copy from URL */
-				info, err = imgPostURLInfo(d, r, req, op, projectName, budget)
+				info, err = imgPostURLInfo(s, r, req, op, projectName, budget)
 			} else {
 				/* Processing image creation from container */
 				imagePublishLock.Lock()
-				info, err = imgPostInstanceInfo(d, r, req, op, builddir, budget)
+				info, err = imgPostInstanceInfo(s, r, req, op, builddir, budget)
 				imagePublishLock.Unlock()
 			}
 		}
@@ -1138,7 +1132,7 @@ func imagesPost(d *Daemon, r *http.Request) response.Response {
 		}
 
 		// Sync the images between each node in the cluster on demand
-		err = imageSyncBetweenNodes(d, r, projectName, info.Fingerprint)
+		err = imageSyncBetweenNodes(s, r, projectName, info.Fingerprint)
 		if err != nil {
 			return fmt.Errorf("Failed syncing image between nodes: %w", err)
 		}
@@ -2168,9 +2162,7 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	return f, schedule
 }
 
-func pruneLeftoverImages(d *Daemon) {
-	s := d.State()
-
+func pruneLeftoverImages(s *state.State) {
 	opRun := func(op *operations.Operation) error {
 		// Check if dealing with shared image storage.
 		var storageImages string
@@ -2212,7 +2204,7 @@ func pruneLeftoverImages(d *Daemon) {
 
 		// Get all images
 		var images []string
-		err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
 			images, err = tx.GetLocalImagesFingerprints(ctx)
 			return err
@@ -2261,7 +2253,7 @@ func pruneLeftoverImages(d *Daemon) {
 		return
 	}
 
-	_, _ = op.Wait(d.shutdownCtx)
+	_, _ = op.Wait(s.ShutdownCtx)
 	logger.Infof("Done pruning leftover image files")
 }
 
@@ -2603,8 +2595,8 @@ func doImageGet(ctx context.Context, tx *db.ClusterTx, project, fingerprint stri
 // imageValidSecret searches for an ImageToken operation running on any member in the default project that has an
 // images resource matching the specified fingerprint and the metadata secret field matches the specified secret.
 // If an operation is found it is returned and the operation is cancelled. Otherwise nil is returned if not found.
-func imageValidSecret(d *Daemon, r *http.Request, projectName string, fingerprint string, secret string) (*api.Operation, error) {
-	ops, err := operationsGetByType(d.State(), r, projectName, operationtype.ImageToken)
+func imageValidSecret(s *state.State, r *http.Request, projectName string, fingerprint string, secret string) (*api.Operation, error) {
+	ops, err := operationsGetByType(s, r, projectName, operationtype.ImageToken)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting image token operations: %w", err)
 	}
@@ -2630,7 +2622,7 @@ func imageValidSecret(d *Daemon, r *http.Request, projectName string, fingerprin
 
 		if opSecret == secret {
 			// Token is single-use, so cancel it now.
-			err = operationCancel(d.State(), r, projectName, op)
+			err = operationCancel(s, r, projectName, op)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to cancel operation %q: %w", op.ID, err)
 			}
@@ -2751,7 +2743,7 @@ func imageGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	op, err := imageValidSecret(d, r, projectName, info.Fingerprint, secret)
+	op, err := imageValidSecret(d.State(), r, projectName, info.Fingerprint, secret)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -3693,7 +3685,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		op, err := imageValidSecret(d, r, projectName, imgInfo.Fingerprint, secret)
+		op, err := imageValidSecret(d.State(), r, projectName, imgInfo.Fingerprint, secret)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -3948,7 +3940,7 @@ func imageSecret(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	return createTokenResponse(d, r, projectName, imgInfo.Fingerprint, nil)
+	return createTokenResponse(d.State(), r, projectName, imgInfo.Fingerprint, nil)
 }
 
 func imageImportFromNode(imagesDir string, client lxd.InstanceServer, fingerprint string) error {
@@ -4121,7 +4113,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		opRun := func(op *operations.Operation) error {
-			return autoSyncImages(ctx, d)
+			return autoSyncImages(ctx, d.State())
 		}
 
 		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, operationtype.ImagesSynchronize, nil, nil, opRun, nil, nil, nil)
@@ -4149,9 +4141,9 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	return f, task.Hourly()
 }
 
-func autoSyncImages(ctx context.Context, d *Daemon) error {
+func autoSyncImages(ctx context.Context, s *state.State) error {
 	// Get all images.
-	imageProjectInfo, err := d.db.Cluster.GetImages()
+	imageProjectInfo, err := s.DB.Cluster.GetImages()
 	if err != nil {
 		return fmt.Errorf("Failed to query image fingerprints: %w", err)
 	}
@@ -4159,7 +4151,7 @@ func autoSyncImages(ctx context.Context, d *Daemon) error {
 	for fingerprint, projects := range imageProjectInfo {
 		ch := make(chan error)
 		go func() {
-			err := imageSyncBetweenNodes(d, nil, projects[0], fingerprint)
+			err := imageSyncBetweenNodes(s, nil, projects[0], fingerprint)
 			if err != nil {
 				logger.Error("Failed to synchronize images", logger.Ctx{"err": err, "fingerprint": fingerprint})
 			}
@@ -4177,15 +4169,13 @@ func autoSyncImages(ctx context.Context, d *Daemon) error {
 	return nil
 }
 
-func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerprint string) error {
-	s := d.State()
-
+func imageSyncBetweenNodes(s *state.State, r *http.Request, project string, fingerprint string) error {
 	logger.Info("Syncing image to members started", logger.Ctx{"fingerprint": fingerprint, "project": project})
 	defer logger.Info("Syncing image to members finished", logger.Ctx{"fingerprint": fingerprint, "project": project})
 
 	var desiredSyncNodeCount int64
 
-	err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		desiredSyncNodeCount = s.GlobalConfig.ImagesMinimalReplica()
 
 		// -1 means that we want to replicate the image on all nodes
@@ -4205,7 +4195,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	}
 
 	// Check how many nodes already have this image
-	syncNodeAddresses, err := d.db.Cluster.GetNodesWithImage(fingerprint)
+	syncNodeAddresses, err := s.DB.Cluster.GetNodesWithImage(fingerprint)
 	if err != nil {
 		return fmt.Errorf("Failed to get nodes for the image synchronization: %w", err)
 	}
@@ -4225,7 +4215,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	// Pick a random node from that slice as the source.
 	syncNodeAddress := syncNodeAddresses[rand.Intn(len(syncNodeAddresses))]
 
-	source, err := cluster.Connect(syncNodeAddress, d.endpoints.NetworkCert(), d.serverCert(), r, true)
+	source, err := cluster.Connect(syncNodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), r, true)
 	if err != nil {
 		return fmt.Errorf("Failed to connect to source node for image synchronization: %w", err)
 	}
@@ -4233,7 +4223,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	source = source.UseProject(project)
 
 	// Get the image.
-	_, image, err := d.db.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &project})
+	_, image, err := s.DB.Cluster.GetImage(fingerprint, dbCluster.ImageFilter{Project: &project})
 	if err != nil {
 		return fmt.Errorf("Failed to get image: %w", err)
 	}
@@ -4247,7 +4237,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	// Replicate on as many nodes as needed.
 	for i := 0; i < int(nodeCount); i++ {
 		// Get a list of nodes that do not have the image.
-		addresses, err := d.db.Cluster.GetNodesWithoutImage(fingerprint)
+		addresses, err := s.DB.Cluster.GetNodesWithoutImage(fingerprint)
 		if err != nil {
 			return fmt.Errorf("Failed to get nodes for the image synchronization: %w", err)
 		}
@@ -4260,7 +4250,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 		// Pick a random node from that slice as the target.
 		targetNodeAddress := addresses[rand.Intn(len(addresses))]
 
-		client, err := cluster.Connect(targetNodeAddress, d.endpoints.NetworkCert(), d.serverCert(), r, true)
+		client, err := cluster.Connect(targetNodeAddress, s.Endpoints.NetworkCert(), s.ServerCert(), r, true)
 		if err != nil {
 			return fmt.Errorf("Failed to connect node for image synchronization: %w", err)
 		}
@@ -4284,7 +4274,7 @@ func imageSyncBetweenNodes(d *Daemon, r *http.Request, project string, fingerpri
 	return nil
 }
 
-func createTokenResponse(d *Daemon, r *http.Request, projectName string, fingerprint string, metadata shared.Jmap) response.Response {
+func createTokenResponse(s *state.State, r *http.Request, projectName string, fingerprint string, metadata shared.Jmap) response.Response {
 	secret, err := shared.RandomCryptoString()
 	if err != nil {
 		return response.InternalError(err)
@@ -4301,12 +4291,12 @@ func createTokenResponse(d *Daemon, r *http.Request, projectName string, fingerp
 	resources := map[string][]string{}
 	resources["images"] = []string{fingerprint}
 
-	op, err := operations.OperationCreate(d.State(), projectName, operations.OperationClassToken, operationtype.ImageToken, resources, meta, nil, nil, nil, r)
+	op, err := operations.OperationCreate(s, projectName, operations.OperationClassToken, operationtype.ImageToken, resources, meta, nil, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
 
-	d.State().Events.SendLifecycle(projectName, lifecycle.ImageSecretCreated.Event(fingerprint, projectName, op.Requestor(), nil))
+	s.Events.SendLifecycle(projectName, lifecycle.ImageSecretCreated.Event(fingerprint, projectName, op.Requestor(), nil))
 
 	return operations.OperationResponse(op)
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2604,7 +2604,7 @@ func doImageGet(ctx context.Context, tx *db.ClusterTx, project, fingerprint stri
 // images resource matching the specified fingerprint and the metadata secret field matches the specified secret.
 // If an operation is found it is returned and the operation is cancelled. Otherwise nil is returned if not found.
 func imageValidSecret(d *Daemon, r *http.Request, projectName string, fingerprint string, secret string) (*api.Operation, error) {
-	ops, err := operationsGetByType(d, r, projectName, operationtype.ImageToken)
+	ops, err := operationsGetByType(d.State(), r, projectName, operationtype.ImageToken)
 	if err != nil {
 		return nil, fmt.Errorf("Failed getting image token operations: %w", err)
 	}
@@ -2630,7 +2630,7 @@ func imageValidSecret(d *Daemon, r *http.Request, projectName string, fingerprin
 
 		if opSecret == secret {
 			// Token is single-use, so cancel it now.
-			err = operationCancel(d, r, projectName, op)
+			err = operationCancel(d.State(), r, projectName, op)
 			if err != nil {
 				return nil, fmt.Errorf("Failed to cancel operation %q: %w", op.ID, err)
 			}

--- a/lxd/instance_backup.go
+++ b/lxd/instance_backup.go
@@ -134,7 +134,7 @@ func instanceBackupsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, cname, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, cname, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -233,7 +233,7 @@ func instanceBackupsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node.
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -411,7 +411,7 @@ func instanceBackupGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -483,7 +483,7 @@ func instanceBackupPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -581,7 +581,7 @@ func instanceBackupDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -661,7 +661,7 @@ func instanceBackupExportGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -557,7 +557,7 @@ func instanceConsoleLogGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Forward the request if the container is remote.
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_delete.go
+++ b/lxd/instance_delete.go
@@ -61,7 +61,7 @@ func instanceDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_file.go
+++ b/lxd/instance_file.go
@@ -41,7 +41,7 @@ func instanceFileHandler(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_get.go
+++ b/lxd/instance_get.go
@@ -122,7 +122,7 @@ func instanceGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_logs.go
+++ b/lxd/instance_logs.go
@@ -116,7 +116,7 @@ func instanceLogsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -217,7 +217,7 @@ func instanceLogGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -299,7 +299,7 @@ func instanceLogDelete(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_metadata.go
+++ b/lxd/instance_metadata.go
@@ -82,7 +82,7 @@ func instanceMetadataGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -192,7 +192,7 @@ func instanceMetadataPatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to an instance on a different node.
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -310,7 +310,7 @@ func instanceMetadataPut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to an instance on a different node.
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -432,7 +432,7 @@ func instanceMetadataTemplatesGet(d *Daemon, r *http.Request) response.Response 
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -582,7 +582,7 @@ func instanceMetadataTemplatesPost(d *Daemon, r *http.Request) response.Response
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -699,7 +699,7 @@ func instanceMetadataTemplatesDelete(d *Daemon, r *http.Request) response.Respon
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_patch.go
+++ b/lxd/instance_patch.go
@@ -76,7 +76,7 @@ func instancePatch(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -189,7 +189,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 	// and we'll either forward the request or load the container.
 	if targetNode == "" || !sourceNodeOffline {
 		// Handle requests targeted to a container on a different node.
-		resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+		resp, err := forwardedResponseIfInstanceIsRemote(s, r, projectName, name, instanceType)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -252,7 +252,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 		if req.Pool != "" {
 			// Setup the instance move operation.
 			run := func(op *operations.Operation) error {
-				return instancePostPoolMigration(d, inst, req.Name, req.InstanceOnly, req.Pool, req.Live, req.AllowInconsistent, op)
+				return instancePostPoolMigration(s, inst, req.Name, req.InstanceOnly, req.Pool, req.Live, req.AllowInconsistent, op)
 			}
 
 			resources := map[string][]string{}
@@ -274,7 +274,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 
 			// Setup the instance move operation.
 			run := func(op *operations.Operation) error {
-				return instancePostProjectMigration(d, inst, req.Name, req.Project, req.InstanceOnly, req.Live, req.AllowInconsistent, op)
+				return instancePostProjectMigration(s, inst, req.Name, req.Project, req.InstanceOnly, req.Live, req.AllowInconsistent, op)
 			}
 
 			resources := map[string][]string{}
@@ -385,7 +385,7 @@ func instancePost(d *Daemon, r *http.Request) response.Response {
 }
 
 // Move an instance to another pool.
-func instancePostPoolMigration(d *Daemon, inst instance.Instance, newName string, instanceOnly bool, newPool string, stateful bool, allowInconsistent bool, op *operations.Operation) error {
+func instancePostPoolMigration(s *state.State, inst instance.Instance, newName string, instanceOnly bool, newPool string, stateful bool, allowInconsistent bool, op *operations.Operation) error {
 	if inst.IsSnapshot() {
 		return fmt.Errorf("Instance snapshots cannot be moved between pools")
 	}
@@ -447,7 +447,7 @@ func instancePostPoolMigration(d *Daemon, inst instance.Instance, newName string
 	}
 
 	// Copy instance to new target instance.
-	targetInst, err := instanceCreateAsCopy(d.State(), instanceCreateAsCopyOpts{
+	targetInst, err := instanceCreateAsCopy(s, instanceCreateAsCopyOpts{
 		sourceInstance:       inst,
 		targetInstance:       args,
 		instanceOnly:         instanceOnly,
@@ -483,7 +483,7 @@ func instancePostPoolMigration(d *Daemon, inst instance.Instance, newName string
 }
 
 // Move an instance to another project.
-func instancePostProjectMigration(d *Daemon, inst instance.Instance, newName string, newProject string, instanceOnly bool, stateful bool, allowInconsistent bool, op *operations.Operation) error {
+func instancePostProjectMigration(s *state.State, inst instance.Instance, newName string, newProject string, instanceOnly bool, stateful bool, allowInconsistent bool, op *operations.Operation) error {
 	localConfig := inst.LocalConfig()
 
 	statefulStart := false
@@ -525,7 +525,7 @@ func instancePostProjectMigration(d *Daemon, inst instance.Instance, newName str
 	}
 
 	// Copy instance to new target instance.
-	targetInst, err := instanceCreateAsCopy(d.State(), instanceCreateAsCopyOpts{
+	targetInst, err := instanceCreateAsCopy(s, instanceCreateAsCopyOpts{
 		sourceInstance:       inst,
 		targetInstance:       args,
 		instanceOnly:         instanceOnly,

--- a/lxd/instance_put.go
+++ b/lxd/instance_put.go
@@ -79,7 +79,7 @@ func instancePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -375,13 +375,13 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 	case "GET":
 		return snapshotGet(d.State(), inst, snapshotName)
 	case "POST":
-		return snapshotPost(d, r, inst, containerName)
+		return snapshotPost(d.State(), r, inst, containerName)
 	case "DELETE":
 		return snapshotDelete(d.State(), r, inst, snapshotName)
 	case "PUT":
-		return snapshotPut(d, r, inst, snapshotName)
+		return snapshotPut(d.State(), r, inst, snapshotName)
 	case "PATCH":
-		return snapshotPatch(d, r, inst, snapshotName)
+		return snapshotPatch(d.State(), r, inst, snapshotName)
 	default:
 		return response.NotFound(fmt.Errorf("Method %q not found", r.Method))
 	}
@@ -419,9 +419,9 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func snapshotPatch(d *Daemon, r *http.Request, snapInst instance.Instance, name string) response.Response {
+func snapshotPatch(s *state.State, r *http.Request, snapInst instance.Instance, name string) response.Response {
 	// Only expires_at is currently editable, so PATCH is equivalent to PUT.
-	return snapshotPut(d, r, snapInst, name)
+	return snapshotPut(s, r, snapInst, name)
 }
 
 // swagger:operation PUT /1.0/instances/{name}/snapshots/{snapshot} instances instance_snapshot_put
@@ -456,7 +456,7 @@ func snapshotPatch(d *Daemon, r *http.Request, snapInst instance.Instance, name 
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name string) response.Response {
+func snapshotPut(s *state.State, r *http.Request, snapInst instance.Instance, name string) response.Response {
 	// Validate the ETag
 	etag := []any{snapInst.ExpiryDate()}
 	err := util.EtagCheck(r, etag)
@@ -525,7 +525,7 @@ func snapshotPut(d *Daemon, r *http.Request, snapInst instance.Instance, name st
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
+	op, err := operations.OperationCreate(s, snapInst.Project().Name, operations.OperationClassTask, opType, resources, nil, do, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -621,7 +621,7 @@ func snapshotGet(s *state.State, snapInst instance.Instance, name string) respon
 //	    $ref: "#/responses/Forbidden"
 //	  "500":
 //	    $ref: "#/responses/InternalServerError"
-func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, containerName string) response.Response {
+func snapshotPost(s *state.State, r *http.Request, snapInst instance.Instance, containerName string) response.Response {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return response.InternalError(err)
@@ -676,12 +676,12 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		}
 
 		run := func(op *operations.Operation) error {
-			return ws.Do(d.State(), op)
+			return ws.Do(s, op)
 		}
 
 		if req.Target != nil {
 			// Push mode.
-			op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotTransfer, resources, nil, run, nil, nil, r)
+			op, err := operations.OperationCreate(s, snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotTransfer, resources, nil, run, nil, nil, r)
 			if err != nil {
 				return response.InternalError(err)
 			}
@@ -690,7 +690,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		}
 
 		// Pull mode.
-		op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassWebsocket, operationtype.SnapshotTransfer, resources, ws.Metadata(), run, nil, ws.Connect, r)
+		op, err := operations.OperationCreate(s, snapInst.Project().Name, operations.OperationClassWebsocket, operationtype.SnapshotTransfer, resources, ws.Metadata(), run, nil, ws.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -712,7 +712,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 	fullName := containerName + shared.SnapshotDelimiter + newName
 
 	// Check that the name isn't already in use
-	id, _ := d.db.Cluster.GetInstanceSnapshotID(snapInst.Project().Name, containerName, newName)
+	id, _ := s.DB.Cluster.GetInstanceSnapshotID(snapInst.Project().Name, containerName, newName)
 	if id > 0 {
 		return response.Conflict(fmt.Errorf("Name '%s' already in use", fullName))
 	}
@@ -728,7 +728,7 @@ func snapshotPost(d *Daemon, r *http.Request, snapInst instance.Instance, contai
 		resources["containers"] = resources["instances"]
 	}
 
-	op, err := operations.OperationCreate(d.State(), snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotRename, resources, nil, rename, nil, nil, r)
+	op, err := operations.OperationCreate(s, snapInst.Project().Name, operations.OperationClassTask, operationtype.SnapshotRename, resources, nil, rename, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/instance_snapshot.go
+++ b/lxd/instance_snapshot.go
@@ -138,7 +138,7 @@ func instanceSnapshotsGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, cname, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, cname, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -266,7 +266,7 @@ func instanceSnapshotsPost(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -352,7 +352,7 @@ func instanceSnapshotHandler(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, containerName, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, containerName, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instance_state.go
+++ b/lxd/instance_state.go
@@ -80,7 +80,7 @@ func instanceState(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -152,7 +152,7 @@ func instanceStatePut(d *Daemon, r *http.Request) response.Response {
 	}
 
 	// Handle requests targeted to a container on a different node
-	resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, name, instanceType)
+	resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -693,7 +693,7 @@ func createFromBackup(d *Daemon, r *http.Request, projectName string, data io.Re
 
 		runRevert.Add(revertHook)
 
-		err = internalImportFromBackup(d, bInfo.Project, bInfo.Name, true, instanceName != "")
+		err = internalImportFromBackup(d.State(), bInfo.Project, bInfo.Name, true, instanceName != "")
 		if err != nil {
 			return fmt.Errorf("Failed importing backup: %w", err)
 		}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1082,7 +1082,7 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		opRun := func(op *operations.Operation) error {
-			return autoRemoveOrphanedOperations(ctx, d)
+			return autoRemoveOrphanedOperations(ctx, d.State())
 		}
 
 		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, operationtype.RemoveOrphanedOperations, nil, nil, opRun, nil, nil, nil)
@@ -1107,10 +1107,9 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 // behind if a cluster member abruptly becomes unreachable. If the affected cluster members comes
 // back online, these operations won't be cleaned up. We therefore need to periodically clean up
 // such operations.
-func autoRemoveOrphanedOperations(ctx context.Context, d *Daemon) error {
+func autoRemoveOrphanedOperations(ctx context.Context, s *state.State) error {
 	logger.Debug("Removing orphaned operations across the cluster")
 
-	s := d.State()
 	offlineThreshold := s.GlobalConfig.OfflineThreshold()
 
 	err := s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lxc/lxd/lxd/rbac"
 	"github.com/lxc/lxd/lxd/request"
 	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -303,7 +304,7 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 }
 
 // operationCancel cancels an operation that exists on any member.
-func operationCancel(d *Daemon, r *http.Request, projectName string, op *api.Operation) error {
+func operationCancel(s *state.State, r *http.Request, projectName string, op *api.Operation) error {
 	// Check if operation is local and if so, cancel it.
 	localOp, _ := operations.OperationGetInternal(op.ID)
 	if localOp != nil {
@@ -314,7 +315,7 @@ func operationCancel(d *Daemon, r *http.Request, projectName string, op *api.Ope
 			}
 		}
 
-		d.State().Events.SendLifecycle(projectName, lifecycle.OperationCancelled.Event(localOp, request.CreateRequestor(r), nil))
+		s.Events.SendLifecycle(projectName, lifecycle.OperationCancelled.Event(localOp, request.CreateRequestor(r), nil))
 
 		return nil
 	}
@@ -322,7 +323,7 @@ func operationCancel(d *Daemon, r *http.Request, projectName string, op *api.Ope
 	// If not found locally, try connecting to remote member to delete it.
 	var memberAddress string
 	var err error
-	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		filter := dbCluster.OperationFilter{UUID: &op.ID}
 		ops, err := dbCluster.GetOperations(ctx, tx.Tx(), filter)
 		if err != nil {
@@ -346,7 +347,7 @@ func operationCancel(d *Daemon, r *http.Request, projectName string, op *api.Ope
 		return err
 	}
 
-	client, err := cluster.Connect(memberAddress, d.endpoints.NetworkCert(), d.serverCert(), r, true)
+	client, err := cluster.Connect(memberAddress, s.Endpoints.NetworkCert(), s.ServerCert(), r, true)
 	if err != nil {
 		return fmt.Errorf("Failed to connect to %q: %w", memberAddress, err)
 	}
@@ -640,7 +641,7 @@ func operationsGet(d *Daemon, r *http.Request) response.Response {
 }
 
 // operationsGetByType gets all operations for a project and type.
-func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType operationtype.Type) ([]*api.Operation, error) {
+func operationsGetByType(s *state.State, r *http.Request, projectName string, opType operationtype.Type) ([]*api.Operation, error) {
 	ops := make([]*api.Operation, 0)
 
 	// Get local operations for project.
@@ -658,7 +659,7 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 	}
 
 	// Check if clustered.
-	clustered, err := cluster.Enabled(d.db.Node)
+	clustered, err := cluster.Enabled(s.DB.Node)
 	if err != nil {
 		return nil, err
 	}
@@ -671,7 +672,7 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 	// Get all operations of the specified type in project.
 	var members []db.NodeInfo
 	memberOps := make(map[string]map[string]dbCluster.Operation)
-	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		members, err = tx.GetNodes(ctx)
 		if err != nil {
 			return fmt.Errorf("Failed getting cluster members: %w", err)
@@ -697,8 +698,6 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 		return nil, err
 	}
 
-	s := d.State()
-
 	// Get local address.
 	localClusterAddress := s.LocalConfig.ClusterAddress()
 	offlineThreshold := s.GlobalConfig.OfflineThreshold()
@@ -718,8 +717,8 @@ func operationsGetByType(d *Daemon, r *http.Request, projectName string, opType 
 		return false
 	}
 
-	networkCert := d.endpoints.NetworkCert()
-	serverCert := d.serverCert()
+	networkCert := s.Endpoints.NetworkCert()
+	serverCert := s.ServerCert()
 	for memberAddress := range memberOps {
 		if memberAddress == localClusterAddress {
 			continue

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -459,7 +459,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
-		err = doProfileUpdateCluster(d, p.Name, name, old)
+		err = doProfileUpdateCluster(d.State(), p.Name, name, old)
 		return response.SmartError(err)
 	}
 
@@ -498,7 +498,7 @@ func profilePut(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	err = doProfileUpdate(d, *p, name, id, profile, req)
+	err = doProfileUpdate(d.State(), *p, name, id, profile, req)
 
 	if err == nil && !isClusterNotification(r) {
 		// Notify all other nodes. If a node is down, it will be ignored.
@@ -648,7 +648,7 @@ func profilePatch(d *Daemon, r *http.Request) response.Response {
 	requestor := request.CreateRequestor(r)
 	d.State().Events.SendLifecycle(p.Name, lifecycle.ProfileUpdated.Event(name, p.Name, requestor, nil))
 
-	return response.SmartError(doProfileUpdate(d, *p, name, id, profile, req))
+	return response.SmartError(doProfileUpdate(d.State(), *p, name, id, profile, req))
 }
 
 // swagger:operation POST /1.0/profiles/{name} profiles profile_post

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -43,8 +43,8 @@ func forwardedResponseIfTargetIsRemote(s *state.State, r *http.Request) response
 // forwardedResponseIfInstanceIsRemote redirects a request to the node running
 // the container with the given name. If the container is local, nothing gets
 // done and nil is returned.
-func forwardedResponseIfInstanceIsRemote(d *Daemon, r *http.Request, project, name string, instanceType instancetype.Type) (response.Response, error) {
-	client, err := cluster.ConnectIfInstanceIsRemote(d.db.Cluster, project, name, d.endpoints.NetworkCert(), d.serverCert(), r, instanceType)
+func forwardedResponseIfInstanceIsRemote(s *state.State, r *http.Request, project, name string, instanceType instancetype.Type) (response.Response, error) {
+	client, err := cluster.ConnectIfInstanceIsRemote(s.DB.Cluster, project, name, s.Endpoints.NetworkCert(), s.ServerCert(), r, instanceType)
 	if err != nil {
 		return nil, err
 	}
@@ -63,12 +63,12 @@ func forwardedResponseIfInstanceIsRemote(d *Daemon, r *http.Request, project, na
 //
 // This is used when no targetNode is specified, and saves users some typing
 // when the volume name/type is unique to a node.
-func forwardedResponseIfVolumeIsRemote(d *Daemon, r *http.Request, poolName string, projectName string, volumeName string, volumeType int) response.Response {
+func forwardedResponseIfVolumeIsRemote(s *state.State, r *http.Request, poolName string, projectName string, volumeName string, volumeType int) response.Response {
 	if queryParam(r, "target") != "" {
 		return nil
 	}
 
-	client, err := cluster.ConnectIfVolumeIsRemote(d.State(), poolName, projectName, volumeName, volumeType, d.endpoints.NetworkCert(), d.serverCert(), r)
+	client, err := cluster.ConnectIfVolumeIsRemote(s, poolName, projectName, volumeName, volumeType, s.Endpoints.NetworkCert(), s.ServerCert(), r)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -549,7 +549,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 
 	// If we're getting binary content, process separately.
 	if r.Header.Get("Content-Type") == "application/octet-stream" {
-		return createStoragePoolVolumeFromBackup(d, r, projectParam(r), projectName, r.Body, poolName, r.Header.Get("X-LXD-name"))
+		return createStoragePoolVolumeFromBackup(s, r, projectParam(r), projectName, r.Body, poolName, r.Header.Get("X-LXD-name"))
 	}
 
 	req := api.StorageVolumesPost{}
@@ -618,24 +618,24 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Source.Type {
 	case "":
-		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(s, r, projectParam(r), projectName, poolName, &req)
 	case "copy":
 		if dbVolume != nil {
-			return doCustomVolumeRefresh(d, r, projectParam(r), projectName, poolName, &req)
+			return doCustomVolumeRefresh(s, r, projectParam(r), projectName, poolName, &req)
 		}
 
-		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(s, r, projectParam(r), projectName, poolName, &req)
 	case "migration":
-		return doVolumeMigration(d, r, projectParam(r), projectName, poolName, &req)
+		return doVolumeMigration(s, r, projectParam(r), projectName, poolName, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
 	}
 }
 
-func doCustomVolumeRefresh(d *Daemon, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
+func doCustomVolumeRefresh(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
 	var run func(op *operations.Operation) error
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -657,7 +657,7 @@ func doCustomVolumeRefresh(d *Daemon, r *http.Request, requestProjectName string
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, operationtype.VolumeCopy, nil, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, requestProjectName, operations.OperationClassTask, operationtype.VolumeCopy, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -665,10 +665,10 @@ func doCustomVolumeRefresh(d *Daemon, r *http.Request, requestProjectName string
 	return operations.OperationResponse(op)
 }
 
-func doVolumeCreateOrCopy(d *Daemon, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
+func doVolumeCreateOrCopy(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
 	var run func(op *operations.Operation) error
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -705,7 +705,7 @@ func doVolumeCreateOrCopy(d *Daemon, r *http.Request, requestProjectName string,
 	}
 
 	// Volume copy operations potentially take a long time, so run as an async operation.
-	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, operationtype.VolumeCopy, nil, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, requestProjectName, operations.OperationClassTask, operationtype.VolumeCopy, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -828,17 +828,17 @@ func storagePoolVolumesPost(d *Daemon, r *http.Request) response.Response {
 
 	switch req.Source.Type {
 	case "":
-		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(s, r, projectParam(r), projectName, poolName, &req)
 	case "copy":
-		return doVolumeCreateOrCopy(d, r, projectParam(r), projectName, poolName, &req)
+		return doVolumeCreateOrCopy(s, r, projectParam(r), projectName, poolName, &req)
 	case "migration":
-		return doVolumeMigration(d, r, projectParam(r), projectName, poolName, &req)
+		return doVolumeMigration(s, r, projectParam(r), projectName, poolName, &req)
 	default:
 		return response.BadRequest(fmt.Errorf("Unknown source type %q", req.Source.Type))
 	}
 }
 
-func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
+func doVolumeMigration(s *state.State, r *http.Request, requestProjectName string, projectName string, poolName string, req *api.StorageVolumesPost) response.Response {
 	// Validate migration mode
 	if req.Source.Mode != "pull" && req.Source.Mode != "push" {
 		return response.NotImplemented(fmt.Errorf("Mode '%s' not implemented", req.Source.Mode))
@@ -894,7 +894,7 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 
 	run := func(op *operations.Operation) error {
 		// And finally run the migration.
-		err = sink.DoStorage(d.State(), projectName, poolName, req, op)
+		err = sink.DoStorage(s, projectName, poolName, req, op)
 		if err != nil {
 			logger.Error("Error during migration sink", logger.Ctx{"err": err})
 			return fmt.Errorf("Error transferring storage volume: %s", err)
@@ -905,12 +905,12 @@ func doVolumeMigration(d *Daemon, r *http.Request, requestProjectName string, pr
 
 	var op *operations.Operation
 	if push {
-		op, err = operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassWebsocket, operationtype.VolumeCreate, resources, sink.Metadata(), run, nil, sink.Connect, r)
+		op, err = operations.OperationCreate(s, requestProjectName, operations.OperationClassWebsocket, operationtype.VolumeCreate, resources, sink.Metadata(), run, nil, sink.Connect, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
 	} else {
-		op, err = operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, operationtype.VolumeCopy, resources, nil, run, nil, nil, r)
+		op, err = operations.OperationCreate(s, requestProjectName, operations.OperationClassTask, operationtype.VolumeCopy, resources, nil, run, nil, nil, r)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -1130,11 +1130,11 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 
 	// Detect a rename request.
 	if (req.Pool == "" || req.Pool == srcPoolName) && (projectName == targetProjectName) {
-		return storagePoolVolumeTypePostRename(d, r, srcPoolName, projectName, &dbVolume.StorageVolume, req)
+		return storagePoolVolumeTypePostRename(s, r, srcPoolName, projectName, &dbVolume.StorageVolume, req)
 	}
 
 	// Otherwise this is a move request.
-	return storagePoolVolumeTypePostMove(d, r, srcPoolName, projectName, targetProjectName, &dbVolume.StorageVolume, req)
+	return storagePoolVolumeTypePostMove(s, r, srcPoolName, projectName, targetProjectName, &dbVolume.StorageVolume, req)
 }
 
 // storagePoolVolumeTypePostMigration handles volume migration type POST requests.
@@ -1171,11 +1171,11 @@ func storagePoolVolumeTypePostMigration(state *state.State, r *http.Request, req
 }
 
 // storagePoolVolumeTypePostRename handles volume rename type POST requests.
-func storagePoolVolumeTypePostRename(d *Daemon, r *http.Request, poolName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
+func storagePoolVolumeTypePostRename(s *state.State, r *http.Request, poolName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
 	newVol := *vol
 	newVol.Name = req.Name
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1184,7 +1184,7 @@ func storagePoolVolumeTypePostRename(d *Daemon, r *http.Request, poolName string
 	defer revert.Fail()
 
 	// Update devices using the volume in instances and profiles.
-	err = storagePoolVolumeUpdateUsers(d, projectName, pool.Name(), vol, pool.Name(), &newVol)
+	err = storagePoolVolumeUpdateUsers(s, projectName, pool.Name(), vol, pool.Name(), &newVol)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1206,16 +1206,16 @@ func storagePoolVolumeTypePostRename(d *Daemon, r *http.Request, poolName string
 }
 
 // storagePoolVolumeTypePostMove handles volume move type POST requests.
-func storagePoolVolumeTypePostMove(d *Daemon, r *http.Request, poolName string, requestProjectName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
+func storagePoolVolumeTypePostMove(s *state.State, r *http.Request, poolName string, requestProjectName string, projectName string, vol *api.StorageVolume, req api.StorageVolumePost) response.Response {
 	newVol := *vol
 	newVol.Name = req.Name
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	newPool, err := storagePools.LoadByName(d.State(), req.Pool)
+	newPool, err := storagePools.LoadByName(s, req.Pool)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -1225,12 +1225,14 @@ func storagePoolVolumeTypePostMove(d *Daemon, r *http.Request, poolName string, 
 		defer revert.Fail()
 
 		// Update devices using the volume in instances and profiles.
-		err = storagePoolVolumeUpdateUsers(d, requestProjectName, pool.Name(), vol, newPool.Name(), &newVol)
+		err = storagePoolVolumeUpdateUsers(s, requestProjectName, pool.Name(), vol, newPool.Name(), &newVol)
 		if err != nil {
 			return err
 		}
 
-		revert.Add(func() { _ = storagePoolVolumeUpdateUsers(d, projectName, newPool.Name(), &newVol, pool.Name(), vol) })
+		revert.Add(func() {
+			_ = storagePoolVolumeUpdateUsers(s, projectName, newPool.Name(), &newVol, pool.Name(), vol)
+		})
 
 		// Provide empty description and nil config to instruct CreateCustomVolumeFromCopy to copy it
 		// from source volume.
@@ -1248,7 +1250,7 @@ func storagePoolVolumeTypePostMove(d *Daemon, r *http.Request, poolName string, 
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, operationtype.VolumeMove, nil, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, requestProjectName, operations.OperationClassTask, operationtype.VolumeMove, nil, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -1853,7 +1855,7 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjectName string, projectName string, data io.Reader, pool string, volName string) response.Response {
+func createStoragePoolVolumeFromBackup(s *state.State, r *http.Request, requestProjectName string, projectName string, data io.Reader, pool string, volName string) response.Response {
 	revert := revert.New()
 	defer revert.Fail()
 
@@ -1896,7 +1898,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 		defer func() { _ = os.Remove(tarFile.Name()) }()
 
 		// Decompress to tarFile temporary file.
-		err = archive.ExtractWithFds(decomArgs[0], decomArgs[1:], nil, nil, d.State().OS, tarFile)
+		err = archive.ExtractWithFds(decomArgs[0], decomArgs[1:], nil, nil, s.OS, tarFile)
 		if err != nil {
 			return response.InternalError(err)
 		}
@@ -1916,7 +1918,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 	}
 
 	logger.Debug("Reading backup file info")
-	bInfo, err := backup.GetInfo(backupFile, d.State().OS, backupFile.Name())
+	bInfo, err := backup.GetInfo(backupFile, s.OS, backupFile.Name())
 	if err != nil {
 		return response.BadRequest(err)
 	}
@@ -1944,7 +1946,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 	})
 
 	// Check storage pool exists.
-	_, _, _, err = d.State().DB.Cluster.GetStoragePoolInAnyState(bInfo.Pool)
+	_, _, _, err = s.DB.Cluster.GetStoragePoolInAnyState(bInfo.Pool)
 	if response.IsNotFoundError(err) {
 		// The storage pool doesn't exist. If backup is in binary format (so we cannot alter
 		// the backup.yaml) or the pool has been specified directly from the user restoring
@@ -1954,7 +1956,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 		}
 
 		// Otherwise try and restore to the project's default profile pool.
-		_, profile, err := d.State().DB.Cluster.GetProfile(bInfo.Project, "default")
+		_, profile, err := s.DB.Cluster.GetProfile(bInfo.Project, "default")
 		if err != nil {
 			return response.InternalError(fmt.Errorf("Failed to get default profile: %w", err))
 		}
@@ -1977,7 +1979,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 		defer func() { _ = backupFile.Close() }()
 		defer runRevert.Fail()
 
-		pool, err := storagePools.LoadByName(d.State(), bInfo.Pool)
+		pool, err := storagePools.LoadByName(s, bInfo.Pool)
 		if err != nil {
 			return err
 		}
@@ -2000,7 +2002,7 @@ func createStoragePoolVolumeFromBackup(d *Daemon, r *http.Request, requestProjec
 	resources := map[string][]string{}
 	resources["storage_volumes"] = []string{bInfo.Name}
 
-	op, err := operations.OperationCreate(d.State(), requestProjectName, operations.OperationClassTask, operationtype.CustomVolumeBackupRestore, resources, nil, run, nil, nil, r)
+	op, err := operations.OperationCreate(s, requestProjectName, operations.OperationClassTask, operationtype.CustomVolumeBackupRestore, resources, nil, run, nil, nil, r)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1045,7 +1045,7 @@ func storagePoolVolumePost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, srcPoolName, projectName, volumeName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, srcPoolName, projectName, volumeName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -1365,7 +1365,7 @@ func storagePoolVolumeGet(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, volumeProjectName, volumeName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, volumeProjectName, volumeName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -1484,7 +1484,7 @@ func storagePoolVolumePut(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, pool.Name(), projectName, volumeName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, pool.Name(), projectName, volumeName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -1658,7 +1658,7 @@ func storagePoolVolumePatch(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, pool.Name(), projectName, volumeName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, pool.Name(), projectName, volumeName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -1786,7 +1786,7 @@ func storagePoolVolumeDelete(d *Daemon, r *http.Request) response.Response {
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, volumeProjectName, volumeName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, volumeProjectName, volumeName, volumeType)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/storage_volumes_backup.go
+++ b/lxd/storage_volumes_backup.go
@@ -191,7 +191,7 @@ func storagePoolVolumeTypeCustomBackupsGet(d *Daemon, r *http.Request) response.
 	}
 
 	// Handle requests targeted to a volume on a different node
-	resp := forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
+	resp := forwardedResponseIfVolumeIsRemote(d.State(), r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
 	if resp != nil {
 		return resp
 	}
@@ -322,7 +322,7 @@ func storagePoolVolumeTypeCustomBackupsPost(d *Daemon, r *http.Request) response
 		return response.SmartError(err)
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
 	if resp != nil {
 		return resp
 	}
@@ -527,7 +527,7 @@ func storagePoolVolumeTypeCustomBackupGet(d *Daemon, r *http.Request) response.R
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
 	if resp != nil {
 		return resp
 	}
@@ -627,7 +627,7 @@ func storagePoolVolumeTypeCustomBackupPost(d *Daemon, r *http.Request) response.
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
 	if resp != nil {
 		return resp
 	}
@@ -753,7 +753,7 @@ func storagePoolVolumeTypeCustomBackupDelete(d *Daemon, r *http.Request) respons
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
 	if resp != nil {
 		return resp
 	}
@@ -862,7 +862,7 @@ func storagePoolVolumeTypeCustomBackupExportGet(d *Daemon, r *http.Request) resp
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, volumeName, db.StoragePoolVolumeTypeCustom)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -150,7 +150,7 @@ func storagePoolVolumeSnapshotsTypePost(d *Daemon, r *http.Request) response.Res
 		return resp
 	}
 
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, volumeName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -525,7 +525,7 @@ func storagePoolVolumeSnapshotTypePost(d *Daemon, r *http.Request) response.Resp
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, volumeName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, volumeName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -659,7 +659,7 @@ func storagePoolVolumeSnapshotTypeGet(d *Daemon, r *http.Request) response.Respo
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, fullSnapshotName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -782,7 +782,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, fullSnapshotName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -910,7 +910,7 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, fullSnapshotName, volumeType)
 	if resp != nil {
 		return resp
 	}
@@ -1070,7 +1070,7 @@ func storagePoolVolumeSnapshotTypeDelete(d *Daemon, r *http.Request) response.Re
 	}
 
 	fullSnapshotName := fmt.Sprintf("%s/%s", volumeName, snapshotName)
-	resp = forwardedResponseIfVolumeIsRemote(d, r, poolName, projectName, fullSnapshotName, volumeType)
+	resp = forwardedResponseIfVolumeIsRemote(s, r, poolName, projectName, fullSnapshotName, volumeType)
 	if resp != nil {
 		return resp
 	}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -21,6 +21,7 @@ import (
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
+	"github.com/lxc/lxd/lxd/state"
 	storagePools "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/lxd/util"
@@ -821,7 +822,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 		return response.BadRequest(err)
 	}
 
-	return doStoragePoolVolumeSnapshotUpdate(d, r, poolName, projectName, dbVolume.Name, volumeType, req)
+	return doStoragePoolVolumeSnapshotUpdate(s, r, poolName, projectName, dbVolume.Name, volumeType, req)
 }
 
 // swagger:operation PATCH /1.0/storage-pools/{name}/volumes/{type}/{volume}/snapshots/{snapshot} storage storage_pool_volumes_type_snapshot_patch
@@ -949,16 +950,16 @@ func storagePoolVolumeSnapshotTypePatch(d *Daemon, r *http.Request) response.Res
 		return response.BadRequest(err)
 	}
 
-	return doStoragePoolVolumeSnapshotUpdate(d, r, poolName, projectName, dbVolume.Name, volumeType, req)
+	return doStoragePoolVolumeSnapshotUpdate(s, r, poolName, projectName, dbVolume.Name, volumeType, req)
 }
 
-func doStoragePoolVolumeSnapshotUpdate(d *Daemon, r *http.Request, poolName string, projectName string, volName string, volumeType int, req api.StorageVolumeSnapshotPut) response.Response {
+func doStoragePoolVolumeSnapshotUpdate(s *state.State, r *http.Request, poolName string, projectName string, volName string, volumeType int, req api.StorageVolumeSnapshotPut) response.Response {
 	expiry := time.Time{}
 	if req.ExpiresAt != nil {
 		expiry = *req.ExpiresAt
 	}
 
-	pool, err := storagePools.LoadByName(d.State(), poolName)
+	pool, err := storagePools.LoadByName(s, poolName)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -974,7 +975,7 @@ func doStoragePoolVolumeSnapshotUpdate(d *Daemon, r *http.Request, poolName stri
 			return response.SmartError(err)
 		}
 	} else {
-		inst, err := instance.LoadByProjectAndName(d.State(), projectName, volName)
+		inst, err := instance.LoadByProjectAndName(s, projectName, volName)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1109,7 +1110,7 @@ func pruneExpireCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) 
 		}
 
 		opRun := func(op *operations.Operation) error {
-			return pruneExpiredCustomVolumeSnapshots(ctx, d, expiredSnapshots)
+			return pruneExpiredCustomVolumeSnapshots(ctx, d.State(), expiredSnapshots)
 		}
 
 		op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, operationtype.CustomVolumeSnapshotsExpire, nil, nil, opRun, nil, nil, nil)
@@ -1145,23 +1146,23 @@ func pruneExpireCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) 
 
 var customVolSnapshotsPruneRunning = sync.Map{}
 
-func pruneExpiredCustomVolumeSnapshots(ctx context.Context, d *Daemon, expiredSnapshots []db.StorageVolumeArgs) error {
-	for _, s := range expiredSnapshots {
-		_, loaded := customVolSnapshotsPruneRunning.LoadOrStore(s.ID, struct{}{})
+func pruneExpiredCustomVolumeSnapshots(ctx context.Context, s *state.State, expiredSnapshots []db.StorageVolumeArgs) error {
+	for _, snapshot := range expiredSnapshots {
+		_, loaded := customVolSnapshotsPruneRunning.LoadOrStore(snapshot.ID, struct{}{})
 		if loaded {
 			continue // Deletion of this snapshot is already running, skip.
 		}
 
-		pool, err := storagePools.LoadByName(d.State(), s.PoolName)
+		pool, err := storagePools.LoadByName(s, snapshot.PoolName)
 		if err != nil {
-			customVolSnapshotsPruneRunning.Delete(s.ID)
-			return fmt.Errorf("Failed to get pool %q: %w", s.PoolName, err)
+			customVolSnapshotsPruneRunning.Delete(snapshot.ID)
+			return fmt.Errorf("Failed to get pool %q: %w", snapshot.PoolName, err)
 		}
 
-		err = pool.DeleteCustomVolumeSnapshot(s.ProjectName, s.Name, nil)
-		customVolSnapshotsPruneRunning.Delete(s.ID)
+		err = pool.DeleteCustomVolumeSnapshot(snapshot.ProjectName, snapshot.Name, nil)
+		customVolSnapshotsPruneRunning.Delete(snapshot.ID)
 		if err != nil {
-			return fmt.Errorf("Error deleting custom volume snapshot %q in project %q: %w", s.Name, s.PoolName, err)
+			return fmt.Errorf("Error deleting custom volume snapshot %q in project %q: %w", snapshot.Name, snapshot.PoolName, err)
 		}
 	}
 
@@ -1293,7 +1294,7 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		opRun := func(op *operations.Operation) error {
-			autoCreateCustomVolumeSnapshots(ctx, d, volumes)
+			autoCreateCustomVolumeSnapshots(ctx, s, volumes)
 			return nil
 		}
 
@@ -1329,13 +1330,13 @@ func autoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 	return f, schedule
 }
 
-func autoCreateCustomVolumeSnapshots(ctx context.Context, d *Daemon, volumes []db.StorageVolumeArgs) {
+func autoCreateCustomVolumeSnapshots(ctx context.Context, s *state.State, volumes []db.StorageVolumeArgs) {
 	// Make the snapshots sequentially.
 	for _, v := range volumes {
 		// Run snapshot process in a go routine then collect the result, to allow context cancellation.
 		ch := make(chan struct{})
 		go func() {
-			snapshotName, err := volumeDetermineNextSnapshotName(d, v, "snap%d")
+			snapshotName, err := volumeDetermineNextSnapshotName(s, v, "snap%d")
 			if err != nil {
 				logger.Error("Error retrieving next snapshot name", logger.Ctx{"err": err, "volume": v})
 				ch <- struct{}{}
@@ -1349,7 +1350,7 @@ func autoCreateCustomVolumeSnapshots(ctx context.Context, d *Daemon, volumes []d
 				return
 			}
 
-			pool, err := storagePools.LoadByName(d.State(), v.PoolName)
+			pool, err := storagePools.LoadByName(s, v.PoolName)
 			if err != nil {
 				logger.Error("Error retrieving pool", logger.Ctx{"err": err, "pool": v.PoolName})
 				ch <- struct{}{}
@@ -1371,7 +1372,7 @@ func autoCreateCustomVolumeSnapshots(ctx context.Context, d *Daemon, volumes []d
 	}
 }
 
-func volumeDetermineNextSnapshotName(d *Daemon, volume db.StorageVolumeArgs, defaultPattern string) (string, error) {
+func volumeDetermineNextSnapshotName(s *state.State, volume db.StorageVolumeArgs, defaultPattern string) (string, error) {
 	var err error
 
 	pattern, ok := volume.Config["snapshots.pattern"]
@@ -1390,7 +1391,7 @@ func volumeDetermineNextSnapshotName(d *Daemon, volume db.StorageVolumeArgs, def
 	if count > 1 {
 		return "", fmt.Errorf("Snapshot pattern may contain '%%d' only once")
 	} else if count == 1 {
-		i := d.db.Cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+		i := s.DB.Cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 
@@ -1399,7 +1400,7 @@ func volumeDetermineNextSnapshotName(d *Daemon, volume db.StorageVolumeArgs, def
 	var snapshots []db.StorageVolumeArgs
 	var projects []string
 
-	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 		projects, err = dbCluster.GetProjectNames(ctx, tx.Tx())
 		return err
 	})
@@ -1407,19 +1408,19 @@ func volumeDetermineNextSnapshotName(d *Daemon, volume db.StorageVolumeArgs, def
 		return "", err
 	}
 
-	pools, err := d.db.Cluster.GetStoragePoolNames()
+	pools, err := s.DB.Cluster.GetStoragePoolNames()
 	if err != nil {
 		return "", err
 	}
 
 	for _, pool := range pools {
-		poolID, err := d.db.Cluster.GetStoragePoolID(pool)
+		poolID, err := s.DB.Cluster.GetStoragePoolID(pool)
 		if err != nil {
 			return "", err
 		}
 
 		for _, project := range projects {
-			snaps, err := d.db.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(project, volume.Name, db.StoragePoolVolumeTypeCustom, poolID)
+			snaps, err := s.DB.Cluster.GetLocalStoragePoolVolumeSnapshotsWithType(project, volume.Name, db.StoragePoolVolumeTypeCustom, poolID)
 			if err != nil {
 				return "", err
 			}
@@ -1438,7 +1439,7 @@ func volumeDetermineNextSnapshotName(d *Daemon, volume db.StorageVolumeArgs, def
 	}
 
 	if snapshotExists {
-		i := d.db.Cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
+		i := s.DB.Cluster.GetNextStorageVolumeSnapshotIndex(volume.PoolName, volume.Name, db.StoragePoolVolumeTypeCustom, pattern)
 		return strings.Replace(pattern, "%d", strconv.Itoa(i), 1), nil
 	}
 

--- a/lxd/storage_volumes_state.go
+++ b/lxd/storage_volumes_state.go
@@ -119,7 +119,7 @@ func storagePoolVolumeTypeStateGet(d *Daemon, r *http.Request) response.Response
 			return response.SmartError(err)
 		}
 	} else {
-		resp, err := forwardedResponseIfInstanceIsRemote(d, r, projectName, volumeName, instancetype.Any)
+		resp, err := forwardedResponseIfInstanceIsRemote(d.State(), r, projectName, volumeName, instancetype.Any)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -70,7 +70,7 @@ func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName str
 		pUpdate.Config = profile.Config
 		pUpdate.Description = profile.Description
 		pUpdate.Devices = profile.Devices
-		err = doProfileUpdate(d, p, profile.Name, profileID, &profile, pUpdate)
+		err = doProfileUpdate(s, p, profile.Name, profileID, &profile, pUpdate)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -15,9 +15,7 @@ import (
 
 var supportedVolumeTypes = []int{db.StoragePoolVolumeTypeContainer, db.StoragePoolVolumeTypeVM, db.StoragePoolVolumeTypeCustom, db.StoragePoolVolumeTypeImage}
 
-func storagePoolVolumeUpdateUsers(d *Daemon, projectName string, oldPoolName string, oldVol *api.StorageVolume, newPoolName string, newVol *api.StorageVolume) error {
-	s := d.State()
-
+func storagePoolVolumeUpdateUsers(s *state.State, projectName string, oldPoolName string, oldVol *api.StorageVolume, newPoolName string, newVol *api.StorageVolume) error {
 	// Update all instances that are using the volume with a local (non-expanded) device.
 	err := storagePools.VolumeUsedByInstanceDevices(s, oldPoolName, projectName, oldVol, false, func(dbInst db.InstanceArgs, project api.Project, usedByDevices []string) error {
 		inst, err := instance.Load(s, dbInst, project)

--- a/lxd/tokens.go
+++ b/lxd/tokens.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/lxc/lxd/lxd/db/operationtype"
 	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/shared/logger"
 )
 
-func autoRemoveExpiredTokens(ctx context.Context, d *Daemon) error {
+func autoRemoveExpiredTokens(ctx context.Context, s *state.State) error {
 	expiredTokenOps := make([]*operations.Operation, 0)
 
 	for _, op := range operations.Clone() {
@@ -42,7 +43,7 @@ func autoRemoveExpiredTokens(ctx context.Context, d *Daemon) error {
 		return nil
 	}
 
-	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, operationtype.RemoveExpiredTokens, nil, nil, opRun, nil, nil, nil)
+	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.RemoveExpiredTokens, nil, nil, opRun, nil, nil, nil)
 	if err != nil {
 		logger.Error("Failed to start remove expired tokens operation", logger.Ctx{"err": err})
 		return err
@@ -65,7 +66,7 @@ func autoRemoveExpiredTokens(ctx context.Context, d *Daemon) error {
 
 func autoRemoveExpiredTokensTask(d *Daemon) (task.Func, task.Schedule) {
 	f := func(ctx context.Context) {
-		_ = autoRemoveExpiredTokens(ctx, d)
+		_ = autoRemoveExpiredTokens(ctx, d.State())
 	}
 
 	return f, task.Every(time.Minute)


### PR DESCRIPTION
The daemon is currently passed to a lot of functions. Some of these functions rely just on the state and gateway.

This PR reduces the use of the daemon as an argument, and replaces it with the state and gateway (if needeed).
