### PR TITLE
doc/faq: add information about `lxc monitor`

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -81,3 +81,13 @@ Many switches do not allow MAC address changes, and will either drop traffic wit
 If you can ping a LXD instance from the host, but are not able to ping it from a different host, this could be the cause.
 
 The way to diagnose this problem is to run a `tcpdump` on the uplink and you will see either ``ARP Who has `xx.xx.xx.xx` tell `yy.yy.yy.yy` ``, with you sending responses but them not getting acknowledged, or ICMP packets going in and out successfully, but never being received by the other host.
+
+## How can I monitor what LXD is doing?
+
+To see detailed information about what LXD is doing and what processes it is running, use the `lxc monitor` command.
+
+For example, to show a human-readable output of all types of messages, enter the following command:
+
+    lxc monitor --pretty
+
+See `lxc monitor --help` for all options, and {doc}`debugging` for more information.


### PR DESCRIPTION
The command is mentioned in the debugging page, but it should probably be mentioned in a more prominent place as well.