### PR TITLE
Doc: clean up FAQ

### DIFF
--- a/doc/explanation/security.md
+++ b/doc/explanation/security.md
@@ -60,6 +60,7 @@ See {ref}`authentication` for details.
 In a production setup, you should set `core.https_address` to the single address where the server should be available (rather than any address on the host).
 In addition, you should set firewall rules to allow access to the LXD port only from authorized hosts/subnets.
 
+(container-security)=
 ## Container security
 
 LXD containers can use a wide range of features for security.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -1,183 +1,75 @@
 # Frequently asked questions
 
-## General issues
+The following sections give answers to frequently asked questions.
+They explain how to resolve common issues and point you to more detailed information.
 
-### How to enable LXD server for remote access?
+## How to enable the LXD server for remote access?
 
-By default, the LXD server is not accessible from the network as it only listens
-on a local Unix socket. You can make LXD available from the network by specifying
-additional addresses to listen to. This is done with the `core.https_address`
-configuration variable.
+By default, the LXD server is not accessible from the network, because it only listens on a local Unix socket.
 
-To see the current server configuration, run:
+You can enable it for remote access by following the instructions in {ref}`server-expose`.
 
-```bash
-lxc config show
-```
+## When I do a `lxc remote add`, it asks for a password or token?
 
-To set the address to listen to, first find out what addresses are available and
-then use the `config set` command on the server:
+To be able to access the remote API, clients must authenticate with the LXD server.
+Depending on how the remote server is configured, you must provide either a trust token issued by the server or specify a trust password (if [`core.trust_password`](server-options-core) is set).
 
-```bash
-ip addr
-lxc config set core.https_address 192.0.2.1
-```
+See {ref}`server-authenticate` for instructions on how to authenticate using a trust token (the recommended way), and  {doc}`authentication` for information about other authentication methods.
 
-Also see {ref}`security_remote_access`.
+## Why should I not run privileged containers?
 
-### When I do a `lxc remote add` over HTTPS, it asks for a password?
+A privileged container can do things that affect the entire host - for example, it can use things in `/sys` to reset the network card, which will reset it for the entire host, causing network blips.
+See {ref}`container-security` for more information.
 
-By default, LXD has no password for security reasons, so you can't do a remote
-add this way. To set a password, enter the following command on the host LXD is
-running on:
+Almost everything can be run in an unprivileged container, or - in cases of things that require unusual privileges, like wanting to mount NFS file systems inside the container - you might need to use bind mounts.
 
-```bash
-lxc config set core.trust_password SECRET
-```
+## Can I bind-mount my home directory in a container?
 
-This will set the remote password that you can then use to do `lxc remote add`.
+Yes, you can do this by using a {ref}`disk device <devices-disk>`:
 
-You can also access the server without setting a password by copying the client
-certificate (`~/.config/lxc/client.crt` or `~/snap/lxd/common/config/client.crt`
-for snap users) to the server and adding it with:
+    lxc config device add container-name home disk source=/home/${USER} path=/home/ubuntu
 
-```bash
-lxc config trust add client.crt
-```
+For unprivileged containers, you need to make sure that the user in the container has working read/write permissions.
+Otherwise, all files will show up as the overflow UID/GID (`65536:65536`) and access to anything that's not world-readable will fail.
+Use either of the following methods to grant the required permissions:
 
-See {doc}`authentication` for detailed information.
-
-### Can I bind-mount my home directory in a container?
-
-Yes. This can be done using a disk device:
-
-```bash
-lxc config device add container-name home disk source=/home/${USER} path=/home/ubuntu
-```
-
-For unprivileged containers, you will also need one of:
-
-- Pass `shift=true` to the `lxc config device add` call. This depends on shiftfs being supported (see `lxc info`)
-- `raw.idmap` entry (see [Idmaps for user namespace](userns-idmap.md))
-- Recursive POSIX ACLs placed on your home directory
-
-Either of those can be used to allow the user in the container to have working read/write permissions.
-When not setting one of those, everything will show up as the overflow UID/GID (65536:65536)
-and access to anything that's not world readable will fail.
+- Pass `shift=true` to the `lxc config device add` call. This depends on the kernel and file system supporting either idmapped mounts or shiftfs (see `lxc info`).
+- Add a `raw.idmap` entry (see [Idmaps for user namespace](userns-idmap.md)).
+- Place recursive POSIX ACLs on your home directory.
 
 Privileged containers do not have this issue because all UID/GID in the container are the same as outside.
 But that's also the cause of most of the security issues with such privileged containers.
 
-### How can I run Docker inside a LXD container?
+## How can I run Docker inside a LXD container?
 
-To run Docker inside a LXD container, the `security.nesting` property of the container should be set to `true`.
-
-```bash
-lxc config set <container> security.nesting true
+```{youtube} https://www.youtube.com/watch?v=_fCSSEyiGro
 ```
 
-Note that LXD containers cannot load kernel modules, so depending on your
-Docker configuration you might need to have the needed extra kernel modules
-loaded by the host.
+To run Docker inside a LXD container, set the [`security.nesting`](instance-options-security) property of the container to `true`:
 
-You can do so by setting a comma-separated list of kernel modules that your container needs with:
+    lxc config set <container> security.nesting true
 
-```bash
-lxc config set <container> linux.kernel_modules <modules>
-```
+Note that LXD containers cannot load kernel modules, so depending on your Docker configuration, you might need to have extra kernel modules loaded by the host.
+You can do so by setting a comma-separated list of kernel modules that your container needs:
 
-We have also received some reports that creating a `/.dockerenv` file in your
-container can help Docker ignore some errors it's getting due to running in a
-nested environment.
+    lxc config set <container_name> linux.kernel_modules <modules>
 
-### Where does `lxc` store its configuration?
+In addition, creating a `/.dockerenv` file in your container can help Docker ignore some errors it's getting due to running in a nested environment.
 
-The `lxc` command stores its configuration under `~/.config/lxc` or in `~/snap/lxd/common/config`
-for snap users.
+## Where does the LXD client (`lxc`) store its configuration?
 
-Various configuration files are stored in that directory, among which are:
+The `lxc` command stores its configuration under `~/.config/lxc`, or in `~/snap/lxd/common/config` for snap users.
+
+Various configuration files are stored in that directory, for example:
 
 - `client.crt`: client certificate (generated on demand)
 - `client.key`: client key (generated on demand)
-- `config.yml`: configuration file (info about `remotes`, `aliases`, etc)
+- `config.yml`: configuration file (info about `remotes`, `aliases`, etc.)
 - `servercerts/`: directory with server certificates belonging to `remotes`
 
-## Networking issues
+## Why can I not ping my LXD instance from another host?
 
-In a larger [Production Environment](performance-tuning), it is common to have
-multiple VLANs and have LXD clients attached directly to those VLANs. Be aware that
-if you are using `netplan` and `systemd-networkd`, you will encounter some bugs that
-could cause catastrophic issues.
+Many switches do not allow MAC address changes, and will either drop traffic with an incorrect MAC or disable the port totally.
+If you can ping a LXD instance from the host, but are not able to ping it from a different host, this could be the cause.
 
-### Do not use `systemd-networkd` with `netplan` and bridges based on VLANs
-
-At time of writing (2019-03-05), `netplan` cannot assign a random MAC address to
-a bridge attached to a VLAN. It always picks the same MAC address, which causes
-layer2 issues when you have more than one machine on the same network segment.
-It also has difficulty creating multiple bridges.  Make sure you use
-`network-manager` instead. An example configuration is below, with a management
-address of 10.61.0.25, and VLAN102 being used for client traffic.
-
-    network:
-      version: 2
-      renderer: NetworkManager
-      ethernets:
-        eth0:
-          dhcp4: no
-          accept-ra: no
-          # This is the 'Management Address'
-          addresses: [ 10.61.0.25/24 ]
-          gateway4: 10.61.0.1
-          nameservers:
-            addresses: [ 1.1.1.1, 8.8.8.8 ]
-        eth1:
-          dhcp4: no
-          accept-ra: no
-          # A bogus IP address is required to ensure the link state is up
-          addresses: [ 10.254.254.25/32 ]
-
-      vlans:
-        vlan102:
-          accept-ra: no
-          dhcp4: no
-          id: 102
-          link: eth1
-
-      bridges:
-        br102:
-          accept-ra: no
-          dhcp4: no
-          interfaces: [ "vlan102" ]
-          # A bogus IP address is required to ensure the link state is up
-          addresses: [ 10.254.102.25/32 ]
-          parameters:
-            stp: false
-
-#### Things to note
-
-- `eth0` is the Management interface, with the default gateway.
-- `vlan102` uses `eth1`.
-- `br102` uses `vlan102`, and has a bogus /32 IP address assigned to it.
-
-The other important thing is to set `stp: false`, otherwise the bridge will sit
-in `learning` state for up to 10 seconds, which is longer than most DHCP requests
-last. As there is no possibility of cross-connecting and causing loops, this is
-safe to do.
-
-### Beware of port security
-
-Many switches do not allow MAC address changes, and will either drop traffic
-with an incorrect MAC or disable the port totally. If you can ping a LXD instance
-from the host, but are not able to ping it from a different host, this could be
-the cause.  The way to diagnose this is to run a `tcpdump` on the uplink (in this case,
-`eth1`), and you will see either "ARP Who has `xx.xx.xx.xx` tell `yy.yy.yy.yy`", with you
-sending responses but them not getting acknowledged, or ICMP packets going in and
-out successfully, but never being received by the other host.
-
-### Do not run privileged containers unless necessary
-
-A privileged container can do things that affect the entire host - for example, it
-can use things in `/sys` to reset the network card, which will reset it for **the entire
-host**, causing network blips. Almost everything can be run in an unprivileged container,
-or - in cases of things that require unusual privileges, like wanting to mount NFS
-file systems inside the container - you might need to use bind mounts.
+The way to diagnose this problem is to run a `tcpdump` on the uplink (`eth1` in the example from the previous question), and you will see either ``ARP Who has `xx.xx.xx.xx` tell `yy.yy.yy.yy` ``, with you sending responses but them not getting acknowledged, or ICMP packets going in and out successfully, but never being received by the other host.

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -3,6 +3,14 @@
 The following sections give answers to frequently asked questions.
 They explain how to resolve common issues and point you to more detailed information.
 
+## Why do my instances not have network access?
+
+Most likely, your firewall blocks network access for your instances.
+See {ref}`network-bridge-firewall` for more information about the problem and how to fix it.
+
+Another frequent reason for connectivity issues is running LXD and Docker on the same host.
+See {ref}`network-lxd-docker` for instructions on how to fix such issues.
+
 ## How to enable the LXD server for remote access?
 
 By default, the LXD server is not accessible from the network, because it only listens on a local Unix socket.

--- a/doc/howto/network_bridge_firewalld.md
+++ b/doc/howto/network_bridge_firewalld.md
@@ -93,6 +93,7 @@ For example:
     :end-before: <!-- Include end warning -->
 ```
 
+(network-lxd-docker)=
 ## Prevent issues with LXD and Docker
 
 Running LXD and Docker on the same host can cause connectivity issues.

--- a/doc/howto/server_expose.md
+++ b/doc/howto/server_expose.md
@@ -1,15 +1,47 @@
 (server-expose)=
 # How to expose LXD to the network
 
-By default, LXD can be used only by local users through a Unix socket.
+By default, LXD can be used only by local users through a Unix socket and is not accessible over the network.
 
-To expose LXD to the network, set the [`core.https_address`](server) server configuration option.
+To expose LXD to the network, you must configure it to listen to addresses other than the local Unix socket.
+To do so, set the [`core.https_address`](server) server configuration option.
+
 For example, to allow access to the LXD server on port `8443`, enter the following command:
 
     lxc config set core.https_address :8443
 
+To allow access through a specific IP address, use `ip addr` to find an available address and then set it.
+For example:
+
+```{terminal}
+:input: ip addr
+
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
+    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+    inet 127.0.0.1/8 scope host lo
+       valid_lft forever preferred_lft forever
+    inet6 ::1/128 scope host
+       valid_lft forever preferred_lft forever
+2: enp5s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc mq state UP group default qlen 1000
+    link/ether 00:16:3e:e3:f3:3f brd ff:ff:ff:ff:ff:ff
+    inet 10.68.216.12/24 metric 100 brd 10.68.216.255 scope global dynamic enp5s0
+       valid_lft 3028sec preferred_lft 3028sec
+    inet6 fd42:e819:7a51:5a7b:216:3eff:fee3:f33f/64 scope global mngtmpaddr noprefixroute
+       valid_lft forever preferred_lft forever
+    inet6 fe80::216:3eff:fee3:f33f/64 scope link
+       valid_lft forever preferred_lft forever
+3: lxdbr0: <NO-CARRIER,BROADCAST,MULTICAST,UP> mtu 1500 qdisc noqueue state DOWN group default qlen 1000
+    link/ether 00:16:3e:8d:f3:72 brd ff:ff:ff:ff:ff:ff
+    inet 10.64.82.1/24 scope global lxdbr0
+       valid_lft forever preferred_lft forever
+    inet6 fd42:f4ab:4399:e6eb::1/64 scope global
+       valid_lft forever preferred_lft forever
+:input: lxc config set core.https_address 10.68.216.12
+```
+
 All remote clients can then connect to LXD and access any image that is marked for public use.
 
+(server-authenticate)=
 ## Authenticate with the LXD server
 
 To be able to access the remote API, clients must authenticate with the LXD server.


### PR DESCRIPTION
Clean up the FAQ (mostly adding links to existing content and moving details to the respective doc sections) and add an entry for the common firewall question.