### PR TITLE
Daemon: Clear left over operations for member during start up

### DIFF
--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
-	clusterDB "github.com/lxc/lxd/lxd/db/cluster"
+	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 )
@@ -37,7 +37,7 @@ func TestGateway_Single(t *testing.T) {
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[clusterDB.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 
@@ -101,7 +101,7 @@ func TestGateway_SingleWithNetworkAddress(t *testing.T) {
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[clusterDB.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 
@@ -146,7 +146,7 @@ func TestGateway_NetworkAuth(t *testing.T) {
 	gateway := newGateway(t, node, cert, s)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[clusterDB.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/db"
-	clusterDB "github.com/lxc/lxd/lxd/db/cluster"
+	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -214,7 +214,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	mux := http.NewServeMux()
 	server := newServer(serverCert, mux)
 
-	trustedCerts := func() map[clusterDB.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
-	clusterDB "github.com/lxc/lxd/lxd/db/cluster"
+	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
@@ -158,7 +158,7 @@ func TestUpgradeMembersWithoutRole(t *testing.T) {
 	gateway := newGateway(t, state.DB.Node, serverCert, state)
 	defer func() { _ = gateway.Shutdown() }()
 
-	trustedCerts := func() map[clusterDB.CertificateType]map[string]x509.Certificate {
+	trustedCerts := func() map[dbCluster.CertificateType]map[string]x509.Certificate {
 		return nil
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1273,6 +1273,12 @@ func (d *Daemon) init() error {
 	maasMachine := d.localConfig.MAASMachine()
 
 	err = d.db.Cluster.Transaction(d.shutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
+		// Delete any left over operations for this member from the global database.
+		err := dbCluster.DeleteOperations(ctx, tx.Tx(), tx.GetNodeID())
+		if err != nil {
+			logger.Error("Failed cleaning up operations")
+		}
+
 		config, err := clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -34,7 +34,7 @@ import (
 	clusterConfig "github.com/lxc/lxd/lxd/cluster/config"
 	"github.com/lxc/lxd/lxd/daemon"
 	"github.com/lxc/lxd/lxd/db"
-	clusterDB "github.com/lxc/lxd/lxd/db/cluster"
+	dbCluster "github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/warningtype"
 	"github.com/lxc/lxd/lxd/dns"
 	"github.com/lxc/lxd/lxd/endpoints"
@@ -267,7 +267,7 @@ func (d *Daemon) checkTrustedClient(r *http.Request) error {
 }
 
 // getTrustedCertificates returns trusted certificates key on DB type and fingerprint.
-func (d *Daemon) getTrustedCertificates() map[clusterDB.CertificateType]map[string]x509.Certificate {
+func (d *Daemon) getTrustedCertificates() map[dbCluster.CertificateType]map[string]x509.Certificate {
 	d.clientCerts.Lock.Lock()
 	defer d.clientCerts.Lock.Unlock()
 
@@ -287,7 +287,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	// Allow internal cluster traffic by checking against the trusted certfificates.
 	if r.TLS != nil {
 		for _, i := range r.TLS.PeerCertificates {
-			trusted, fingerprint := util.CheckTrustState(*i, trustedCerts[clusterDB.CertificateTypeServer], d.endpoints.NetworkCert(), false)
+			trusted, fingerprint := util.CheckTrustState(*i, trustedCerts[dbCluster.CertificateTypeServer], d.endpoints.NetworkCert(), false)
 			if trusted {
 				return true, fingerprint, "cluster", nil
 			}
@@ -356,7 +356,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	// Validate metrics certificates.
 	if r.URL.Path == "/1.0/metrics" {
 		for _, i := range r.TLS.PeerCertificates {
-			trusted, username := util.CheckTrustState(*i, trustedCerts[clusterDB.CertificateTypeMetrics], d.endpoints.NetworkCert(), trustCACertificates)
+			trusted, username := util.CheckTrustState(*i, trustedCerts[dbCluster.CertificateTypeMetrics], d.endpoints.NetworkCert(), trustCACertificates)
 			if trusted {
 				return true, username, "tls", nil
 			}
@@ -364,7 +364,7 @@ func (d *Daemon) Authenticate(w http.ResponseWriter, r *http.Request) (bool, str
 	}
 
 	for _, i := range r.TLS.PeerCertificates {
-		trusted, username := util.CheckTrustState(*i, trustedCerts[clusterDB.CertificateTypeClient], d.endpoints.NetworkCert(), trustCACertificates)
+		trusted, username := util.CheckTrustState(*i, trustedCerts[dbCluster.CertificateTypeClient], d.endpoints.NetworkCert(), trustCACertificates)
 		if trusted {
 			return true, username, "tls", nil
 		}
@@ -761,7 +761,7 @@ func (d *Daemon) setupLoki(URL string, cert string, key string, caCert string, l
 }
 
 func (d *Daemon) init() error {
-	var dbWarnings []clusterDB.Warning
+	var dbWarnings []dbCluster.Warning
 
 	// Setup logger
 	events.LoggingServer = d.events
@@ -1020,7 +1020,7 @@ func (d *Daemon) init() error {
 	}
 
 	// Detect if clustered, but not yet upgraded to per-server client certificates.
-	if clustered && len(d.clientCerts.Certificates[clusterDB.CertificateTypeServer]) < 1 {
+	if clustered && len(d.clientCerts.Certificates[dbCluster.CertificateTypeServer]) < 1 {
 		// If the cluster has not yet upgraded to per-server client certificates (by running patch
 		// patchClusteringServerCertTrust) then temporarily use the network (cluster) certificate as client
 		// certificate, and cause us to trust it for use as client certificate from the other members.
@@ -1828,7 +1828,7 @@ func (d *Daemon) setupRBACServer(rbacURL string, rbacKey string, rbacExpiry int6
 		var result map[int64]string
 		err := d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
 			var err error
-			result, err = clusterDB.GetProjectIDsToNames(ctx, tx.Tx())
+			result, err = dbCluster.GetProjectIDsToNames(ctx, tx.Tx())
 			return err
 		})
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1272,7 +1272,7 @@ func (d *Daemon) init() error {
 	maasAPIKey := ""
 	maasMachine := d.localConfig.MAASMachine()
 
-	err = d.db.Cluster.Transaction(context.TODO(), func(ctx context.Context, tx *db.ClusterTx) error {
+	err = d.db.Cluster.Transaction(d.shutdownCtx, func(ctx context.Context, tx *db.ClusterTx) error {
 		config, err := clusterConfig.Load(ctx, tx)
 		if err != nil {
 			return err
@@ -1288,6 +1288,7 @@ func (d *Daemon) init() error {
 		d.serverName = serverName
 		d.globalConfig = config
 		d.globalConfigMu.Unlock()
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
The actual operation (in memory) will be long gone, so lets not leave anything orphaned in the global DB.

Related to #11636