### PR TITLE
Operations: Refactor op.Wait() to return an error so operation failures can be easily discovered

### DIFF
--- a/lxd/acme.go
+++ b/lxd/acme.go
@@ -151,7 +151,7 @@ func autoRenewCertificate(ctx context.Context, d *Daemon, force bool) error {
 
 	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.RenewServerCertificate, nil, nil, opRun, nil, nil, nil)
 	if err != nil {
-		logger.Error("Failed to start renew server certificate operation", logger.Ctx{"err": err})
+		logger.Error("Failed creating renew server certificate operation", logger.Ctx{"err": err})
 		return err
 	}
 
@@ -159,10 +159,16 @@ func autoRenewCertificate(ctx context.Context, d *Daemon, force bool) error {
 
 	err = op.Start()
 	if err != nil {
-		logger.Error("Failed to renew server certificate", logger.Ctx{"err": err})
+		logger.Error("Failed starting renew server certificate operation", logger.Ctx{"err": err})
+		return err
 	}
 
-	_, _ = op.Wait(ctx)
+	err = op.Wait(ctx)
+	if err != nil {
+		logger.Error("Failed server certificate renewal", logger.Ctx{"err": err})
+		return err
+	}
+
 	logger.Info("Done automatic server certificate renewal check")
 
 	return nil

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -4460,17 +4460,21 @@ func autoHealClusterTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ClusterHeal, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed starting heal cluster operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating cluster instances heal operation", logger.Ctx{"err": err})
 			return
 		}
 
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed healing cluster instances", logger.Ctx{"err": err})
+			logger.Error("Failed starting cluster instances heal operation", logger.Ctx{"err": err})
 			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed healing cluster instances", logger.Ctx{"err": err})
+			return
+		}
 	}
 
 	return f, task.Every(time.Minute)

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -300,17 +300,23 @@ func pruneExpiredContainerBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.BackupsExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start expired instance backups operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating expired instance backups operation", logger.Ctx{"err": err})
 			return
 		}
 
 		logger.Info("Pruning expired instance backups")
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to expire instance backups", logger.Ctx{"err": err})
+			logger.Error("Failed starting expired instance backups operation", logger.Ctx{"err": err})
+			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed pruning expired instance backups", logger.Ctx{"err": err})
+			return
+		}
+
 		logger.Info("Done pruning expired instance backups")
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2138,7 +2138,7 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ImagesExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start expired image operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating expired image prune operation", logger.Ctx{"err": err})
 			return
 		}
 
@@ -2150,10 +2150,16 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		logger.Info("Pruning expired images")
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to expire images", logger.Ctx{"err": err})
+			logger.Error("Failed starting expired image prune operation", logger.Ctx{"err": err})
+			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed expiring images", logger.Ctx{"err": err})
+			return
+		}
+
 		logger.Info("Done pruning expired images")
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -4166,7 +4166,7 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ImagesSynchronize, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start image synchronization operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating image synchronization operation", logger.Ctx{"err": err})
 			return
 		}
 
@@ -4178,11 +4178,16 @@ func autoSyncImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		logger.Info("Synchronizing images across the cluster")
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to synchronize images", logger.Ctx{"err": err})
+			logger.Error("Failed starting image synchronization operation", logger.Ctx{"err": err})
 			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed synchronizing images", logger.Ctx{"err": err})
+			return
+		}
+
 		logger.Info("Done synchronizing images across the cluster")
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1566,7 +1566,7 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ImagesUpdate, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start image update operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating image update operation", logger.Ctx{"err": err})
 			return
 		}
 
@@ -1578,10 +1578,16 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		logger.Info("Updating images")
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to update images", logger.Ctx{"err": err})
+			logger.Error("Failed starting image update operation", logger.Ctx{"err": err})
+			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed updating images", logger.Ctx{"err": err})
+			return
+		}
+
 		logger.Info("Done updating images")
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2256,7 +2256,7 @@ func pruneLeftoverImages(s *state.State) {
 
 	op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.ImagesPruneLeftover, nil, nil, opRun, nil, nil, nil)
 	if err != nil {
-		logger.Error("Failed to start image leftover cleanup operation", logger.Ctx{"err": err})
+		logger.Error("Failed creating leftover image clean up operation", logger.Ctx{"err": err})
 		return
 	}
 
@@ -2265,15 +2265,20 @@ func pruneLeftoverImages(s *state.State) {
 	defer imageTaskMu.Unlock()
 	logger.Debug("Acquired image task lock")
 
-	logger.Info("Pruning leftover image files")
+	logger.Info("Cleaning up leftover image files")
 	err = op.Start()
 	if err != nil {
-		logger.Error("Failed to prune leftover image files", logger.Ctx{"err": err})
+		logger.Error("Failed starting leftover image clean up operation", logger.Ctx{"err": err})
 		return
 	}
 
-	_, _ = op.Wait(s.ShutdownCtx)
-	logger.Infof("Done pruning leftover image files")
+	err = op.Wait(s.ShutdownCtx)
+	if err != nil {
+		logger.Error("Failed cleaning up leftover image files", logger.Ctx{"err": err})
+		return
+	}
+
+	logger.Infof("Done cleaning up leftover image files")
 }
 
 func pruneExpiredImages(ctx context.Context, s *state.State, op *operations.Operation) error {

--- a/lxd/instance.go
+++ b/lxd/instance.go
@@ -569,26 +569,25 @@ func pruneExpiredAndAutoCreateInstanceSnapshotsTask(d *Daemon) (task.Func, task.
 		// disk space.
 		if len(expiredSnapshotInstances) > 0 {
 			opRun := func(op *operations.Operation) error {
-				err := pruneExpiredInstanceSnapshots(ctx, s, expiredSnapshotInstances)
-				if err != nil {
-					logger.Error("Failed pruning instance snapshots", logger.Ctx{"err": err})
-				}
-
-				return err
+				return pruneExpiredInstanceSnapshots(ctx, s, expiredSnapshotInstances)
 			}
 
 			op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.SnapshotsExpire, nil, nil, opRun, nil, nil, nil)
 			if err != nil {
-				logger.Error("Failed to create instance snapshots expiry operation", logger.Ctx{"err": err})
+				logger.Error("Failed creating instance snapshots expiry operation", logger.Ctx{"err": err})
 			} else {
 				logger.Info("Pruning expired instance snapshots")
 
 				err = op.Start()
 				if err != nil {
-					logger.Error("Failed to start instance snapshots expiry operation", logger.Ctx{"err": err})
+					logger.Error("Failed starting instance snapshots expiry operation", logger.Ctx{"err": err})
 				} else {
-					_, _ = op.Wait(ctx)
-					logger.Info("Done pruning expired instance snapshots")
+					err = op.Wait(ctx)
+					if err != nil {
+						logger.Error("Failed pruning instance snapshots", logger.Ctx{"err": err})
+					} else {
+						logger.Info("Done pruning expired instance snapshots")
+					}
 				}
 			}
 		}
@@ -596,26 +595,25 @@ func pruneExpiredAndAutoCreateInstanceSnapshotsTask(d *Daemon) (task.Func, task.
 		// Handle snapshot auto creation.
 		if len(instances) > 0 {
 			opRun := func(op *operations.Operation) error {
-				err := autoCreateInstanceSnapshots(ctx, s, instances)
-				if err != nil {
-					logger.Error("Failed scheduled instance snapshots", logger.Ctx{"err": err})
-				}
-
-				return err
+				return autoCreateInstanceSnapshots(ctx, s, instances)
 			}
 
 			op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.SnapshotCreate, nil, nil, opRun, nil, nil, nil)
 			if err != nil {
-				logger.Error("Failed to create auto instance snapshot operation", logger.Ctx{"err": err})
+				logger.Error("Failed creating scheduled instance snapshot operation", logger.Ctx{"err": err})
 			} else {
 				logger.Info("Creating scheduled instance snapshots")
 
 				err = op.Start()
 				if err != nil {
-					logger.Error("Failed to start auto instance snapshot operation", logger.Ctx{"err": err})
+					logger.Error("Failed starting scheduled instance snapshot operation", logger.Ctx{"err": err})
 				} else {
-					_, _ = op.Wait(ctx)
-					logger.Info("Done creating scheduled instance snapshots")
+					err = op.Wait(ctx)
+					if err != nil {
+						logger.Error("Failed scheduled instance snapshots", logger.Ctx{"err": err})
+					} else {
+						logger.Info("Done creating scheduled instance snapshots")
+					}
 				}
 			}
 		}

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -96,17 +96,23 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.InstanceTypesUpdate, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start instance types update operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating instance types update operation", logger.Ctx{"err": err})
 			return
 		}
 
 		logger.Info("Updating instance types")
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to update instance types", logger.Ctx{"err": err})
+			logger.Error("Failed starting instance types update operation", logger.Ctx{"err": err})
+			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed updating instance types", logger.Ctx{"err": err})
+			return
+		}
+
 		logger.Info("Done updating instance types")
 	}
 

--- a/lxd/instance_instance_types.go
+++ b/lxd/instance_instance_types.go
@@ -68,30 +68,11 @@ func instanceLoadCache() error {
 }
 
 func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
-	// This is basically a check of whether we're on Go >= 1.8 and
-	// http.Request has cancellation support. If that's the case, it will
-	// be used internally by instanceRefreshTypes to terminate gracefully,
-	// otherwise we'll wrap instanceRefreshTypes in a goroutine and force
-	// returning in case the context expires.
-	_, hasCancellationSupport := any(&http.Request{}).(util.ContextAwareRequest)
 	f := func(ctx context.Context) {
 		s := d.State()
 
 		opRun := func(op *operations.Operation) error {
-			if hasCancellationSupport {
-				return instanceRefreshTypes(ctx, s)
-			}
-
-			ch := make(chan error)
-			go func() {
-				ch <- instanceRefreshTypes(ctx, s)
-			}()
-			select {
-			case <-ctx.Done():
-				return nil
-			case err := <-ch:
-				return err
-			}
+			return instanceRefreshTypes(ctx, s)
 		}
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.InstanceTypesUpdate, nil, nil, opRun, nil, nil, nil)

--- a/lxd/instance_post.go
+++ b/lxd/instance_post.go
@@ -707,7 +707,7 @@ func instancePostClusteringMigrate(s *state.State, r *http.Request, srcPool stor
 			return fmt.Errorf("Instance move to destination failed: %w", err)
 		}
 
-		_, err = srcOp.Wait(context.Background())
+		err = srcOp.Wait(context.Background())
 		if err != nil {
 			return fmt.Errorf("Instance move to destination failed on source: %w", err)
 		}

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -27,17 +27,23 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(state, "", operations.OperationClassTask, operationtype.LogsExpire, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start log expiry operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating log files expiry operation", logger.Ctx{"err": err})
 			return
 		}
 
 		logger.Info("Expiring log files")
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to expire logs", logger.Ctx{"err": err})
+			logger.Error("Failed starting log files expiry operation", logger.Ctx{"err": err})
+			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed expiring log files", logger.Ctx{"err": err})
+			return
+		}
+
 		logger.Info("Done expiring log files")
 	}
 

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -887,9 +887,9 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 
 		defer cancel()
 
-		_, err = op.Wait(ctx)
+		err = op.Wait(ctx)
 		if err != nil {
-			return response.InternalError(err)
+			return response.SmartError(err)
 		}
 
 		_, body, err := op.Render()

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -1097,17 +1097,21 @@ func autoRemoveOrphanedOperationsTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.RemoveOrphanedOperations, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start remove orphaned operations operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating remove orphaned operations operation", logger.Ctx{"err": err})
 			return
 		}
 
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to remove orphaned operations", logger.Ctx{"err": err})
+			logger.Error("Failed starting remove orphaned operations operation", logger.Ctx{"err": err})
 			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed removing orphaned operations", logger.Ctx{"err": err})
+			return
+		}
 	}
 
 	return f, task.Hourly()

--- a/lxd/operations/operations.go
+++ b/lxd/operations/operations.go
@@ -508,13 +508,13 @@ func (op *Operation) Render() (string, *api.Operation, error) {
 }
 
 // Wait for the operation to be done.
-// Returns true if operation completed or false if context was cancelled.
-func (op *Operation) Wait(ctx context.Context) (bool, error) {
+// Returns non-nil error if operation failed or context was cancelled.
+func (op *Operation) Wait(ctx context.Context) error {
 	select {
 	case <-op.finished.Done():
-		return true, nil
+		return op.err
 	case <-ctx.Done():
-		return false, nil
+		return ctx.Err()
 	}
 }
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -1263,25 +1263,24 @@ func pruneExpiredAndAutoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, t
 		// disk space.
 		if len(expiredSnapshots) > 0 {
 			opRun := func(op *operations.Operation) error {
-				err := pruneExpiredCustomVolumeSnapshots(ctx, s, expiredSnapshots)
-				if err != nil {
-					logger.Error("Failed pruning expired custom volume snapshots", logger.Ctx{"err": err})
-				}
-
-				return err
+				return pruneExpiredCustomVolumeSnapshots(ctx, s, expiredSnapshots)
 			}
 
 			op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.CustomVolumeSnapshotsExpire, nil, nil, opRun, nil, nil, nil)
 			if err != nil {
-				logger.Error("Failed to start expired custom volume snapshots operation", logger.Ctx{"err": err})
+				logger.Error("Failed creating expired custom volume snapshots prune operation", logger.Ctx{"err": err})
 			} else {
 				logger.Info("Pruning expired custom volume snapshots")
 				err = op.Start()
 				if err != nil {
-					logger.Error("Failed expiring custom volume snapshots", logger.Ctx{"err": err})
+					logger.Error("Failed starting expired custom volume snapshots prune operation", logger.Ctx{"err": err})
 				} else {
-					_, _ = op.Wait(ctx)
-					logger.Info("Done pruning expired custom volume snapshots")
+					err = op.Wait(ctx)
+					if err != nil {
+						logger.Error("Failed pruning expired custom volume snapshots", logger.Ctx{"err": err})
+					} else {
+						logger.Info("Done pruning expired custom volume snapshots")
+					}
 				}
 			}
 		}
@@ -1289,25 +1288,24 @@ func pruneExpiredAndAutoCreateCustomVolumeSnapshotsTask(d *Daemon) (task.Func, t
 		// Handle snapshot auto creation.
 		if len(volumes) > 0 {
 			opRun := func(op *operations.Operation) error {
-				err := autoCreateCustomVolumeSnapshots(ctx, s, volumes)
-				if err != nil {
-					logger.Error("Failed scheduled custom volume snapshots", logger.Ctx{"err": err})
-				}
-
-				return err
+				return autoCreateCustomVolumeSnapshots(ctx, s, volumes)
 			}
 
 			op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.VolumeSnapshotCreate, nil, nil, opRun, nil, nil, nil)
 			if err != nil {
-				logger.Error("Failed to start create volume snapshot operation", logger.Ctx{"err": err})
+				logger.Error("Failed creating scheduled volume snapshot operation", logger.Ctx{"err": err})
 			} else {
 				logger.Info("Creating scheduled volume snapshots")
 				err = op.Start()
 				if err != nil {
-					logger.Error("Failed to create scheduled volume snapshots", logger.Ctx{"err": err})
+					logger.Error("Failed starting scheduled volume snapshot operation", logger.Ctx{"err": err})
 				} else {
-					_, _ = op.Wait(ctx)
-					logger.Info("Done creating scheduled volume snapshots")
+					err = op.Wait(ctx)
+					if err != nil {
+						logger.Error("Failed scheduled custom volume snapshots", logger.Ctx{"err": err})
+					} else {
+						logger.Info("Done creating scheduled volume snapshots")
+					}
 				}
 			}
 		}

--- a/lxd/warnings.go
+++ b/lxd/warnings.go
@@ -431,17 +431,23 @@ func pruneResolvedWarningsTask(d *Daemon) (task.Func, task.Schedule) {
 
 		op, err := operations.OperationCreate(s, "", operations.OperationClassTask, operationtype.WarningsPruneResolved, nil, nil, opRun, nil, nil, nil)
 		if err != nil {
-			logger.Error("Failed to start prune resolved warnings operation", logger.Ctx{"err": err})
+			logger.Error("Failed creating prune resolved warnings operation", logger.Ctx{"err": err})
 			return
 		}
 
 		logger.Info("Pruning resolved warnings")
 		err = op.Start()
 		if err != nil {
-			logger.Error("Failed to prune resolved warnings", logger.Ctx{"err": err})
+			logger.Error("Failed starting prune resolved warnings operation", logger.Ctx{"err": err})
+			return
 		}
 
-		_, _ = op.Wait(ctx)
+		err = op.Wait(ctx)
+		if err != nil {
+			logger.Error("Failed pruning resolved warnings", logger.Ctx{"err": err})
+			return
+		}
+
 		logger.Info("Done pruning resolved warnings")
 	}
 


### PR DESCRIPTION
Also make task operation logging consistent.

Also fixes various missing returns on earlier errors.

Related to #11636 - as needed to have a way to handle operation errors.