### PR TITLE
Daemon: Start tertiary listeners (storage buckets and metrics) after managed network are initialised

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1084,8 +1084,6 @@ func (d *Daemon) init() error {
 	localHTTPAddress := d.localConfig.HTTPSAddress()
 	localClusterAddress := d.localConfig.ClusterAddress()
 	debugAddress := d.localConfig.DebugAddress()
-	metricsAddress := d.localConfig.MetricsAddress()
-	storageBucketsAddress := d.localConfig.StorageBucketsAddress()
 
 	if os.Getenv("LISTEN_PID") != "" {
 		d.systemdSocketActivated = true
@@ -1093,21 +1091,19 @@ func (d *Daemon) init() error {
 
 	/* Setup the web server */
 	config := &endpoints.Config{
-		Dir:                   d.os.VarDir,
-		UnixSocket:            d.UnixSocket(),
-		Cert:                  networkCert,
-		RestServer:            restServer(d),
-		DevLxdServer:          devLxdServer(d),
-		LocalUnixSocketGroup:  d.config.Group,
-		NetworkAddress:        localHTTPAddress,
-		ClusterAddress:        localClusterAddress,
-		DebugAddress:          debugAddress,
-		MetricsAddress:        metricsAddress,
-		MetricsServer:         metricsServer(d),
-		StorageBucketsAddress: storageBucketsAddress,
-		StorageBucketsServer:  storageBucketsServer(d),
-		VsockServer:           vSockServer(d),
-		VsockSupport:          false,
+		Dir:                  d.os.VarDir,
+		UnixSocket:           d.UnixSocket(),
+		Cert:                 networkCert,
+		RestServer:           restServer(d),
+		DevLxdServer:         devLxdServer(d),
+		LocalUnixSocketGroup: d.config.Group,
+		NetworkAddress:       localHTTPAddress,
+		ClusterAddress:       localClusterAddress,
+		DebugAddress:         debugAddress,
+		MetricsServer:        metricsServer(d),
+		StorageBucketsServer: storageBucketsServer(d),
+		VsockServer:          vSockServer(d),
+		VsockSupport:         false,
 	}
 
 	// Enable vsock server support if VM instances supported.
@@ -1409,6 +1405,23 @@ func (d *Daemon) init() error {
 	err = networkStartup(d.State())
 	if err != nil {
 		return err
+	}
+
+	// Setup tertiary listeners that may use managed network addresses and must be started after networks.
+	metricsAddress := d.localConfig.MetricsAddress()
+	if metricsAddress != "" {
+		err = d.endpoints.UpMetrics(metricsAddress)
+		if err != nil {
+			return err
+		}
+	}
+
+	storageBucketsAddress := d.localConfig.StorageBucketsAddress()
+	if storageBucketsAddress != "" {
+		err = d.endpoints.UpStorageBuckets(storageBucketsAddress)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Load instance placement scriptlet.

--- a/lxd/endpoints/listeners/fancytls.go
+++ b/lxd/endpoints/listeners/fancytls.go
@@ -12,8 +12,8 @@ import (
 )
 
 // FancyTLSListener is a variation of the standard tls.Listener that supports
-// atomically swapping the underlying TLS configuration. Requests served before
-// the swap will continue using the old configuration.
+// atomically swapping the underlying TLS configuration and proxy protocol wrapping.
+// Requests served before the swap will continue using the old configuration.
 type FancyTLSListener struct {
 	net.Listener
 	mu           sync.RWMutex


### PR DESCRIPTION
This allows these listeners to be bound to a managed network addresses.