### PR TITLE
lxc/export: Fix export rename when run inside snap

### DIFF
--- a/lxc/export.go
+++ b/lxc/export.go
@@ -170,7 +170,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		err = os.Rename(shared.HostPathFollow(targetName), name+ext)
+		err = os.Rename(shared.HostPathFollow(targetName), shared.HostPathFollow(name+ext))
 		if err != nil {
 			return fmt.Errorf("Failed to rename export file: %w", err)
 		}


### PR DESCRIPTION
Fixes #11669