### PR TITLE
lxd/certificates: Allow non-admin users to delete only their certificates

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -1119,6 +1119,45 @@ func certificateDelete(d *Daemon, r *http.Request) response.Response {
 				return err
 			}
 
+			return nil
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		// Non-admins are able to delete only their own certificate.
+		if !rbac.UserIsAdmin(r) {
+			if r.TLS == nil {
+				response.Forbidden(fmt.Errorf("Cannot delete certificate"))
+			}
+
+			certBlock, _ := pem.Decode([]byte(certInfo.Certificate))
+
+			cert, err := x509.ParseCertificate(certBlock.Bytes)
+			if err != nil {
+				// This should not happen
+				return response.InternalError(err)
+			}
+
+			trustedCerts := map[string]x509.Certificate{
+				certInfo.Name: *cert,
+			}
+
+			trusted := false
+			for _, i := range r.TLS.PeerCertificates {
+				trusted, _ = util.CheckTrustState(*i, trustedCerts, s.Endpoints.NetworkCert(), false)
+
+				if trusted {
+					break
+				}
+			}
+
+			if !trusted {
+				return response.Forbidden(fmt.Errorf("Certificate cannot be deleted"))
+			}
+		}
+
+		err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			// Perform the delete with the expanded fingerprint.
 			return dbCluster.DeleteCertificate(ctx, tx.Tx(), certInfo.Fingerprint)
 		})

--- a/test/suites/pki.sh
+++ b/test/suites/pki.sh
@@ -77,6 +77,12 @@ test_pki() {
     # This should succeed as is the same as the test above but with an incorrect password rather than no password.
     lxc_remote remote add pki-lxd "${LXD5_ADDR}" --accept-certificate --password=bar
     lxc_remote config trust ls pki-lxd: | grep lxd-client
+
+    # Try removing the fingerprint.
+    # This should succeed as the admin can delete all certificates.
+    fingerprint="$(lxc_remote config trust ls pki-lxd: --format csv | cut -d, -f4)"
+    lxc_remote config trust rm pki-lxd:"${fingerprint}"
+
     lxc_remote remote remove pki-lxd
 
     # Replace the client certificate with a revoked certificate in the CRL.


### PR DESCRIPTION
Up until now, non-admin users could delete certificates other than their
own. This should not be possible, but instead align with what is done
when updating certificates. There, non-admin users can only update their
own certificate.

This ensures that non-admin users can only delete their own certificate.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>
