### PR TITLE
doc/storage/zfs: add missing storage volume configuration

### DIFF
--- a/doc/reference/storage_ceph.md
+++ b/doc/reference/storage_ceph.md
@@ -109,11 +109,11 @@ Key                           | Type                          | Default         
 
 Key                     | Type      | Condition                 | Default                                        | Description
 :--                     | :---      | :--------                 | :------                                        | :----------
-`block.filesystem`      | string    | block based driver        | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`   | string    | block based driver        | same as `volume.block.mount_options`           | Mount options for block devices
+`block.filesystem`      | string    |                           | same as `volume.block.filesystem`              | {{block_filesystem}}
+`block.mount_options`   | string    |                           | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
 `security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
 `security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage volume
+`size`                  | string    |                           | same as `volume.size`                          | Size/quota of the storage volume
 `snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
 `snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
 `snapshots.schedule`    | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}

--- a/doc/reference/storage_lvm.md
+++ b/doc/reference/storage_lvm.md
@@ -62,18 +62,18 @@ Key                           | Type                          | Default         
 (storage-lvm-vol-config)=
 ### Storage volume configuration
 
-Key                     | Type      | Condition                 | Default                                        | Description
-:--                     | :---      | :--------                 | :------                                        | :----------
-`block.filesystem`      | string    | block based driver        | same as `volume.block.filesystem`              | {{block_filesystem}}
-`block.mount_options`   | string    | block based driver        | same as `volume.block.mount_options`           | Mount options for block devices
-`lvm.stripes`           | string    | LVM driver                | same as `volume.lvm.stripes`                   | Number of stripes to use for new volumes (or thin pool volume)
-`lvm.stripes.size`      | string    | LVM driver                | same as `volume.lvm.stripes.size`              | Size of stripes to use (at least 4096 bytes and multiple of 512 bytes)
-`security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
-`security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage volume
-`snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
-`snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
-`snapshots.schedule`    | string    | custom volume             | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
+Key                     | Type      | Condition     | Default                                        | Description
+:--                     | :---      | :------       | :------                                        | :----------
+`block.filesystem`      | string    |               | same as `volume.block.filesystem`              | {{block_filesystem}}
+`block.mount_options`   | string    |               | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
+`lvm.stripes`           | string    |               | same as `volume.lvm.stripes`                   | Number of stripes to use for new volumes (or thin pool volume)
+`lvm.stripes.size`      | string    |               | same as `volume.lvm.stripes.size`              | Size of stripes to use (at least 4096 bytes and multiple of 512 bytes)
+`security.shifted`      | bool      | custom volume | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
+`security.unmapped`     | bool      | custom volume | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
+`size`                  | string    |               | same as `volume.size`                          | Size/quota of the storage volume
+`snapshots.expiry`      | string    | custom volume | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
+`snapshots.pattern`     | string    | custom volume | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
+`snapshots.schedule`    | string    | custom volume | same as `volume.snapshots.schedule`            | {{snapshot_schedule_format}}
 
 [^*]: {{snapshot_pattern_detail}}
 

--- a/doc/reference/storage_zfs.md
+++ b/doc/reference/storage_zfs.md
@@ -115,17 +115,19 @@ Key                           | Type                          | Default         
 
 Key                     | Type      | Condition                 | Default                                        | Description
 :--                     | :---      | :--------                 | :------                                        | :----------
+`block.filesystem`      | string    | `zfs.block_mode` enabled  | same as `volume.block.filesystem`              | {{block_filesystem}}
+`block.mount_options`   | string    | `zfs.block_mode` enabled  | same as `volume.block.mount_options`           | Mount options for block-backed file system volumes
 `security.shifted`      | bool      | custom volume             | same as `volume.security.shifted` or `false`   | {{enable_ID_shifting}}
 `security.unmapped`     | bool      | custom volume             | same as `volume.security.unmapped` or `false`  | Disable ID mapping for the volume
-`size`                  | string    | appropriate driver        | same as `volume.size`                          | Size/quota of the storage volume
+`size`                  | string    |                           | same as `volume.size`                          | Size/quota of the storage volume
 `snapshots.expiry`      | string    | custom volume             | same as `volume.snapshots.expiry`              | {{snapshot_expiry_format}}
 `snapshots.pattern`     | string    | custom volume             | same as `volume.snapshots.pattern` or `snap%d` | {{snapshot_pattern_format}} [^*]
 `snapshots.schedule`    | string    | custom volume             | same as `snapshots.schedule`                   | {{snapshot_schedule_format}}
-`zfs.blocksize`         | string    | ZFS driver                | same as `volume.zfs.blocksize`                 | Size of the ZFS block in range from 512 to 16 MiB (must be power of 2) - for block volume, a maximum value of 128 KiB will be used even if a higher value is set
-`zfs.block_mode`        | bool      | ZFS driver                | same as `volume.zfs.block_mode`                | Whether to use a formatted `zvol` rather than a {spellexception}`dataset`
-`zfs.remove_snapshots`  | bool      | ZFS driver                | same as `volume.zfs.remove_snapshots` or `false` | Remove snapshots as needed
-`zfs.use_refquota`      | bool      | ZFS driver                | same as `volume.zfs.use_refquota` or `false`   | Use `refquota` instead of `quota` for space
-`zfs.reserve_space`     | bool      | ZFS driver                | same as `volume.zfs.reserve_space` or `false`  | Use `reservation`/`refreservation` along with `quota`/`refquota`
+`zfs.blocksize`         | string    |                           | same as `volume.zfs.blocksize`                 | Size of the ZFS block in range from 512 to 16 MiB (must be power of 2) - for block volume, a maximum value of 128 KiB will be used even if a higher value is set
+`zfs.block_mode`        | bool      |                           | same as `volume.zfs.block_mode`                | Whether to use a formatted `zvol` rather than a {spellexception}`dataset`
+`zfs.remove_snapshots`  | bool      |                           | same as `volume.zfs.remove_snapshots` or `false` | Remove snapshots as needed
+`zfs.use_refquota`      | bool      |                           | same as `volume.zfs.use_refquota` or `false`   | Use `refquota` instead of `quota` for space
+`zfs.reserve_space`     | bool      |                           | same as `volume.zfs.reserve_space` or `false`  | Use `reservation`/`refreservation` along with `quota`/`refquota`
 
 [^*]: {{snapshot_pattern_detail}}
 

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -4,7 +4,7 @@
 ```
 
 All communication between LXD and its clients happens using a RESTful API over HTTP.
-This API is encapsulated over either SSL (for remote operations) or a Unix socket (for local operations).
+This API is encapsulated over either TLS (for remote operations) or a Unix socket (for local operations).
 
 See {ref}`authentication` for information about how to access the API remotely.
 


### PR DESCRIPTION
Add `block.filesystem` and `block.mount_options` to the list of storage volume configuration options.

As mentioned in #10077.