### PR TITLE
lxc/config_device: Don't panic on nil device map.

### DIFF
--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -142,6 +142,10 @@ func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
+		if profile.Devices == nil {
+			profile.Devices = make(map[string]map[string]string)
+		}
+
 		_, ok := profile.Devices[devname]
 		if ok {
 			return fmt.Errorf(i18n.G("The device already exists"))


### PR DESCRIPTION
System tests for this PR https://github.com/canonical/lxd-cloud/pull/287 are failing because the device map is nil (https://github.com/canonical/lxd-cloud/actions/runs/4893364018/jobs/8736415167?pr=287#step:6:2856). 

This adds a nil check on the profile device map before assignment.