### PR TITLE
Storage: Fix VM filesystem volumes incorrectly being created as ZVOLs when zfs.block_mode enabled

### DIFF
--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -310,8 +310,9 @@ func (d *zfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		}
 
 		if vol.contentType == ContentTypeBlock {
-			// Re-create the FS config volume's readonly snapshot now that the filler function has run and unpacked into both config and block volumes.
-			fsVol := NewVolume(d, d.name, vol.volType, ContentTypeFS, vol.name, vol.config, vol.poolConfig)
+			// Re-create the FS config volume's readonly snapshot now that the filler function has run
+			// and unpacked into both config and block volumes.
+			fsVol := vol.NewVMBlockFilesystemVolume()
 
 			_, err := shared.RunCommand("zfs", "destroy", fmt.Sprintf("%s@readonly", d.dataset(fsVol, false)))
 			if err != nil {

--- a/lxd/storage/drivers/volume.go
+++ b/lxd/storage/drivers/volume.go
@@ -393,6 +393,10 @@ func (v Volume) NewVMBlockFilesystemVolume() Volume {
 	// Copy volume config so modifications don't affect original volume.
 	newConf := make(map[string]string, len(v.config))
 	for k, v := range v.config {
+		if k == "zfs.block_mode" {
+			continue // VM filesystem volumes never use ZFS block mode.
+		}
+
 		newConf[k] = v
 	}
 


### PR DESCRIPTION
VM filesystem volumes should always be ZFS datasets.

Fixes #11403 