### PR TITLE
Cluster: Don't create a cluster heal operation every minute (and cause unnecessary logs) 

### DIFF
--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -793,7 +793,7 @@ func OperationLockName(operationName string, poolName string, volType VolumeType
 }
 
 // loopFileSizeDefault returns the size in Gigabytes to use as the default size for a pool loop file.
-// This is based on the free space available in LXD's VarPath().
+// This is based on the size of the filesystem of LXD's VarPath().
 func loopFileSizeDefault() (uint64, error) {
 	st := unix.Statfs_t{}
 	err := unix.Statfs(shared.VarPath(), &st)


### PR DESCRIPTION
When there is nothing to heal.

Fixes https://github.com/lxc/lxd/issues/11702