### PR TITLE
doc: Fix descrption for lxd_memory_Inactive_anon_bytes metric

### DIFF
--- a/doc/reference/provided_metrics.md
+++ b/doc/reference/provided_metrics.md
@@ -46,7 +46,7 @@ The following instance metrics are provided:
 * - `lxd_memory_HugepagesTotal_bytes`
   - Amount of used memory for `hugetlb`
 * - `lxd_memory_Inactive_anon_bytes`
-  - Amount of file-backed memory on inactive LRU list
+  - Amount of anonymous memory on inactive LRU list
 * - `lxd_memory_Inactive_bytes`
   - Amount of memory on inactive LRU list
 * - `lxd_memory_Inactive_file_bytes`


### PR DESCRIPTION
cf. The description `Amount of file-backed memory on inactive LRU list` is for metric `lxd_memory_Inactive_file_bytes`