### PR TITLE
lxc/utils: Change sort ByName interface name to SortColumnsNaturally

### DIFF
--- a/lxc/alias.go
+++ b/lxc/alias.go
@@ -124,7 +124,7 @@ func (c *cmdAliasList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{k, v})
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("ALIAS"),

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -178,7 +178,7 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -920,7 +920,7 @@ func (c *cmdClusterListTokens) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/cluster_group.go
+++ b/lxc/cluster_group.go
@@ -416,7 +416,7 @@ func (c *cmdClusterGroupList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -278,7 +278,7 @@ func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{template})
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("FILENAME"),

--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -509,7 +509,7 @@ func (c *cmdConfigTrustListTokens) Run(cmd *cobra.Command, args []string) error 
 		data = append(data, line)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -437,7 +437,7 @@ func (c *cmdList) showInstances(instances []api.InstanceFull, filters []string, 
 		data = append(data, col)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	headers := []string{}
 	for _, column := range columns {

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -958,7 +958,7 @@ func (c *cmdNetworkList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -1030,7 +1030,7 @@ func (c *cmdNetworkListLeases) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, entry)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("HOSTNAME"),

--- a/lxc/network_acl.go
+++ b/lxc/network_acl.go
@@ -142,7 +142,7 @@ func (c *cmdNetworkACLList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/network_forward.go
+++ b/lxc/network_forward.go
@@ -139,7 +139,7 @@ func (c *cmdNetworkForwardList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("LISTEN ADDRESS"),

--- a/lxc/network_load_balancer.go
+++ b/lxc/network_load_balancer.go
@@ -142,7 +142,7 @@ func (c *cmdNetworkLoadBalancerList) Run(cmd *cobra.Command, args []string) erro
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("LISTEN ADDRESS"),

--- a/lxc/network_peer.go
+++ b/lxc/network_peer.go
@@ -134,7 +134,7 @@ func (c *cmdNetworkPeerList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/network_zone.go
+++ b/lxc/network_zone.go
@@ -133,7 +133,7 @@ func (c *cmdNetworkZoneList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -697,7 +697,7 @@ func (c *cmdNetworkZoneRecordList) Run(cmd *cobra.Command, args []string) error 
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/operation.go
+++ b/lxc/operation.go
@@ -156,7 +156,7 @@ func (c *cmdOperationList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, entry)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("ID"),

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -627,7 +627,7 @@ func (c *cmdProfileList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{profile.Name, profile.Description, strUsedBy})
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -480,7 +480,7 @@ func (c *cmdProjectList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{name, images, profiles, storageVolumes, storageBuckets, networks, networkZones, project.Description, strUsedBy})
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -821,7 +821,7 @@ func (c *cmdProjectInfo) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{strings.ToUpper(k), limit, usage})
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("RESOURCE"),

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -724,7 +724,7 @@ func (c *cmdRemoteList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, []string{strName, rc.Addr, rc.Protocol, rc.AuthType, strPublic, strStatic, strGlobal})
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -621,7 +621,7 @@ func (c *cmdStorageList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/storage_bucket.go
+++ b/lxc/storage_bucket.go
@@ -489,7 +489,7 @@ func (c *cmdStorageBucketList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),
@@ -784,7 +784,7 @@ func (c *cmdStorageBucketKeyList) Run(cmd *cobra.Command, args []string) error {
 		data = append(data, details)
 	}
 
-	sort.Sort(utils.ByName(data))
+	sort.Sort(utils.SortColumnsNaturally(data))
 
 	header := []string{
 		i18n.G("NAME"),

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1272,7 +1272,7 @@ func (c *cmdStorageVolumeInfo) Run(cmd *cobra.Command, args []string) error {
 			snapData = append(snapData, row)
 		}
 
-		sort.Sort(utils.ByName(snapData))
+		sort.Sort(utils.SortColumnsNaturally(snapData))
 		snapHeader := []string{
 			i18n.G("Name"),
 			i18n.G("Description"),

--- a/lxc/utils/sort.go
+++ b/lxc/utils/sort.go
@@ -36,18 +36,18 @@ func (a StringList) Less(i, j int) bool {
 	return sortorder.NaturalLess(a[i][x], a[j][x])
 }
 
-// ByName represents the type for sorting by one string (i.e. Instance names).
-type ByName [][]string
+// SortColumnsNaturally represents the type for sorting columns in a natural order from left to right.
+type SortColumnsNaturally [][]string
 
-func (a ByName) Len() int {
+func (a SortColumnsNaturally) Len() int {
 	return len(a)
 }
 
-func (a ByName) Swap(i, j int) {
+func (a SortColumnsNaturally) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
-func (a ByName) Less(i, j int) bool {
+func (a SortColumnsNaturally) Less(i, j int) bool {
 	for k := range a[i] {
 		if a[i][k] == a[j][k] {
 			continue


### PR DESCRIPTION
Rename the sort interface `ByName` into `SortColumnsNaturally` to avoid any confusion regarding its implementation.

Fixes #11645