### PR TITLE
doc/faq: add info about hanging instances

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -82,6 +82,7 @@ If you can ping a LXD instance from the host, but are not able to ping it from a
 
 The way to diagnose this problem is to run a `tcpdump` on the uplink and you will see either ``ARP Who has `xx.xx.xx.xx` tell `yy.yy.yy.yy` ``, with you sending responses but them not getting acknowledged, or ICMP packets going in and out successfully, but never being received by the other host.
 
+(faq-monitor)=
 ## How can I monitor what LXD is doing?
 
 To see detailed information about what LXD is doing and what processes it is running, use the `lxc monitor` command.
@@ -91,3 +92,10 @@ For example, to show a human-readable output of all types of messages, enter the
     lxc monitor --pretty
 
 See `lxc monitor --help` for all options, and {doc}`debugging` for more information.
+
+## Why does LXD stall when creating an instance?
+
+Check if your storage pool is out of space (by running `lxc storage info <pool_name>`).
+In that case, LXD cannot finish unpacking the image, and the instance that you're trying to create shows up as stopped.
+
+To get more insight into what is happening, run `lxc monitor` (see {ref}`faq-monitor`), and check `sudo dmesg` for any I/O errors.


### PR DESCRIPTION
A likely cause for instance creation to hang is that LXD runs out of space.