### PR TITLE
Websocket: Continue switch to shared/ws package

### DIFF
--- a/lxc-to-lxd/transfer.go
+++ b/lxc-to-lxd/transfer.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net"
@@ -13,8 +14,8 @@ import (
 
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/rsync"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/linux"
+	"github.com/lxc/lxd/shared/ws"
 )
 
 // Send an rsync stream of a path over a websocket.
@@ -28,7 +29,7 @@ func rsyncSend(conn *websocket.Conn, path string, rsyncArgs string) error {
 		defer func() { _ = dataSocket.Close() }()
 	}
 
-	readDone, writeDone := shared.WebsocketMirror(conn, dataSocket, io.ReadCloser(dataSocket), nil, nil)
+	readDone, writeDone := ws.Mirror(context.Background(), conn, dataSocket)
 
 	output, err := io.ReadAll(stderr)
 	if err != nil {

--- a/lxd-agent/events.go
+++ b/lxd-agent/events.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/lxc/lxd/lxd/events"
 	"github.com/lxc/lxd/lxd/response"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/ws"
 )
 
 var eventsCmd = APIEndpoint{
@@ -44,7 +44,7 @@ func eventsSocket(d *Daemon, r *http.Request, w http.ResponseWriter) error {
 	// If the client has not requested a websocket connection then fallback to long polling event stream mode.
 	if r.Header.Get("Upgrade") == "websocket" {
 		// Upgrade the connection to websocket
-		conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+		conn, err := ws.Upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd-agent/exec.go
+++ b/lxd-agent/exec.go
@@ -189,7 +189,7 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 
 	for fd, fdSecret := range s.fds {
 		if secret == fdSecret {
-			conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+			conn, err := ws.Upgrader.Upgrade(w, r, nil)
 			if err != nil {
 				return err
 			}

--- a/lxd-migrate/transfer.go
+++ b/lxd-migrate/transfer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/linux"
+	"github.com/lxc/lxd/shared/ws"
 )
 
 // Send an rsync stream of a path over a websocket.
@@ -30,7 +31,7 @@ func rsyncSend(ctx context.Context, conn *websocket.Conn, path string, rsyncArgs
 		defer func() { _ = dataSocket.Close() }()
 	}
 
-	readDone, writeDone := shared.WebsocketMirror(conn, dataSocket, io.ReadCloser(dataSocket), nil, nil)
+	readDone, writeDone := ws.Mirror(context.Background(), conn, dataSocket)
 
 	output, err := io.ReadAll(stderr)
 	if err != nil {

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
+	"github.com/lxc/lxd/shared/ws"
 )
 
 type hoistFunc func(f func(*Daemon, instance.Instance, http.ResponseWriter, *http.Request) response.Response, d *Daemon) func(http.ResponseWriter, *http.Request)
@@ -139,7 +140,7 @@ var devlxdEventsGet = devLxdHandler{"/1.0/events", func(d *Daemon, c instance.In
 
 	// If the client has not requested a websocket connection then fallback to long polling event stream mode.
 	if r.Header.Get("Upgrade") == "websocket" {
-		conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+		conn, err := ws.Upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return response.DevLxdErrorResponse(api.StatusErrorf(http.StatusInternalServerError, "internal server error"), c.Type() == instancetype.VM)
 		}

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/ws"
 )
 
 var eventTypes = []string{api.EventTypeLogging, api.EventTypeOperation, api.EventTypeLifecycle}
@@ -85,7 +86,7 @@ func eventsSocket(s *state.State, r *http.Request, w http.ResponseWriter) error 
 	l := logger.AddContext(logger.Log, logger.Ctx{"remote": r.RemoteAddr})
 
 	// Upgrade the connection to websocket
-	conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+	conn, err := ws.Upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		l.Warn("Failed upgrading event connection", logger.Ctx{"err": err})
 		return nil

--- a/lxd/instance/drivers/driver_lxc.go
+++ b/lxd/instance/drivers/driver_lxc.go
@@ -73,6 +73,7 @@ import (
 	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/termios"
 	"github.com/lxc/lxd/shared/units"
+	"github.com/lxc/lxd/shared/ws"
 )
 
 // Helper functions.
@@ -5350,7 +5351,7 @@ func (d *lxc) MigrateSend(args instance.MigrateSendArgs) error {
 							return os.ErrPermission
 						}
 
-						c, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+						c, err := ws.Upgrader.Upgrade(w, r, nil)
 						if err != nil {
 							return err
 						}

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -277,16 +277,16 @@ func (s *consoleWs) doConsole(op *operations.Operation) error {
 	// Mirror the console and websocket.
 	mirrorDoneCh := make(chan struct{})
 	go func() {
-		defer logger.Debugf("Finished mirroring websocket to console")
+		defer logger.Debug("Finished mirroring websocket to console")
 		s.connsLock.Lock()
 		conn := s.conns[0]
 		s.connsLock.Unlock()
 
-		logger.Debugf("Started mirroring websocket")
+		logger.Debug("Started mirroring websocket")
 		readDone, writeDone := ws.Mirror(context.Background(), conn, console)
 
 		<-readDone
-		logger.Debugf("Finished mirroring console to websocket")
+		logger.Debug("Finished mirroring console to websocket")
 		<-writeDone
 		close(mirrorDoneCh)
 	}()

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -283,7 +283,7 @@ func (s *consoleWs) doConsole(op *operations.Operation) error {
 		s.connsLock.Unlock()
 
 		logger.Debugf("Started mirroring websocket")
-		readDone, writeDone := shared.WebsocketConsoleMirror(conn, console, console)
+		readDone, writeDone := ws.Mirror(context.Background(), conn, console)
 
 		<-readDone
 		logger.Debugf("Finished mirroring console to websocket")

--- a/lxd/instance_console.go
+++ b/lxd/instance_console.go
@@ -94,7 +94,7 @@ func (s *consoleWs) connectConsole(op *operations.Operation, r *http.Request, w 
 
 	for fd, fdSecret := range s.fds {
 		if secret == fdSecret {
-			conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+			conn, err := ws.Upgrader.Upgrade(w, r, nil)
 			if err != nil {
 				return err
 			}
@@ -138,7 +138,7 @@ func (s *consoleWs) connectVGA(op *operations.Operation, r *http.Request, w http
 			continue
 		}
 
-		conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+		conn, err := ws.Upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/instance_exec.go
+++ b/lxd/instance_exec.go
@@ -77,7 +77,7 @@ func (s *execWs) Connect(op *operations.Operation, r *http.Request, w http.Respo
 
 	for fd, fdSecret := range s.fds {
 		if secret == fdSecret {
-			conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+			conn, err := ws.Upgrader.Upgrade(w, r, nil)
 			if err != nil {
 				return err
 			}

--- a/lxd/migration_connection.go
+++ b/lxd/migration_connection.go
@@ -91,7 +91,7 @@ func (c *migrationConn) AcceptIncoming(r *http.Request, w http.ResponseWriter) e
 	}
 
 	var err error
-	c.conn, err = shared.WebsocketUpgrader.Upgrade(w, r, nil)
+	c.conn, err = ws.Upgrader.Upgrade(w, r, nil)
 	if err != nil {
 		return fmt.Errorf("Failed upgrading incoming request to websocket: %w", err)
 	}

--- a/lxd/operations/websocket.go
+++ b/lxd/operations/websocket.go
@@ -7,7 +7,6 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/lxd/lxd/response"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/ws"
 )
 
@@ -53,7 +52,7 @@ func ForwardedOperationWebSocket(req *http.Request, id string, source *websocket
 
 func (r *forwardedOperationWebSocket) Render(w http.ResponseWriter) error {
 	// Upgrade target connection to websocket.
-	target, err := shared.WebsocketUpgrader.Upgrade(w, r.req, nil)
+	target, err := ws.Upgrader.Upgrade(w, r.req, nil)
 	if err != nil {
 		return err
 	}

--- a/shared/network.go
+++ b/shared/network.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"net/http"
 	"os"
 	"strings"
 	"time"
@@ -271,11 +270,6 @@ func WebsocketMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, Re
 	go WriteFunc(conn, w, writeDone)
 
 	return readDone, writeDone
-}
-
-var WebsocketUpgrader = websocket.Upgrader{
-	CheckOrigin:      func(r *http.Request) bool { return true },
-	HandshakeTimeout: time.Second * 5,
 }
 
 // AllocatePort asks the kernel for a free open port that is ready to use.


### PR DESCRIPTION
As this PR changes the instance console websocket mirroring implementation we can close #11174 as that function no longer exists.

Closes #11174