### PR TITLE
Make LXD-Agent run on FreeBSD

### DIFF
--- a/lxd-agent/api_1.0.go
+++ b/lxd-agent/api_1.0.go
@@ -47,7 +47,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		AuthMethods:   []string{"tls"},
 	}
 
-	uname, err := shared.Uname()
+	kernelName, kernelArch, kernalVersion, err := kernelInfo()
 	if err != nil {
 		return response.InternalError(err)
 	}
@@ -58,9 +58,9 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 	}
 
 	env := api.ServerEnvironment{
-		Kernel:             uname.Sysname,
-		KernelArchitecture: uname.Machine,
-		KernelVersion:      uname.Release,
+		Kernel:             kernelName,
+		KernelArchitecture: kernelArch,
+		KernelVersion:      kernalVersion,
 		Server:             "lxd-agent",
 		ServerPid:          os.Getpid(),
 		ServerVersion:      version.Version,

--- a/lxd-agent/kernel_info_linux.go
+++ b/lxd-agent/kernel_info_linux.go
@@ -1,0 +1,16 @@
+//go:build linux
+
+package main
+
+import (
+	"github.com/lxc/lxd/shared"
+)
+
+func kernelInfo() (name string, arch string, version string, err error) {
+	uname, err := shared.Uname()
+	if err != nil {
+		return "", "", "", err
+	}
+
+	return uname.Sysname, uname.Machine, uname.Release, nil
+}

--- a/lxd-agent/kernel_info_others.go
+++ b/lxd-agent/kernel_info_others.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build windows
 
 package main
 

--- a/lxd-agent/kernel_info_others.go
+++ b/lxd-agent/kernel_info_others.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package main
+
+import (
+	"fmt"
+)
+
+func kernelInfo() (name string, arch string, version string, err error) {
+	return "", "", "", fmt.Errorf("Not implemented")
+}

--- a/lxd-agent/kernel_info_unix.go
+++ b/lxd-agent/kernel_info_unix.go
@@ -1,4 +1,4 @@
-//go:build linux
+//go:build !windows
 
 package main
 

--- a/lxd-agent/metrics.go
+++ b/lxd-agent/metrics.go
@@ -13,8 +13,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/metrics"
 	"github.com/lxc/lxd/lxd/response"
-	"github.com/lxc/lxd/lxd/storage/filesystem"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -241,47 +239,6 @@ func getDiskMetrics(d *Daemon) (map[string]metrics.DiskMetrics, error) {
 		stats.WrittenBytes = sectorsWritten * 512
 
 		out[fields[2]] = stats
-	}
-
-	return out, nil
-}
-
-func getFilesystemMetrics(d *Daemon) (map[string]metrics.FilesystemMetrics, error) {
-	mounts, err := os.ReadFile("/proc/mounts")
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read /proc/mounts: %w", err)
-	}
-
-	out := map[string]metrics.FilesystemMetrics{}
-	scanner := bufio.NewScanner(bytes.NewReader(mounts))
-
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-
-		// Skip uninteresting mounts
-		if shared.StringInSlice(fields[2], defFSTypesExcluded) || defMountPointsExcluded.MatchString(fields[1]) {
-			continue
-		}
-
-		stats := metrics.FilesystemMetrics{}
-
-		stats.Mountpoint = fields[1]
-
-		statfs, err := filesystem.StatVFS(stats.Mountpoint)
-		if err != nil {
-			return nil, fmt.Errorf("Failed to stat %s: %w", stats.Mountpoint, err)
-		}
-
-		fsType, err := filesystem.FSTypeToName(int32(statfs.Type))
-		if err == nil {
-			stats.FSType = fsType
-		}
-
-		stats.AvailableBytes = statfs.Bavail * uint64(statfs.Bsize)
-		stats.FreeBytes = statfs.Bfree * uint64(statfs.Bsize)
-		stats.SizeBytes = statfs.Blocks * uint64(statfs.Bsize)
-
-		out[fields[0]] = stats
 	}
 
 	return out, nil

--- a/lxd-agent/metrics_linux.go
+++ b/lxd-agent/metrics_linux.go
@@ -1,0 +1,56 @@
+//go:build linux
+
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/lxc/lxd/lxd/metrics"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
+	"github.com/lxc/lxd/shared"
+)
+
+func getFilesystemMetrics(d *Daemon) (map[string]metrics.FilesystemMetrics, error) {
+	mounts, err := os.ReadFile("/proc/mounts")
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read /proc/mounts: %w", err)
+	}
+
+	out := map[string]metrics.FilesystemMetrics{}
+	scanner := bufio.NewScanner(bytes.NewReader(mounts))
+
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+
+		// Skip uninteresting mounts
+		if shared.StringInSlice(fields[2], defFSTypesExcluded) || defMountPointsExcluded.MatchString(fields[1]) {
+			continue
+		}
+
+		stats := metrics.FilesystemMetrics{}
+
+		stats.Mountpoint = fields[1]
+
+		statfs, err := filesystem.StatVFS(stats.Mountpoint)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to stat %s: %w", stats.Mountpoint, err)
+		}
+
+		fsType, err := filesystem.FSTypeToName(int32(statfs.Type))
+		if err == nil {
+			stats.FSType = fsType
+		}
+
+		stats.AvailableBytes = statfs.Bavail * uint64(statfs.Bsize)
+		stats.FreeBytes = statfs.Bfree * uint64(statfs.Bsize)
+		stats.SizeBytes = statfs.Blocks * uint64(statfs.Bsize)
+
+		out[fields[0]] = stats
+	}
+
+	return out, nil
+}

--- a/lxd-agent/metrics_others.go
+++ b/lxd-agent/metrics_others.go
@@ -1,0 +1,13 @@
+//go:build !linux
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/lxc/lxd/lxd/metrics"
+)
+
+func getFilesystemMetrics(d *Daemon) (map[string]metrics.FilesystemMetrics, error) {
+	return nil, fmt.Errorf("Not implemented")
+}

--- a/lxd-user/lxd.go
+++ b/lxd-user/lxd.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/revert"
-	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -47,7 +47,7 @@ func lxdInitialConfiguration(client lxd.InstanceServer) error {
 		return fmt.Errorf("Failed to get server info: %w", err)
 	}
 
-	availableBackends := util.AvailableStorageDrivers(info.Environment.StorageSupportedDrivers, util.PoolTypeLocal)
+	availableBackends := filesystem.AvailableStorageDrivers(info.Environment.StorageSupportedDrivers, filesystem.PoolTypeLocal)
 
 	// Load the default profile.
 	profile, profileEtag, err := client.GetProfile("default")

--- a/lxd/ip/vdpa.go
+++ b/lxd/ip/vdpa.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package ip
 
 import (

--- a/lxd/main_init_auto.go
+++ b/lxd/main_init_auto.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/project"
 	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
+	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -19,7 +20,7 @@ func (c *cmdInit) RunAuto(cmd *cobra.Command, args []string, d lxd.InstanceServe
 		return nil, fmt.Errorf("The requested backend '%s' isn't supported by lxd init", c.flagStorageBackend)
 	}
 
-	if c.flagStorageBackend != "" && !shared.StringInSlice(c.flagStorageBackend, util.AvailableStorageDrivers(server.Environment.StorageSupportedDrivers, util.PoolTypeAny)) {
+	if c.flagStorageBackend != "" && !shared.StringInSlice(c.flagStorageBackend, filesystem.AvailableStorageDrivers(server.Environment.StorageSupportedDrivers, filesystem.PoolTypeAny)) {
 		return nil, fmt.Errorf("The requested backend '%s' isn't available on your system (missing tools)", c.flagStorageBackend)
 	}
 

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -630,7 +630,7 @@ func (c *cmdInit) askStorage(config *api.InitPreseed, d lxd.InstanceServer, serv
 		}
 
 		if localStoragePool {
-			err := c.askStoragePool(config, d, server, util.PoolTypeLocal)
+			err := c.askStoragePool(config, d, server, filesystem.PoolTypeLocal)
 			if err != nil {
 				return err
 			}
@@ -642,7 +642,7 @@ func (c *cmdInit) askStorage(config *api.InitPreseed, d lxd.InstanceServer, serv
 		}
 
 		if remoteStoragePool {
-			err := c.askStoragePool(config, d, server, util.PoolTypeRemote)
+			err := c.askStoragePool(config, d, server, filesystem.PoolTypeRemote)
 			if err != nil {
 				return err
 			}
@@ -660,15 +660,15 @@ func (c *cmdInit) askStorage(config *api.InitPreseed, d lxd.InstanceServer, serv
 		return nil
 	}
 
-	return c.askStoragePool(config, d, server, util.PoolTypeAny)
+	return c.askStoragePool(config, d, server, filesystem.PoolTypeAny)
 }
 
-func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, server *api.Server, poolType util.PoolType) error {
+func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, server *api.Server, poolType filesystem.PoolType) error {
 	// Figure out the preferred storage driver
-	availableBackends := util.AvailableStorageDrivers(server.Environment.StorageSupportedDrivers, poolType)
+	availableBackends := filesystem.AvailableStorageDrivers(server.Environment.StorageSupportedDrivers, poolType)
 
 	if len(availableBackends) == 0 {
-		if poolType != util.PoolTypeAny {
+		if poolType != filesystem.PoolTypeAny {
 			return fmt.Errorf("No storage backends available")
 		}
 
@@ -694,7 +694,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 		pool := api.StoragePoolsPost{}
 		pool.Config = map[string]string{}
 
-		if poolType == util.PoolTypeAny {
+		if poolType == filesystem.PoolTypeAny {
 			pool.Name, err = cli.AskString("Name of the new storage pool [default=default]: ", "default", nil)
 			if err != nil {
 				return err
@@ -705,7 +705,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 
 		_, _, err := d.GetStoragePool(pool.Name)
 		if err == nil {
-			if poolType == util.PoolTypeAny {
+			if poolType == filesystem.PoolTypeAny {
 				fmt.Printf("The requested storage pool \"%s\" already exists. Please choose another name.\n", pool.Name)
 				continue
 			}
@@ -725,7 +725,7 @@ func (c *cmdInit) askStoragePool(config *api.InitPreseed, d lxd.InstanceServer, 
 		// Storage backend
 		if len(availableBackends) > 1 {
 			defaultBackend := defaultStorage
-			if poolType == util.PoolTypeRemote {
+			if poolType == filesystem.PoolTypeRemote {
 				if shared.StringInSlice("ceph", availableBackends) {
 					defaultBackend = "ceph"
 				} else {

--- a/lxd/storage/filesystem/drivers_available.go
+++ b/lxd/storage/filesystem/drivers_available.go
@@ -1,7 +1,6 @@
-package util
+package filesystem
 
 import (
-	"github.com/lxc/lxd/lxd/storage/filesystem"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -20,7 +19,7 @@ const PoolTypeRemote PoolType = "remote"
 
 // AvailableStorageDrivers returns a list of storage drivers that are available.
 func AvailableStorageDrivers(supportedDrivers []api.ServerStorageDriverInfo, poolType PoolType) []string {
-	backingFs, err := filesystem.Detect(shared.VarPath())
+	backingFs, err := Detect(shared.VarPath())
 	if err != nil {
 		backingFs = "dir"
 	}

--- a/lxd/util/kernel_linux.go
+++ b/lxd/util/kernel_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 package util
 
 import (

--- a/lxd/util/kernel_unix.go
+++ b/lxd/util/kernel_unix.go
@@ -1,0 +1,33 @@
+//go:build !windows && !linux
+package util
+
+import (
+	"fmt"
+
+	"github.com/lxc/lxd/shared"
+)
+
+// LoadModule loads the kernel module with the given name, by invoking
+// kldload.
+func LoadModule(module string) error {
+	_, err := shared.RunCommand("kldstat", "-n", module)
+	if err != nil {
+		_, err := shared.RunCommand("kldload", module)
+		return err
+	}
+	return nil
+}
+
+// SupportsFilesystem checks whether a given filesystem is already supported
+// by the kernel. This is unimplemented for other Unices, since it's only used
+// by the daemon, which only runs on Linux
+func SupportsFilesystem(filesystem string) bool {
+	return false
+}
+
+// HugepagesPath attempts to locate the mount point of the hugepages filesystem.
+// this is unimplemented on other Unices, since it's only used in the daemon,
+// which only runs on Linux
+func HugepagesPath() (string, error) {
+	return "", fmt.Errorf("Not Implemented")
+}

--- a/shared/util.go
+++ b/shared/util.go
@@ -42,6 +42,16 @@ const HTTPSMetricsDefaultPort = 9100
 // HTTPSStorageBucketsDefaultPort the default port for the storage buckets listener.
 const HTTPSStorageBucketsDefaultPort = 9000
 
+// Utsname returns the same info as unix.Utsname, as strings.
+type Utsname struct {
+	Sysname    string
+	Nodename   string
+	Release    string
+	Version    string
+	Machine    string
+	Domainname string
+}
+
 // URLEncode encodes a path and query parameters to a URL.
 func URLEncode(path string, query map[string]string) (string, error) {
 	u, err := url.Parse(path)
@@ -1359,4 +1369,32 @@ func JoinTokenDecode(input string) (*api.ClusterMemberJoinToken, error) {
 	}
 
 	return &j, nil
+}
+
+func intArrayToString(arr any) string {
+	slice := reflect.ValueOf(arr)
+	s := ""
+	for i := 0; i < slice.Len(); i++ {
+		val := slice.Index(i)
+		valInt := int64(-1)
+
+		switch val.Kind() {
+		case reflect.Int:
+		case reflect.Int8:
+			valInt = int64(val.Int())
+		case reflect.Uint:
+		case reflect.Uint8:
+			valInt = int64(val.Uint())
+		default:
+			continue
+		}
+
+		if valInt == 0 {
+			break
+		}
+
+		s += string(byte(valInt))
+	}
+
+	return s
 }

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -369,30 +368,4 @@ func OpenPtyInDevpts(devpts_fd int, uid, gid int64) (*os.File, *os.File, error) 
 // OpenPty creates a new PTS pair, configures them and returns them.
 func OpenPty(uid, gid int64) (*os.File, *os.File, error) {
 	return OpenPtyInDevpts(-1, uid, gid)
-}
-
-// ExitStatus extracts the exit status from the error returned by exec.Cmd.
-// If a nil err is provided then an exit status of 0 is returned along with the nil error.
-// If a valid exit status can be extracted from err then it is returned along with a nil error.
-// If no valid exit status can be extracted then a -1 exit status is returned along with the err provided.
-func ExitStatus(err error) (int, error) {
-	if err == nil {
-		return 0, err // No error exit status.
-	}
-
-	var exitErr *exec.ExitError
-
-	// Detect and extract ExitError to check the embedded exit status.
-	if errors.As(err, &exitErr) {
-		// If the process was signaled, extract the signal.
-		status, isWaitStatus := exitErr.Sys().(unix.WaitStatus)
-		if isWaitStatus && status.Signaled() {
-			return 128 + int(status.Signal()), nil // 128 + n == Fatal error signal "n"
-		}
-
-		// Otherwise capture the exit status from the command.
-		return exitErr.ExitCode(), nil
-	}
-
-	return -1, err // Not able to extract an exit status.
 }

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -7,9 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
-	"reflect"
 	"strings"
+	"syscall"
 	"unsafe"
 
 	"github.com/pkg/xattr"
@@ -20,6 +21,65 @@ import (
 )
 
 // --- pure Go functions ---
+
+// Uname returns Utsname as strings.
+func Uname() (*Utsname, error) {
+	/*
+	 * Based on: https://groups.google.com/forum/#!topic/golang-nuts/Jel8Bb-YwX8
+	 * there is really no better way to do this, which is
+	 * unfortunate. Also, we ditch the more accepted CharsToString
+	 * version in that thread, since it doesn't seem as portable,
+	 * viz. github issue #206.
+	 */
+
+	uname := unix.Utsname{}
+	err := unix.Uname(&uname)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Utsname{
+		Sysname:    intArrayToString(uname.Sysname),
+		Nodename:   intArrayToString(uname.Nodename),
+		Release:    intArrayToString(uname.Release),
+		Version:    intArrayToString(uname.Version),
+		Machine:    intArrayToString(uname.Machine),
+		Domainname: intArrayToString(uname.Domainname),
+	}, nil
+}
+
+func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
+	mode := fInfo.Mode()
+	uid := int(fInfo.Sys().(*syscall.Stat_t).Uid)
+	gid := int(fInfo.Sys().(*syscall.Stat_t).Gid)
+	return mode, uid, gid
+}
+
+// ExitStatus extracts the exit status from the error returned by exec.Cmd.
+// If a nil err is provided then an exit status of 0 is returned along with the nil error.
+// If a valid exit status can be extracted from err then it is returned along with a nil error.
+// If no valid exit status can be extracted then a -1 exit status is returned along with the err provided.
+func ExitStatus(err error) (int, error) {
+	if err == nil {
+		return 0, err // No error exit status.
+	}
+
+	var exitErr *exec.ExitError
+
+	// Detect and extract ExitError to check the embedded exit status.
+	if errors.As(err, &exitErr) {
+		// If the process was signaled, extract the signal.
+		status, isWaitStatus := exitErr.Sys().(unix.WaitStatus)
+		if isWaitStatus && status.Signaled() {
+			return 128 + int(status.Signal()), nil // 128 + n == Fatal error signal "n"
+		}
+
+		// Otherwise capture the exit status from the command.
+		return exitErr.ExitCode(), nil
+	}
+
+	return -1, err // Not able to extract an exit status.
+}
 
 func GetFileStat(p string) (uid int, gid int, major uint32, minor uint32, inode uint64, nlink int, err error) {
 	var stat unix.Stat_t
@@ -150,70 +210,6 @@ func GetErrno(err error) (errno error, iserrno bool) {
 	}
 
 	return nil, false
-}
-
-// Utsname returns the same info as unix.Utsname, as strings.
-type Utsname struct {
-	Sysname    string
-	Nodename   string
-	Release    string
-	Version    string
-	Machine    string
-	Domainname string
-}
-
-// Uname returns Utsname as strings.
-func Uname() (*Utsname, error) {
-	/*
-	 * Based on: https://groups.google.com/forum/#!topic/golang-nuts/Jel8Bb-YwX8
-	 * there is really no better way to do this, which is
-	 * unfortunate. Also, we ditch the more accepted CharsToString
-	 * version in that thread, since it doesn't seem as portable,
-	 * viz. github issue #206.
-	 */
-
-	uname := unix.Utsname{}
-	err := unix.Uname(&uname)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Utsname{
-		Sysname:    intArrayToString(uname.Sysname),
-		Nodename:   intArrayToString(uname.Nodename),
-		Release:    intArrayToString(uname.Release),
-		Version:    intArrayToString(uname.Version),
-		Machine:    intArrayToString(uname.Machine),
-		Domainname: intArrayToString(uname.Domainname),
-	}, nil
-}
-
-func intArrayToString(arr any) string {
-	slice := reflect.ValueOf(arr)
-	s := ""
-	for i := 0; i < slice.Len(); i++ {
-		val := slice.Index(i)
-		valInt := int64(-1)
-
-		switch val.Kind() {
-		case reflect.Int:
-		case reflect.Int8:
-			valInt = int64(val.Int())
-		case reflect.Uint:
-		case reflect.Uint8:
-			valInt = int64(val.Uint())
-		default:
-			continue
-		}
-
-		if valInt == 0 {
-			break
-		}
-
-		s += string(byte(valInt))
-	}
-
-	return s
 }
 
 func DeviceTotalMemory() (int64, error) {

--- a/shared/util_unix.go
+++ b/shared/util_unix.go
@@ -3,8 +3,12 @@
 package shared
 
 import (
+	"errors"
 	"os"
+	"os/exec"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
@@ -12,4 +16,30 @@ func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	uid := int(fInfo.Sys().(*syscall.Stat_t).Uid)
 	gid := int(fInfo.Sys().(*syscall.Stat_t).Gid)
 	return mode, uid, gid
+}
+
+// ExitStatus extracts the exit status from the error returned by exec.Cmd.
+// If a nil err is provided then an exit status of 0 is returned along with the nil error.
+// If a valid exit status can be extracted from err then it is returned along with a nil error.
+// If no valid exit status can be extracted then a -1 exit status is returned along with the err provided.
+func ExitStatus(err error) (int, error) {
+	if err == nil {
+		return 0, err // No error exit status.
+	}
+
+	var exitErr *exec.ExitError
+
+	// Detect and extract ExitError to check the embedded exit status.
+	if errors.As(err, &exitErr) {
+		// If the process was signaled, extract the signal.
+		status, isWaitStatus := exitErr.Sys().(unix.WaitStatus)
+		if isWaitStatus && status.Signaled() {
+			return 128 + int(status.Signal()), nil // 128 + n == Fatal error signal "n"
+		}
+
+		// Otherwise capture the exit status from the command.
+		return exitErr.ExitCode(), nil
+	}
+
+	return -1, err // Not able to extract an exit status.
 }

--- a/shared/util_unix.go
+++ b/shared/util_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !linux
 
 package shared
 
@@ -10,6 +10,32 @@ import (
 
 	"golang.org/x/sys/unix"
 )
+
+// Uname returns Utsname as strings.
+func Uname() (*Utsname, error) {
+	/*
+	 * Based on: https://groups.google.com/forum/#!topic/golang-nuts/Jel8Bb-YwX8
+	 * there is really no better way to do this, which is
+	 * unfortunate. Also, we ditch the more accepted CharsToString
+	 * version in that thread, since it doesn't seem as portable,
+	 * viz. github issue #206.
+	 */
+
+	uname := unix.Utsname{}
+	err := unix.Uname(&uname)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Utsname{
+		Sysname:    intArrayToString(uname.Sysname),
+		Nodename:   intArrayToString(uname.Nodename),
+		Release:    intArrayToString(uname.Release),
+		Version:    intArrayToString(uname.Version),
+		Machine:    intArrayToString(uname.Machine),
+		Domainname: "(none)", // emulate Linux
+	}, nil
+}
 
 func GetOwnerMode(fInfo os.FileInfo) (os.FileMode, int, int) {
 	mode := fInfo.Mode()

--- a/shared/util_unix_notlinux.go
+++ b/shared/util_unix_notlinux.go
@@ -11,3 +11,7 @@ import (
 func OpenPty(uid, gid int64) (*os.File, *os.File, error) {
 	return nil, nil, fmt.Errorf("Not implemented")
 }
+
+func SetSize(fd int, width int, height int) (err error) {
+	return fmt.Errorf("Not implemented")
+}

--- a/shared/util_unix_notlinux.go
+++ b/shared/util_unix_notlinux.go
@@ -1,0 +1,13 @@
+//go:build !windows && !linux
+
+package shared
+
+import (
+	"fmt"
+	"os"
+)
+
+// OpenPty creates a new PTS pair, configures them and returns them.
+func OpenPty(uid, gid int64) (*os.File, *os.File, error) {
+	return nil, nil, fmt.Errorf("Not implemented")
+}


### PR DESCRIPTION
This is a continuation of #11626, which made lxd-agent build on FreeBSD.

This patch cleans up the previous, which left quite a few functions unimplemented.
The main barrier to success is the lack of vsock on FreeBSD.

fixes #11603 
Sponsored by: The FreeBSD Foundation

Signed-off-by: Mina Galić <freebsd@igalic.co>
