### PR TITLE
Instance: Reject import if conflicting DB records found

### DIFF
--- a/lxd/instances_post.go
+++ b/lxd/instances_post.go
@@ -692,7 +692,7 @@ func createFromBackup(s *state.State, r *http.Request, projectName string, data 
 
 		runRevert.Add(revertHook)
 
-		err = internalImportFromBackup(s, bInfo.Project, bInfo.Name, true, instanceName != "")
+		err = internalImportFromBackup(s, bInfo.Project, bInfo.Name, instanceName != "")
 		if err != nil {
 			return fmt.Errorf("Failed importing backup: %w", err)
 		}


### PR DESCRIPTION
Discovered from https://discuss.linuxcontainers.org/t/how-to-recover-a-failed-cluster-node-after-lxc-import/17013/2?u=tomp

`internalImportFromBackup` originally harked from the `lxd import` recovery command (as well as still being used for `lxc import).

However now that we have `lxd recover`, the `internalImportFromBackup` doesn't need to support a `force` option as when we are restoring an instance from a backup we should require that there are no conflicting DB entries before completing.