### PR TITLE
Images: Rework concurrent download locking

### DIFF
--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -600,7 +600,7 @@ WHERE images.fingerprint = ?
 	}
 
 	if len(addresses) == 0 {
-		return "", fmt.Errorf("Image not available on any online node")
+		return "", fmt.Errorf("Image not available on any online member")
 	}
 
 	for _, address := range addresses {

--- a/lxd/events/internalListener.go
+++ b/lxd/events/internalListener.go
@@ -34,8 +34,6 @@ func NewInternalListener(ctx context.Context, server *Server) *InternalListener 
 func (l *InternalListener) startListener() {
 	var err error
 
-	// Create a listener if necessary. This avoids having a listener around if there are no
-	// handlers.
 	l.listenerCtx, l.listenerCancel = context.WithCancel(l.ctx)
 	aEnd, bEnd := memorypipe.NewPipePair(l.listenerCtx)
 	listenerConnection := NewSimpleListenerConnection(aEnd)
@@ -93,6 +91,7 @@ func (l *InternalListener) AddHandler(name string, handler EventHandler) {
 	l.handlers[name] = handler
 
 	if l.listener == nil {
+		// Create a listener if necessary. This avoids having a listener around if there are no handlers.
 		l.startListener()
 	}
 }

--- a/lxd/instance/operationlock/operationlock.go
+++ b/lxd/instance/operationlock/operationlock.go
@@ -158,7 +158,7 @@ func (op *InstanceOperation) Action() Action {
 	return op.action
 }
 
-// ActionMatch returns true if operations' action matches on of the matchActions.
+// ActionMatch returns true if operation's action matches one of the matchActions.
 func (op *InstanceOperation) ActionMatch(matchActions ...Action) bool {
 	for _, matchAction := range matchActions {
 		if op.action == matchAction {

--- a/lxd/locking/lock.go
+++ b/lxd/locking/lock.go
@@ -17,7 +17,7 @@ var locksMutex sync.Mutex
 // UnlockFunc unlocks the lock.
 type UnlockFunc func()
 
-// Lock creates a lock for a specific storage volume to allow activities that require exclusive access to occur.
+// Lock creates a named lock to allow activities that require exclusive access to occur.
 // Will block until the lock is established or the context is cancelled.
 // On successfully acquiring the lock, it returns an unlock function which needs to be called to unlock the lock.
 // If the context is canceled then nil will be returned.


### PR DESCRIPTION
Avoids checking for local images twice.


Related to #11636