### PR TITLE
Instance: Handle VM panic by shutting down

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -4258,6 +4258,7 @@ func (d *qemu) Stop(stateful bool) error {
 
 	// Must be run prior to creating the operation lock.
 	// Allow to proceed if statusCode is Error or Frozen as we may need to forcefully kill the QEMU process.
+	// Also Stop() is called from migrateSendLive in some cases, and instance status will be Frozen then.
 	statusCode := d.statusCode()
 	if !d.isRunningStatusCode(statusCode) && statusCode != api.Error && statusCode != api.Frozen {
 		return ErrInstanceIsStopped

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -7383,19 +7383,18 @@ func (d *qemu) statusCode() api.StatusCode {
 		return api.Error
 	}
 
-	if status == "running" {
-		if shared.IsTrue(d.LocalConfig()["volatile.last_state.ready"]) {
+	switch status {
+	case "prelaunch", "running":
+		if status == "running" && shared.IsTrue(d.LocalConfig()["volatile.last_state.ready"]) {
 			return api.Ready
 		}
 
 		return api.Running
-	} else if status == "paused" || status == "postmigrate" {
+	case "inmigrate", "postmigrate", "finish-migrate", "save-vm", "suspended", "paused":
 		return api.Frozen
-	} else if status == "internal-error" || status == "io-error" {
+	default:
 		return api.Error
 	}
-
-	return api.Stopped
 }
 
 // State returns the instance's state code.


### PR DESCRIPTION
If the guest had panicked it would have shown as STOPPED, but the QEMU process would still be running and not be stoppable using `lxc stop -f`. This PR fixes this by:

1. Instructing QEMU to shutdown when a panic occurs.
2. Reporting unknown statuses (such as panic) as "ERROR" status.

Fixes #11741