### PR TITLE
shared/ws/mirror: Allow passing nil to Exec

### DIFF
--- a/shared/ws/mirror.go
+++ b/shared/ws/mirror.go
@@ -77,9 +77,14 @@ func MirrorWithHooks(ctx context.Context, conn *websocket.Conn, rwc io.ReadWrite
 
 // MirrorRead is a uni-directional mirror which replicates an io.ReadCloser to a websocket.
 func MirrorRead(ctx context.Context, conn *websocket.Conn, rc io.ReadCloser) chan struct{} {
+	chDone := make(chan struct{}, 1)
+	if rc == nil {
+		close(chDone)
+		return chDone
+	}
+
 	logger.Debug("Websocket: Started read mirror", logger.Ctx{"address": conn.RemoteAddr().String()})
 
-	chDone := make(chan struct{}, 1)
 	connRWC := NewWrapper(conn)
 
 	go func() {
@@ -107,9 +112,14 @@ func MirrorRead(ctx context.Context, conn *websocket.Conn, rc io.ReadCloser) cha
 
 // MirrorWrite is a uni-directional mirror which replicates a websocket to an io.WriteCloser.
 func MirrorWrite(ctx context.Context, conn *websocket.Conn, wc io.WriteCloser) chan struct{} {
+	chDone := make(chan struct{}, 1)
+	if wc == nil {
+		close(chDone)
+		return chDone
+	}
+
 	logger.Debug("Websocket: Started write mirror", logger.Ctx{"address": conn.RemoteAddr().String()})
 
-	chDone := make(chan struct{}, 1)
 	connRWC := NewWrapper(conn)
 
 	go func() {


### PR DESCRIPTION
Allow passing `nil` to `InstanceExecArgs.{Stdin,Stdout,Stderr}`

Reintroducing this fix https://github.com/lxc/lxd/commit/b91a4fa6de83151996c68a68d3f0ca8d139385a9


