### PR TITLE
Instance: Allow copying running VMs (both consistently and inconsistently) locally

### DIFF
--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -295,10 +295,6 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 		}
 
 		rootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(entry.Devices)
-		if err != nil {
-			return err
-		}
-
 		if rootDiskDeviceKey != "" && pool != "" {
 			entry.Devices[rootDiskDeviceKey]["pool"] = pool
 		} else if pool != "" {

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -362,6 +362,13 @@ func (c *cmdCopy) copyInstance(conf *config.Config, sourceResource string, destR
 		// Ensure we don't change the target's volatile.idmap.next value.
 		writable.Config["volatile.idmap.next"] = inst.Config["volatile.idmap.next"]
 
+		// Ensure we don't change the target's root disk pool.
+		srcRootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(writable.Devices)
+		destRootDiskDeviceKey, destRootDiskDevice, _ := shared.GetRootDiskDevice(inst.Devices)
+		if srcRootDiskDeviceKey != "" && srcRootDiskDeviceKey == destRootDiskDeviceKey {
+			writable.Devices[destRootDiskDeviceKey]["pool"] = destRootDiskDevice["pool"]
+		}
+
 		op, err := dest.UpdateInstance(destName, writable, etag)
 		if err != nil {
 			return err

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -214,7 +214,7 @@ func instanceCreateAsCopy(s *state.State, opts instanceCreateAsCopyOpts, op *ope
 	} else {
 		instOp, err = inst.LockExclusive()
 		if err != nil {
-			return nil, fmt.Errorf("Failed getting exclusive access to instance: %w", err)
+			return nil, fmt.Errorf("Failed getting exclusive access to target instance: %w", err)
 		}
 	}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/minio/madmin-go"
 	"github.com/minio/minio-go/v7"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/lxd/backup"
@@ -1054,15 +1055,18 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-
-		// Use in-memory pipe pair to simulate a connection between the sender and receiver.
-		aEnd, bEnd := memorypipe.NewPipePair(ctx)
+		defer cancel()
 
 		// Run sender and receiver in separate go routines to prevent deadlocks.
-		aEndErrCh := make(chan error, 1)
-		bEndErrCh := make(chan error, 1)
-		go func() {
-			err := srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
+		g, ctx := errgroup.WithContext(ctx)
+
+		// Use in-memory pipe pair to simulate a connection between the sender and receiver.
+		// Use context from error group so that if either side fails the pipes are closed.
+		aEnd, bEnd := memorypipe.NewPipePair(ctx)
+
+		// Start each side of the migration concurrently and collect any errors.
+		g.Go(func() error {
+			return srcPool.MigrateInstance(src, aEnd, &migration.VolumeSourceArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               src.Name(),
 				Snapshots:          snapshotNames,
@@ -1072,16 +1076,10 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 				VolumeOnly:         !snapshots,
 				Info:               &migration.Info{Config: srcConfig},
 			}, op)
+		})
 
-			if err != nil {
-				cancel()
-			}
-
-			aEndErrCh <- err
-		}()
-
-		go func() {
-			err := b.CreateInstanceFromMigration(inst, bEnd, migration.VolumeTargetArgs{
+		g.Go(func() error {
+			return b.CreateInstanceFromMigration(inst, bEnd, migration.VolumeTargetArgs{
 				IndexHeaderVersion: migration.IndexHeaderVersion,
 				Name:               inst.Name(),
 				Snapshots:          snapshotNames,
@@ -1090,30 +1088,11 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 				TrackProgress:      false,         // Do not use a progress tracker on receiver.
 				VolumeOnly:         !snapshots,
 			}, op)
+		})
 
-			if err != nil {
-				cancel()
-			}
-
-			bEndErrCh <- err
-		}()
-
-		// Capture errors from the sender and receiver from their result channels.
-		errs := []error{}
-		aEndErr := <-aEndErrCh
-		if aEndErr != nil {
-			errs = append(errs, aEndErr)
-		}
-
-		bEndErr := <-bEndErrCh
-		if bEndErr != nil {
-			errs = append(errs, bEndErr)
-		}
-
-		cancel()
-
-		if len(errs) > 0 {
-			return fmt.Errorf("Create instance volume from copy failed: %v", errs)
+		err = g.Wait()
+		if err != nil {
+			return fmt.Errorf("Create instance volume from copy failed: %w", err)
 		}
 	}
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1423,6 +1423,11 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 		return err
 	}
 
+	srcPoolBackend, ok := srcPool.(*lxdBackend)
+	if !ok {
+		return fmt.Errorf("Source pool is not a lxdBackend")
+	}
+
 	// Check source volume exists, and get its config.
 	srcConfig, err := srcPool.GenerateInstanceBackupConfig(src, snapshots, op)
 	if err != nil {
@@ -1464,6 +1469,20 @@ func (b *lxdBackend) RefreshInstance(inst instance.Instance, src instance.Instan
 
 	revert := revert.New()
 	defer revert.Fail()
+
+	// Some driver backing stores require that running instances be frozen during copy.
+	if !src.IsSnapshot() && srcPoolBackend.driver.Info().RunningCopyFreeze && src.IsRunning() && !src.IsFrozen() && !allowInconsistent {
+		b.logger.Info("Freezing instance for consistent refresh")
+		err = src.Freeze()
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = src.Unfreeze() }()
+
+		// Attempt to sync the filesystem.
+		_ = filesystem.SyncFS(src.RootfsPath())
+	}
 
 	if b.Name() == srcPool.Name() {
 		l.Debug("RefreshInstance same-pool mode detected")

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -926,10 +926,6 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst instance.Instance, src instance
 		return fmt.Errorf("Instance types must match")
 	}
 
-	if src.Type() == instancetype.VM && src.IsRunning() {
-		return fmt.Errorf("Unable to perform VM live migration: %w", drivers.ErrNotSupported)
-	}
-
 	volType, err := InstanceTypeToVolumeType(inst.Type())
 	if err != nil {
 		return err

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -1208,6 +1208,7 @@ func (d *btrfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *m
 	// Handle simple rsync and block_and_rsync through generic.
 	if volSrcArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSrcArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
 		// If volume is filesystem type and is not already a snapshot, create a fast snapshot to ensure migration is consistent.
+		// TODO add support for temporary snapshots of block volumes here.
 		if vol.contentType == ContentTypeFS && !vol.IsSnapshot() {
 			snapshotPath, cleanup, err := d.readonlySnapshot(vol)
 			if err != nil {

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -1331,6 +1331,7 @@ func (d *ceph) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mi
 
 	// Handle simple rsync and block_and_rsync through generic.
 	if volSrcArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSrcArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
+		// TODO this should take a temporary snapshot.
 		// Before doing a generic volume migration, we need to ensure volume (or snap volume parent) is
 		// activated to avoid issues activating the snapshot volume device.
 		parent, _, _ := api.GetParentAndSnapshotName(vol.Name())

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -2213,6 +2213,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 	// Handle simple rsync and block_and_rsync through generic.
 	if volSrcArgs.MigrationType.FSType == migration.MigrationFSType_RSYNC || volSrcArgs.MigrationType.FSType == migration.MigrationFSType_BLOCK_AND_RSYNC {
 		// If volume is filesystem type, create a fast snapshot to ensure migration is consistent.
+		// TODO add support for temporary snapshots of block volumes here.
 		if vol.contentType == ContentTypeFS && !vol.IsSnapshot() {
 			snapshotPath, cleanup, err := d.readonlySnapshot(vol)
 			if err != nil {


### PR DESCRIPTION
Fixes #11729 

- Removes some blunt checks that prevented copying running VMs locally (both same pool and cross-pool).
- Updates the "should freeze instance" logic in `CreateInstanceFromCopy` to consider whether the source pool indicates whether the instance should be frozen during copy, rather than consulting the target, which is incorrect during a cross-pool copy.
- Applies the same freezing logic from `CreateInstanceFromCopy` to `RefreshInstance`.
- Incorporates check for raw block transfer mode in `MigrateInstance` into source instance freezing logic, rather that outright banning the migration.
- Switches `CreateInstanceFromCopy` and `RefreshInstance` migration mode to use `errgroup` to simplify and improve the UX so that only the first error is returned to the user rather than a slice of errors.
- Clarifies the error returned when the target instance is running, preventing a refresh.
- Fixes issue with root disk device pool trying to be updated by `lxc copy` on subsequent refresh.