### PR TITLE
doc: clarify TSIG key name generation for network zones

### DIFF
--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -148,9 +148,9 @@ Key                 | Type       | Required | Default | Description
 `user.*`            | *          | no       | -       | User-provided free-form key/value pairs
 
 ```{note}
-When generating the TSIG key using `tsig-keygen`, the key name should follow the format `<zone_name>_<peer_name>.`.
-For example, if your zone name is `lxd.example.net` and peer name is `bind9`, then the key name should be `lxd.example.net_bind9.`.
-If this format is not followed, zone transfer may fail.
+When generating the TSIG key using `tsig-keygen`, the key name must follow the format `<zone_name>_<peer_name>.`.
+For example, if your zone name is `lxd.example.net` and the peer name is `bind9`, then the key name must be `lxd.example.net_bind9.`.
+If this format is not followed, zone transfer might fail.
 ```
 
 ## Add a network zone to a network

--- a/doc/howto/network_zones.md
+++ b/doc/howto/network_zones.md
@@ -147,6 +147,12 @@ Key                 | Type       | Required | Default | Description
 `network.nat`       | bool       | no       | `true`  | Whether to generate records for NAT-ed subnets
 `user.*`            | *          | no       | -       | User-provided free-form key/value pairs
 
+```{note}
+When generating the TSIG key using `tsig-keygen`, the key name should follow the format `<zone_name>_<peer_name>.`.
+For example, if your zone name is `lxd.example.net` and peer name is `bind9`, then the key name should be `lxd.example.net_bind9.`.
+If this format is not followed, zone transfer may fail.
+```
+
 ## Add a network zone to a network
 
 To add a zone to a network, set the corresponding configuration option in the network configuration:


### PR DESCRIPTION
This PR enhances the documentation by elucidating an undocumented behavior regarding the generation of TSIG key names within network zones. This change aims to prevent confusion and aid in the correct utilization of the feature.

Link to the corresponding code:
https://github.com/lxc/lxd/blob/d4cfed376e76e47bcf4bf8b1e72ce101200fb4bc/lxd/db/network_zones.go#L104
