### PR TITLE
Network: Add support for sticky DHCPv4 dynamic allocations for `ovn` NICs

### DIFF
--- a/doc/reference/instance_options.md
+++ b/doc/reference/instance_options.md
@@ -446,6 +446,7 @@ Key                                         | Type      | Description
 `volatile.<name>.last_state.created`        | string    | Whether the network device physical device was created (`true` or `false`)
 `volatile.<name>.last_state.mtu`            | string    | Network device original MTU used when moving a physical device into an instance
 `volatile.<name>.last_state.hwaddr`         | string    | Network device original MAC used when moving a physical device into an instance
+`volatile.<name>.last_state.ip_addresses`   | string    | Network device comma-separated list of last used IP addresses
 `volatile.<name>.last_state.vdpa.name`      | string    | VDPA device name used when moving a VDPA device file descriptor into an instance
 `volatile.<name>.last_state.vf.id`          | string    | SR-IOV virtual function ID used when moving a VF into an instance
 `volatile.<name>.last_state.vf.hwaddr`      | string    | SR-IOV virtual function original MAC used when moving a VF into an instance

--- a/lxd/device/nic_ovn.go
+++ b/lxd/device/nic_ovn.go
@@ -37,7 +37,7 @@ type ovnNet interface {
 
 	InstanceDevicePortValidateExternalRoutes(deviceInstance instance.Instance, deviceName string, externalRoutes []*net.IPNet) error
 	InstanceDevicePortAdd(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
-	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, error)
+	InstanceDevicePortStart(opts *network.OVNInstanceNICSetupOpts, securityACLsRemove []string) (openvswitch.OVNSwitchPort, []net.IP, error)
 	InstanceDevicePortStop(ovsExternalOVNPort openvswitch.OVNSwitchPort, opts *network.OVNInstanceNICStopOpts) error
 	InstanceDevicePortRemove(instanceUUID string, deviceName string, deviceConfig deviceConfig.Device) error
 	InstanceDevicePortDynamicIPs(instanceUUID string, deviceName string) ([]net.IP, error)
@@ -539,7 +539,7 @@ func (d *nicOVN) Start() (*deviceConfig.RunConfig, error) {
 	networkVethFillFromVolatile(d.config, saveData)
 
 	// Add new OVN logical switch port for instance.
-	logicalPortName, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+	logicalPortName, _, err := d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
 		InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 		DNSName:      d.inst.Name(),
 		DeviceName:   d.name,
@@ -707,7 +707,7 @@ func (d *nicOVN) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 			}
 
 			// Update OVN logical switch port for instance.
-			_, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
+			_, _, err = d.network.InstanceDevicePortStart(&network.OVNInstanceNICSetupOpts{
 				InstanceUUID: d.inst.LocalConfig()["volatile.uuid"],
 				DNSName:      d.inst.Name(),
 				DeviceName:   d.name,

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3298,7 +3298,7 @@ func (n *ovn) InstanceDevicePortAdd(instanceUUID string, deviceName string, devi
 		return fmt.Errorf("Failed to get OVN client: %w", err)
 	}
 
-	dnsUUID, err := client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, "", nil, nil)
+	dnsUUID, err := client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, "", nil)
 	if err != nil {
 		return fmt.Errorf("Failed adding DNS record: %w", err)
 	}
@@ -3491,9 +3491,10 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 
 	// Add DNS records for port's IPs, and retrieve the IP addresses used.
 	var dnsIPv4, dnsIPv6 net.IP
+	dnsIPs := make([]net.IP, 0, 2)
 
 	// checkAndStoreIP checks if the supplied IP is valid and can be used for a missing DNS IP.
-	// If the found IP is needed, stores into the relevant dnsIPv{X} variable.
+	// If the found IP is needed, stores into the relevant dnsIPv{X} variable and into dnsIPs slice.
 	checkAndStoreIP := func(ip net.IP) {
 		if ip != nil {
 			isV4 := ip.To4() != nil
@@ -3502,6 +3503,8 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 			} else if dnsIPv6 == nil && !isV4 {
 				dnsIPv6 = ip
 			}
+
+			dnsIPs = append(dnsIPs, ip)
 		}
 	}
 
@@ -3540,7 +3543,7 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 	}
 
 	dnsName := fmt.Sprintf("%s.%s", opts.DNSName, n.getDomainName())
-	dnsUUID, err := client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, dnsName, dnsIPv4, dnsIPv6)
+	dnsUUID, err := client.LogicalSwitchPortSetDNS(n.getIntSwitchName(), instancePortName, dnsName, dnsIPs)
 	if err != nil {
 		return "", fmt.Errorf("Failed setting DNS for %q: %w", dnsName, err)
 	}

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -71,6 +71,7 @@ type OVNInstanceNICSetupOpts struct {
 	DeviceConfig deviceConfig.Device
 	UplinkConfig map[string]string
 	DNSName      string
+	LastStateIPs []net.IP
 }
 
 // OVNInstanceNICStopOpts options for stopping an OVN Instance NIC.

--- a/lxd/network/driver_ovn.go
+++ b/lxd/network/driver_ovn.go
@@ -3422,10 +3422,11 @@ func (n *ovn) InstanceDevicePortStart(opts *OVNInstanceNICSetupOpts, securityACL
 				return "", nil, fmt.Errorf("Could not find DHCPv6 options for instance port for subnet %q", dhcpv6Subnet.String())
 			}
 
-			// If port isn't going to have fully dynamic IPs allocated by OVN, and instead only static IPv4
-			// addresses have been added, then add an EUI64 static IPv6 address so that the switch port has an
-			// IPv6 address that will be used to generate a DNS record. This works around a limitation in OVN
-			// that prevents us requesting dynamic IPv6 address allocation when static IPv4 allocation is used.
+			// If port isn't going to have fully dynamic IPs allocated by OVN, and instead only static
+			// IPv4 addresses have been added, then add an EUI64 static IPv6 address so that the switch
+			// port has an IPv6 address that will be used to generate a DNS record. This works around a
+			// limitation in OVN that prevents us requesting dynamic IPv6 address allocation when
+			// static IPv4 allocation is used.
 			if len(staticIPs) > 0 {
 				hasIPv6 := false
 				for _, ip := range staticIPs {

--- a/lxd/network/network_utils.go
+++ b/lxd/network/network_utils.go
@@ -1097,6 +1097,16 @@ func InterfaceExists(nic string) bool {
 	return false
 }
 
+// IPInSlice returns true if slice has IP element.
+func IPInSlice(key net.IP, list []net.IP) bool {
+	for _, entry := range list {
+		if entry.Equal(key) {
+			return true
+		}
+	}
+	return false
+}
+
 // SubnetContains returns true if outerSubnet contains innerSubnet.
 func SubnetContains(outerSubnet *net.IPNet, innerSubnet *net.IPNet) bool {
 	if outerSubnet == nil || innerSubnet == nil {

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -1152,6 +1152,8 @@ func (o *OVN) LogicalSwitchPortAdd(switchName OVNSwitch, portName OVNSwitchPort,
 		}
 	}
 
+	args = append(args, "--", "set", "logical_switch_port", string(portName), fmt.Sprintf("external_ids:%s=%s", ovnExtIDLXDSwitch, switchName))
+
 	_, err := o.nbctl(args...)
 	if err != nil {
 		return err

--- a/lxd/network/openvswitch/ovn.go
+++ b/lxd/network/openvswitch/ovn.go
@@ -763,7 +763,7 @@ func (o *OVN) LogicalSwitchDHCPv4RevervationsSet(switchName OVNSwitch, reservedI
 
 // LogicalSwitchDHCPv4RevervationsGet gets the DHCPv4 IP reservations.
 func (o *OVN) LogicalSwitchDHCPv4RevervationsGet(switchName OVNSwitch) ([]shared.IPRange, error) {
-	excludeIPsRaw, err := o.nbctl("get", "logical_switch", string(switchName), "other_config:exclude_ips")
+	excludeIPsRaw, err := o.nbctl("--if-exists", "get", "logical_switch", string(switchName), "other_config:exclude_ips")
 	if err != nil {
 		return nil, err
 	}
@@ -771,7 +771,7 @@ func (o *OVN) LogicalSwitchDHCPv4RevervationsGet(switchName OVNSwitch) ([]shared
 	excludeIPsRaw = strings.TrimSpace(excludeIPsRaw)
 
 	// Check if no dynamic IPs set.
-	if excludeIPsRaw == "[]" {
+	if excludeIPsRaw == "" || excludeIPsRaw == "[]" {
 		return []shared.IPRange{}, nil
 	}
 

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -332,6 +332,10 @@ func ConfigKeyChecker(key string, instanceType instancetype.Type) (func(value st
 			return validate.IsAny, nil
 		}
 
+		if strings.HasSuffix(key, ".last_state.ip_addresses") {
+			return validate.IsListOf(validate.IsNetworkAddress), nil
+		}
+
 		if strings.HasSuffix(key, ".apply_quota") {
 			return validate.IsAny, nil
 		}


### PR DESCRIPTION
This PR introduces the instance volatile key `volatile.<name>.last_state.ip_addresses` which is used to store a comma-separated list of the DNS IPs associated to an OVN NIC port on last start.

This is then provided to the OVN driver when creating the port so that the OVN driver can choose to allocate this IPv4 address to the port if it is still appropriate to use (DHCPv4 is enabled, no static IPs being used and subnet is unchanged) and is available for use (not statically reserved or in use by another instance).

This fixes an issue where, because OVN allocates IPs from the subnet sequentially (unlike dnsmasq), if an instance with an IP lower than another instance is stopped/deleted and then that other instance is rebooted it will be then allocated that lower IP.

Whilst technically correct, there are some applications (Juju) that expect IPs to remain allocated across a reboot.

This PR also starts storing the OVN logical switch name in the `ovnExtIDLXDSwitch` external_id for logical switch ports.
This was required so LXD can efficiently retrieve all IPs associated to active logical switch ports as part of checking if a previously used IP is still available for reuse.

Fixes #11658

Associated tests https://github.com/lxc/lxc-ci/pull/743