### PR TITLE
Instance: Cluster healing fixes to support projects and starting instances after evacuation

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -4437,7 +4437,13 @@ func autoHealClusterTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		opRun := func(op *operations.Operation) error {
-			return autoHealCluster(ctx, s, offlineMembers)
+			err := autoHealCluster(ctx, s, offlineMembers)
+			if err != nil {
+				logger.Error("Failed healing cluster instances", logger.Ctx{"err": err})
+				return err
+			}
+
+			return nil
 		}
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ClusterHeal, nil, nil, opRun, nil, nil, nil)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -4408,7 +4408,7 @@ func autoHealClusterTask(d *Daemon) (task.Func, task.Schedule) {
 		var offlineMembers []db.NodeInfo
 		{
 			var members []db.NodeInfo
-			err = s.DB.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+			err = s.DB.Cluster.Transaction(ctx, func(ctx context.Context, tx *db.ClusterTx) error {
 				members, err = tx.GetNodes(ctx)
 				if err != nil {
 					return fmt.Errorf("Failed getting cluster members: %w", err)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -4473,9 +4473,10 @@ func autoHealCluster(ctx context.Context, s *state.State, offlineMembers []db.No
 	}
 
 	for _, member := range offlineMembers {
+		logger.Info("Healing cluster member instances", logger.Ctx{"member": member.Name})
 		_, _, err = dest.RawQuery("POST", fmt.Sprintf("/internal/cluster/heal/%s", member.Name), nil, "")
 		if err != nil {
-			return err
+			return fmt.Errorf("Failed evacuating cluster member %q: %w", member.Name, err)
 		}
 	}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3044,6 +3044,7 @@ func internalClusterHeal(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
+		dest = dest.UseProject(inst.Project().Name)
 		dest = dest.UseTarget(targetMemberInfo.Name)
 
 		migrateOp, err := dest.MigrateInstance(inst.Name(), req)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -4384,11 +4384,9 @@ func evacuateClusterSelectTarget(ctx context.Context, s *state.State, gateway *c
 }
 
 func autoHealClusterTask(d *Daemon) (task.Func, task.Schedule) {
-	s := d.State()
-
 	f := func(ctx context.Context) {
+		s := d.State()
 		healingThreshold := s.GlobalConfig.ClusterHealingThreshold()
-
 		if healingThreshold == 0 {
 			return // Skip healing if it's disabled.
 		}

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -3057,6 +3057,21 @@ func internalClusterHeal(d *Daemon, r *http.Request) response.Response {
 			return err
 		}
 
+		if !startInstance || live {
+			return nil
+		}
+
+		// Start it back up on target.
+		startOp, err := dest.UpdateInstanceState(inst.Name(), api.InstanceStatePut{Action: "start"}, "")
+		if err != nil {
+			return err
+		}
+
+		err = startOp.Wait()
+		if err != nil {
+			return err
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
As part of testing the recent logging changes more thoroughly I noticed some issues with cluster healing that were unrelated to the logging change:

- Healing of instances in non-default projects didn't work.
- The failure of evacuations wasn't logged at error level.
- Instances that were running when the cluster member went offline were not started again on target host.
- Logging improvements showing which members were being evacuated.
- Don't keep long-lived state variables around (would go out of date).
- Don't start evacuations if daemon is shutting down.