### PR TITLE
lxd/instance: Fix exec record-output location

### DIFF
--- a/doc/rest-api.yaml
+++ b/doc/rest-api.yaml
@@ -9060,6 +9060,108 @@ paths:
             summary: Get the log file
             tags:
                 - instances
+    /1.0/instances/{name}/logs/exec-output:
+        get:
+            description: Returns a list of exec record-output files (URLs).
+            operationId: instance_exec-outputs_get
+            parameters:
+                - description: Project name
+                  example: default
+                  in: query
+                  name: project
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    description: API endpoints
+                    schema:
+                        description: Sync response
+                        properties:
+                            metadata:
+                                description: List of endpoints
+                                example: |-
+                                    [
+                                      "/1.0/instances/foo/logs/exec-output/exec_d0a89537-0617-4ed6-a79b-c2e88a970965.stdout",
+                                      "/1.0/instances/foo/logs/exec-output/exec_d0a89537-0617-4ed6-a79b-c2e88a970965.stderr",
+                                    ]
+                                items:
+                                    type: string
+                                type: array
+                            status:
+                                description: Status description
+                                example: Success
+                                type: string
+                            status_code:
+                                description: Status code
+                                example: 200
+                                type: integer
+                            type:
+                                description: Response type
+                                example: sync
+                                type: string
+                        type: object
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get the exec record-output files
+            tags:
+                - instances
+    /1.0/instances/{name}/logs/exec-output/{filename}:
+        delete:
+            description: Removes the exec record-output file.
+            operationId: instance_exec-output_delete
+            parameters:
+                - description: Project name
+                  example: default
+                  in: query
+                  name: project
+                  type: string
+            produces:
+                - application/json
+            responses:
+                "200":
+                    $ref: '#/responses/EmptySyncResponse'
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Delete the exec record-output file
+            tags:
+                - instances
+        get:
+            description: Gets the exec-output file.
+            operationId: instance_exec-output_get
+            parameters:
+                - description: Project name
+                  example: default
+                  in: query
+                  name: project
+                  type: string
+            produces:
+                - application/json
+                - application/octet-stream
+            responses:
+                "200":
+                    description: Raw file
+                "400":
+                    $ref: '#/responses/BadRequest'
+                "403":
+                    $ref: '#/responses/Forbidden'
+                "404":
+                    $ref: '#/responses/NotFound'
+                "500":
+                    $ref: '#/responses/InternalServerError'
+            summary: Get the exec-output log file
+            tags:
+                - instances
     /1.0/instances/{name}/metadata:
         get:
             description: Gets the image metadata for the instance.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -57,6 +57,8 @@ var api10 = []APIEndpoint{
 	instanceConsoleCmd,
 	instanceExecCmd,
 	instanceFileCmd,
+	instanceExecOutputCmd,
+	instanceExecOutputsCmd,
 	instanceLogCmd,
 	instanceLogsCmd,
 	instanceMetadataCmd,

--- a/lxd/instance/drivers/driver_common.go
+++ b/lxd/instance/drivers/driver_common.go
@@ -385,6 +385,11 @@ func (d *common) Path() string {
 	return storagePools.InstancePath(d.dbType, d.project.Name, d.name, d.isSnapshot)
 }
 
+// ExecOutputPath returns the instance's exec output path.
+func (d *common) ExecOutputPath() string {
+	return filepath.Join(d.Path(), "exec-output")
+}
+
 // RootfsPath returns the instance's rootfs path.
 func (d *common) RootfsPath() string {
 	return filepath.Join(d.Path(), "rootfs")

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -142,6 +142,7 @@ type Instance interface {
 
 	// Paths.
 	Path() string
+	ExecOutputPath() string
 	RootfsPath() string
 	TemplatesPath() string
 	StatePath() string

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -401,6 +401,10 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 		var mt time.Time
 		var sz int64
 
+		if r.files[0].Cleanup != nil {
+			defer r.files[0].Cleanup()
+		}
+
 		if r.files[0].File != nil {
 			rs = r.files[0].File
 			mt = r.files[0].FileModified
@@ -429,10 +433,6 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 
 		http.ServeContent(w, r.req, r.files[0].Filename, mt, rs)
 
-		if r.files[0].Cleanup != nil {
-			r.files[0].Cleanup()
-		}
-
 		return nil
 	}
 
@@ -445,6 +445,11 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 
 	for _, entry := range r.files {
 		var rd io.Reader
+
+		if entry.Cleanup != nil {
+			defer entry.Cleanup()
+		}
+
 		if entry.File != nil {
 			rd = entry.File
 		} else {
@@ -466,10 +471,6 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 		_, err = io.Copy(fw, rd)
 		if err != nil {
 			return err
-		}
-
-		if entry.Cleanup != nil {
-			entry.Cleanup()
 		}
 	}
 


### PR DESCRIPTION
Store the output of an exec command (when `record-output` is true) in the instance storage instead of the log directory, as instance's storage quota is not applied to the log directory.

Fixes #11643

